### PR TITLE
fix: enable Stripe auto-capture for payment intents

### DIFF
--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -44,6 +44,7 @@ module.exports = defineConfig({
             id: "stripe",
             options: {
               apiKey: process.env.STRIPE_API_KEY,
+              capture: true,
             },
           },
         ],


### PR DESCRIPTION
### Motivation
- Stripe provider in `medusa-config.ts` only set `apiKey` which caused Payment Intents to be created with `capture_method=manual`, requiring manual capture and risking missed charges for ecommerce checkouts.

### Description
- Add a single line `capture: true` to the Stripe payment provider `options` in `medusa-config.ts` so Payment Intents use automatic capture, without modifying `apiKey`, notification provider, or `projectConfig`.

### Testing
- Performed an automated file update and diff inspection which confirmed only the `capture: true` line was added and the patch application succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69adb365534883339c54e38700355d59)