### PR TITLE
feat: add email notification subscribers and abandoned cart workflow

### DIFF
--- a/src/subscribers/customer-password-reset.ts
+++ b/src/subscribers/customer-password-reset.ts
@@ -1,0 +1,25 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+
+export default async function customerPasswordResetHandler({
+  event,
+  container,
+}: SubscriberArgs<{ id: string; email: string; token: string }>) {
+  const notificationService = container.resolve("notification")
+
+  const resetUrl = `${process.env.STOREFRONT_URL}/account/reset-password?token=${event.data.token}&email=${event.data.email}`
+
+  await notificationService.createNotifications({
+    to: event.data.email,
+    channel: "email",
+    template: "password-reset",
+    data: {
+      resetUrl,
+      email: event.data.email,
+      subject: "NordHjem 密码重置 | Password Reset",
+    },
+  })
+}
+
+export const config: SubscriberConfig = {
+  event: "customer.password_reset",
+}

--- a/src/subscribers/order-placed.ts
+++ b/src/subscribers/order-placed.ts
@@ -1,0 +1,27 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+
+export default async function orderPlacedHandler({
+  event,
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  const notificationService = container.resolve("notification")
+  const orderService = container.resolve("order")
+
+  const order = await orderService.retrieveOrder(event.data.id, {
+    relations: ["items", "shipping_address"],
+  })
+
+  await notificationService.createNotifications({
+    to: order.email,
+    channel: "email",
+    template: "order-confirmation",
+    data: {
+      order,
+      subject: `NordHjem 订单确认 | Order Confirmation #${order.display_id}`,
+    },
+  })
+}
+
+export const config: SubscriberConfig = {
+  event: "order.placed",
+}

--- a/src/subscribers/order-shipment.ts
+++ b/src/subscribers/order-shipment.ts
@@ -1,0 +1,35 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+
+export default async function orderShipmentHandler({
+  event,
+  container,
+}: SubscriberArgs<{ id: string; fulfillment_id: string }>) {
+  const notificationService = container.resolve("notification")
+  const orderService = container.resolve("order")
+  const fulfillmentService = container.resolve("fulfillment")
+
+  const order = await orderService.retrieveOrder(event.data.id, {
+    relations: ["items", "shipping_address"],
+  })
+
+  const fulfillment = await fulfillmentService.retrieveFulfillment(
+    event.data.fulfillment_id,
+    { relations: ["tracking_links"] }
+  )
+
+  await notificationService.createNotifications({
+    to: order.email,
+    channel: "email",
+    template: "shipping-notification",
+    data: {
+      order,
+      fulfillment,
+      trackingNumber: fulfillment.tracking_links?.[0]?.tracking_number,
+      subject: `NordHjem 发货通知 | Shipping Notification #${order.display_id}`,
+    },
+  })
+}
+
+export const config: SubscriberConfig = {
+  event: "order.fulfillment_created",
+}

--- a/src/workflows/abandoned-cart-workflow.ts
+++ b/src/workflows/abandoned-cart-workflow.ts
@@ -1,0 +1,34 @@
+import {
+  createWorkflow,
+  WorkflowResponse,
+  createStep,
+  StepResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+const sendAbandonedCartEmailStep = createStep(
+  "send-abandoned-cart-email",
+  async (input: { cartId: string; email: string; items: unknown[] }, { container }) => {
+    const notificationService = container.resolve("notification")
+
+    await notificationService.createNotifications({
+      to: input.email,
+      channel: "email",
+      template: "abandoned-cart",
+      data: {
+        cartId: input.cartId,
+        items: input.items,
+        subject: "NordHjem 您的购物车还在等您 | Your Cart is Waiting",
+      },
+    })
+
+    return new StepResponse({ sent: true })
+  }
+)
+
+export const abandonedCartWorkflow = createWorkflow(
+  "abandoned-cart-email",
+  (input: { cartId: string; email: string; items: unknown[] }) => {
+    const result = sendAbandonedCartEmailStep(input)
+    return new WorkflowResponse(result)
+  }
+)


### PR DESCRIPTION
### Motivation
- Add event-driven email notification handlers so the system sends emails for key lifecycle events (order placed, fulfillment created, customer password reset) and supports an abandoned-cart workflow for follow-up emails. 
- Integrate these flows with the existing `notification` service to centralize email dispatch and use Medusa's subscribers/workflows scanning for automatic loading.

### Description
- Added `src/subscribers/order-placed.ts` which listens to `order.placed`, retrieves the order, and sends an `order-confirmation` email via `notification.createNotifications`.
- Added `src/subscribers/order-shipment.ts` which listens to `order.fulfillment_created`, retrieves order and fulfillment (including `tracking_links`), and sends a `shipping-notification` email with tracking support.
- Added `src/subscribers/customer-password-reset.ts` which listens to `customer.password_reset`, builds a storefront reset URL from `process.env.STOREFRONT_URL`, and sends a `password-reset` email.
- Added `src/workflows/abandoned-cart-workflow.ts` which defines an `abandoned-cart-email` workflow and a `send-abandoned-cart-email` step that sends an `abandoned-cart` email via the `notification` service.

### Testing
- Ran `npm run build` which invokes the Medusa build, but the command failed in this environment with `sh: 1: medusa: not found`, so the project could not be built here.
- No additional automated tests were discovered or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac2f64381083339374875fa171e512)