### PR TITLE
fix: correct resend notification provider export format

### DIFF
--- a/src/modules/resend-notification/index.ts
+++ b/src/modules/resend-notification/index.ts
@@ -1,6 +1,5 @@
-import { Module } from "@medusajs/framework/utils"
 import ResendNotificationProviderService from "./service"
 
-export default Module("resend-notification", {
-  service: ResendNotificationProviderService,
-})
+export default {
+  services: [ResendNotificationProviderService],
+}


### PR DESCRIPTION
### Motivation
- Medusa v2's notification provider loader expects a provider to export `services` (an array), but the file used `Module()` and exported a singular `service`, which caused runtime loader errors such as `resend-notification doesn't seem to have a main service exported`.

### Description
- Replaced the `Module()` wrapper with a plain default export object and removed the `Module` import in `src/modules/resend-notification/index.ts`, changing the export to `export default { services: [ResendNotificationProviderService] }`.

### Testing
- Verified the git diff/commit touched only `src/modules/resend-notification/index.ts` and committed the change; ran `npx tsc --noEmit` (failed due to missing project type/dependency declarations unrelated to this tiny change) and `npx tsc --noEmit src/modules/resend-notification/index.ts` (failed due to unresolved imports in `service.ts` from missing dependencies), and confirmed the file now exports a `services` array.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ace0516908833393e930023b745228)