### PR TITLE
fix/email-template-price-format

### DIFF
--- a/src/modules/resend-notification/service.ts
+++ b/src/modules/resend-notification/service.ts
@@ -91,7 +91,7 @@ class ResendNotificationProviderService extends AbstractNotificationProviderServ
       `<tr>
         <td style="padding:8px;border-bottom:1px solid #e5e5e5;">${item.title || ""}${item.variant_title ? ` - ${item.variant_title}` : ""}</td>
         <td style="padding:8px;border-bottom:1px solid #e5e5e5;text-align:center;">${item.quantity || 1}</td>
-        <td style="padding:8px;border-bottom:1px solid #e5e5e5;text-align:right;">$${((item.unit_price || 0) / 100).toFixed(2)}</td>
+        <td style="padding:8px;border-bottom:1px solid #e5e5e5;text-align:right;">$${(item.unit_price || 0).toFixed(2)}</td>
       </tr>`
     ).join("")
 
@@ -197,7 +197,7 @@ class ResendNotificationProviderService extends AbstractNotificationProviderServ
       `<tr>
         <td style="padding:8px;border-bottom:1px solid #e5e5e5;">${item.title || ""}${item.variant_title ? ` - ${item.variant_title}` : ""}</td>
         <td style="padding:8px;border-bottom:1px solid #e5e5e5;text-align:center;">${item.quantity || 1}</td>
-        <td style="padding:8px;border-bottom:1px solid #e5e5e5;text-align:right;">$${((item.unit_price || 0) / 100).toFixed(2)}</td>
+        <td style="padding:8px;border-bottom:1px solid #e5e5e5;text-align:right;">$${(item.unit_price || 0).toFixed(2)}</td>
       </tr>`
     ).join("")
 


### PR DESCRIPTION
### Motivation
- The Store API now returns prices in major units (e.g. `849` meaning $849.00) but the email templates were still dividing `unit_price` by 100, causing prices like $849 to display as $8.49 in `orderConfirmationHtml` and `orderCanceledHtml`.

### Description
- Remove the erroneous `/100` division in `orderConfirmationHtml` and `orderCanceledHtml` and format prices using `(item.unit_price || 0).toFixed(2)`, affecting only these two templates.

### Testing
- Verified the change with `rg -n "unit_price" src/modules/resend-notification/service.ts` which shows the updated lines, and attempted `npm run build` which failed in this environment due to a missing `medusa` binary (`sh: 1: medusa: not found`), so the code edits and commit were validated but a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ad24482ab083338b2a4a112ac7b530)