### PR TITLE
feat: add Resend notification module provider

### DIFF
--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -17,4 +17,23 @@ module.exports = defineConfig({
       cookieSecret: process.env.COOKIE_SECRET || "supersecret",
     },
   },
+  modules: [
+    {
+      resolve: "@medusajs/medusa/notification",
+      options: {
+        providers: [
+          {
+            resolve: "./src/modules/resend-notification",
+            id: "resend-notification",
+            options: {
+              channels: ["email"],
+              apiKey: process.env.RESEND_API_KEY,
+              fromEmail: process.env.RESEND_FROM_EMAIL || "NordHjem <noreply@nordhjem.store>",
+              replyToEmail: process.env.RESEND_REPLY_TO || "support@nordhjem.store",
+            },
+          },
+        ],
+      },
+    },
+  ],
 })

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@medusajs/admin-sdk": "2.13.1",
     "@medusajs/cli": "2.13.1",
     "@medusajs/framework": "2.13.1",
-    "@medusajs/medusa": "2.13.1"
+    "@medusajs/medusa": "2.13.1",
+    "resend": "^4.1.0"
   },
   "devDependencies": {
     "@swc/core": "^1.7.28",

--- a/src/modules/resend-notification/index.ts
+++ b/src/modules/resend-notification/index.ts
@@ -1,0 +1,6 @@
+import { Module } from "@medusajs/framework/utils"
+import ResendNotificationProviderService from "./service"
+
+export default Module("resend-notification", {
+  service: ResendNotificationProviderService,
+})

--- a/src/modules/resend-notification/service.ts
+++ b/src/modules/resend-notification/service.ts
@@ -1,0 +1,60 @@
+import { AbstractNotificationProviderService } from "@medusajs/framework/utils"
+import { Resend } from "resend"
+import { Logger } from "@medusajs/framework/types"
+
+type ResendNotificationConfig = {
+  apiKey: string
+  fromEmail: string
+  replyToEmail?: string
+}
+
+type SendNotificationInput = {
+  to: string
+  channel: string
+  template: string
+  data: Record<string, unknown>
+}
+
+type SendNotificationResult = {
+  id: string
+}
+
+class ResendNotificationProviderService extends AbstractNotificationProviderService {
+  static identifier = "resend-notification"
+  private resend: Resend
+  private fromEmail: string
+  private replyToEmail?: string
+  private logger: Logger
+
+  constructor(container: Record<string, unknown>, config: ResendNotificationConfig) {
+    super()
+    this.logger = container.logger as Logger
+    this.resend = new Resend(config.apiKey)
+    this.fromEmail = config.fromEmail
+    this.replyToEmail = config.replyToEmail
+  }
+
+  async send(notification: SendNotificationInput): Promise<SendNotificationResult> {
+    if (notification.channel === "email") {
+      const { data, error } = await this.resend.emails.send({
+        from: this.fromEmail,
+        to: notification.to,
+        replyTo: this.replyToEmail,
+        subject: (notification.data as Record<string, string>).subject || "NordHjem Notification",
+        html: (notification.data as Record<string, string>).html || "",
+      })
+
+      if (error) {
+        this.logger.error(`Resend send failed: ${JSON.stringify(error)}`)
+        throw new Error(`Failed to send email: ${error.message}`)
+      }
+
+      this.logger.info(`Email sent via Resend: ${data?.id}`)
+      return { id: data?.id || "unknown" }
+    }
+
+    throw new Error(`Channel ${notification.channel} not supported`)
+  }
+}
+
+export default ResendNotificationProviderService


### PR DESCRIPTION
### Motivation
- Introduce a Resend-based email notification provider so the Medusa backend can send transactional emails via Resend.
- Provide a pluggable module that follows Medusa's notification provider pattern and is configurable via environment variables.
- Support the EM-015 email notification integration by wiring a concrete provider into the project's module configuration.

### Description
- Added `src/modules/resend-notification/service.ts` implementing `ResendNotificationProviderService` with types, a `Resend` client, logging, and a `send` method that handles the `email` channel.
- Added `src/modules/resend-notification/index.ts` to register the provider as a Medusa `Module` named `resend-notification`.
- Updated `medusa-config.ts` to register the notification module under `modules` and to wire provider options from `process.env` (including `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, and `RESEND_REPLY_TO`).
- Added the `resend` dependency (`^4.1.0`) to `package.json` so the provider can instantiate the `Resend` client.

### Testing
- Ran `npm run build` to validate the project build, which failed due to the `medusa` CLI not being available in the environment (`sh: 1: medusa: not found`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac2e32e68883338f470edd19f0e060)