### PR TITLE
fix: resolve subscriber TypeScript errors in order notification handlers

### DIFF
--- a/src/subscribers/order-placed.ts
+++ b/src/subscribers/order-placed.ts
@@ -11,6 +11,10 @@ export default async function orderPlacedHandler({
     relations: ["items", "shipping_address"],
   })
 
+  if (!order.email) {
+    return
+  }
+
   await notificationService.createNotifications({
     to: order.email,
     channel: "email",

--- a/src/subscribers/order-shipment.ts
+++ b/src/subscribers/order-shipment.ts
@@ -12,10 +12,19 @@ export default async function orderShipmentHandler({
     relations: ["items", "shipping_address"],
   })
 
+  if (!order.email) {
+    return
+  }
+
   const fulfillment = await fulfillmentService.retrieveFulfillment(
     event.data.fulfillment_id,
-    { relations: ["tracking_links"] }
+    { relations: ["labels"] }
   )
+
+  const trackingNumber =
+    (fulfillment as any).tracking_links?.[0]?.tracking_number ??
+    fulfillment.labels?.[0]?.tracking_number ??
+    null
 
   await notificationService.createNotifications({
     to: order.email,
@@ -24,7 +33,7 @@ export default async function orderShipmentHandler({
     data: {
       order,
       fulfillment,
-      trackingNumber: fulfillment.tracking_links?.[0]?.tracking_number,
+      trackingNumber,
       subject: `NordHjem 发货通知 | Shipping Notification #${order.display_id}`,
     },
   })


### PR DESCRIPTION
### Motivation
- `medusa build` failed because TypeScript errors in subscriber handlers caused the build to exit with no compiled artifacts.
- The failing issues were that `to: order.email` could be `string | undefined` (TS2769) and that `FulfillmentDTO` does not expose `tracking_links` (TS2339), leading to type errors in two subscriber files.

### Description
- Added an `if (!order.email) return` guard to `src/subscribers/order-placed.ts` so `createNotifications` always receives a `string` for `to`.
- Applied the same `order.email` guard to `src/subscribers/order-shipment.ts` and changed fulfillment retrieval relations to `["labels"]`.
- Added a safe `trackingNumber` extraction that uses `(fulfillment as any).tracking_links` as a fallback to `fulfillment.labels` and passes the resolved `trackingNumber` into the notification data.
- Only the two files `src/subscribers/order-placed.ts` and `src/subscribers/order-shipment.ts` were modified.

### Testing
- Ran `npx tsc --noEmit src/subscribers/order-placed.ts src/subscribers/order-shipment.ts` which could not complete in this environment due to missing project type definitions and global library (`Promise`) declarations.
- Ran `npx tsc --noEmit` which also failed for the same environment-level type resolution issues.
- Attempted an AST sanity check with `node -e "require('typescript').createSourceFile(... )"` which failed because the `typescript` package is not installed in the execution environment.
- Verified that only `src/subscribers/order-placed.ts` and `src/subscribers/order-shipment.ts` were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69acbd97d11883338a97d0e68249d68e)