### PR TITLE
feat: add Stripe payment provider configuration

### DIFF
--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -35,5 +35,19 @@ module.exports = defineConfig({
         ],
       },
     },
+    {
+      resolve: "@medusajs/medusa/payment",
+      options: {
+        providers: [
+          {
+            resolve: "@medusajs/medusa/payment-stripe",
+            id: "stripe",
+            options: {
+              apiKey: process.env.STRIPE_API_KEY,
+            },
+          },
+        ],
+      },
+    },
   ],
 })

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@medusajs/cli": "2.13.1",
     "@medusajs/framework": "2.13.1",
     "@medusajs/medusa": "2.13.1",
-    "resend": "^4.1.0"
+    "resend": "^4.1.0",
+    "stripe": "^17.0.0"
   },
   "devDependencies": {
     "@swc/core": "^1.7.28",


### PR DESCRIPTION
### Motivation
- Integrate Stripe (Test Mode) as a payment provider so the frontend checkout can process Stripe payments.
- Provide the Stripe SDK peer dependency required by `@medusajs/medusa/payment-stripe`.

### Description
- Added a `@medusajs/medusa/payment` module entry to the `modules` array in `medusa-config.ts` with provider `@medusajs/medusa/payment-stripe` configured to use `process.env.STRIPE_API_KEY`.
- Added `"stripe": "^17.0.0"` to `dependencies` in `package.json`.

### Testing
- Ran `npm run build` which invoked `medusa build` and failed with `medusa: not found`, indicating the Medusa CLI is not installed in this environment rather than a code error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac314e6e748333b657feeb5f1550e6)