### PR TITLE
fix/dockerfile-rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,30 @@
 FROM node:20-alpine
+
 WORKDIR /app
+
+# 构建依赖
 RUN apk add --no-cache python3 make g++ curl
+
+# 先复制依赖清单，利用 Docker 缓存层
 COPY package*.json ./
-RUN npm install --no-audit --no-fund
+
+# 安装依赖（优先 npm ci，失败则回退）
+RUN if [ -f package-lock.json ]; then \
+      npm ci --legacy-peer-deps || npm install --legacy-peer-deps; \
+    else \
+      npm install --legacy-peer-deps; \
+    fi
+
+# 复制源码
 COPY . .
-RUN npx medusa build && mkdir -p /app/public && ln -sfn /app/.medusa/server/public/admin /app/public/admin
+
+# 编译 TypeScript → JavaScript (medusa build)
+RUN npx medusa build
+
+# 创建 admin 静态文件链接
+RUN mkdir -p /app/public && \
+    ln -sfn /app/.medusa/server/public/admin /app/public/admin
+
 EXPOSE 9000
+
 CMD ["npx", "medusa", "start"]

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@medusajs/cli": "2.13.1",
     "@medusajs/framework": "2.13.1",
     "@medusajs/medusa": "2.13.1",
+    "@mikro-orm/postgresql": "^6.0.0",
     "resend": "^4.1.0",
     "stripe": "^17.0.0"
   },


### PR DESCRIPTION
### Motivation
- Fix the Dockerfile and dependency setup so `docker compose build` can complete `medusa build` (TypeScript compile) and deploy custom modules (Resend notification, Stripe, Subscribers, Workflows). 
- Avoid in-Dockerfile single-package installs that trigger peer dependency failures and enable a reproducible dependency layer using lockfile-aware installs. 
- Ensure repository dependencies and config are synchronized so the build context contains the Resend and Stripe integrations and not the removed `@lambdacurry/medusa-webhooks` package. 

### Description
- Replaced `Dockerfile` with an Alpine Node 20 build flow that installs build tools, copies `package*.json`, and runs a resilient install step that prefers `npm ci --legacy-peer-deps` and falls back to `npm install --legacy-peer-deps`, then runs `npx medusa build` and creates the admin symlink. 
- Added `@mikro-orm/postgresql` to `package.json` dependencies and verified `resend` and `stripe` are present while `@lambdacurry/medusa-webhooks` is not. 
- Confirmed `tsconfig.json` requires no changes and verified the repo contains the required module/subscriber/workflow source files and `medusa-config.ts` wiring for Resend and Stripe. 

### Testing
- Ran `docker build -t test-medusa .` in this environment but the build could not run because the `docker` binary is unavailable. 
- Attempted dependency installs (`npm ci --legacy-peer-deps`, `npm install --legacy-peer-deps`, and `npm install @mikro-orm/postgresql`) but all package fetches failed due to registry `403` restrictions in the execution environment. 
- Attempted `npm run build` but it failed because `medusa` is not installed locally since dependency installation could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac4924d6008333b8270899e72658bf)