### PR TITLE
feat: implement Medusa v2 restock notification module

### DIFF
--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -19,6 +19,9 @@ module.exports = defineConfig({
   },
   modules: [
     {
+      resolve: "./src/modules/restock",
+    },
+    {
       resolve: "@medusajs/medusa/notification",
       options: {
         providers: [

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -1,0 +1,17 @@
+import { defineMiddlewares, authenticate, validateAndTransformBody } from "@medusajs/framework/http"
+import { StoreCreateRestockSubscription } from "./store/restock-subscriptions/validators"
+
+export default defineMiddlewares({
+  routes: [
+    {
+      matcher: "/store/restock-subscriptions",
+      method: "POST",
+      middlewares: [
+        authenticate("customer", ["bearer", "session"], {
+          allowUnauthenticated: true,
+        }),
+        validateAndTransformBody(StoreCreateRestockSubscription),
+      ],
+    },
+  ],
+})

--- a/src/api/store/restock-subscriptions/route.ts
+++ b/src/api/store/restock-subscriptions/route.ts
@@ -1,0 +1,31 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { createRestockSubscriptionWorkflow } from "../../../workflows/create-restock-subscription"
+import { StoreCreateRestockSubscriptionType } from "./validators"
+
+type StoreCreateRestockSubscriptionRequest = StoreCreateRestockSubscriptionType
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest<StoreCreateRestockSubscriptionRequest>,
+  res: MedusaResponse
+) => {
+  const body = req.validatedBody
+  const publishableSalesChannelId = req.publishable_key_context?.sales_channel_ids?.[0]
+
+  const customer = req.auth_context?.actor_type === "customer"
+    ? {
+        id: req.auth_context.actor_id,
+        email: (req.auth_context as Record<string, any>)?.app_metadata?.email,
+      }
+    : undefined
+
+  const { result } = await createRestockSubscriptionWorkflow(req.scope).run({
+    input: {
+      variant_id: body.variant_id,
+      sales_channel_id: body.sales_channel_id ?? publishableSalesChannelId,
+      customer,
+      email: body.email,
+    },
+  })
+
+  res.status(200).json({ restock_subscription: result })
+}

--- a/src/api/store/restock-subscriptions/validators.ts
+++ b/src/api/store/restock-subscriptions/validators.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const StoreCreateRestockSubscription = z.object({
+  variant_id: z.string().min(1),
+  email: z.string().email().optional(),
+  sales_channel_id: z.string().optional(),
+})
+
+export type StoreCreateRestockSubscriptionType = z.infer<typeof StoreCreateRestockSubscription>

--- a/src/jobs/check-restock.ts
+++ b/src/jobs/check-restock.ts
@@ -1,0 +1,24 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { sendRestockNotificationsWorkflow } from "../workflows/send-restock-notifications"
+
+export default async function checkRestockJob(container: MedusaContainer) {
+  const logger = container.resolve("logger") as {
+    info: (message: string) => void
+    error: (message: string) => void
+  }
+
+  try {
+    const { result } = await sendRestockNotificationsWorkflow(container).run({
+      input: {},
+    })
+
+    logger.info(`[check-restock] Completed: ${JSON.stringify(result)}`)
+  } catch (error) {
+    logger.error(`[check-restock] Failed: ${error}`)
+  }
+}
+
+export const config = {
+  name: "check-restock",
+  schedule: "0 * * * *",
+}

--- a/src/links/restock-variant.ts
+++ b/src/links/restock-variant.ts
@@ -1,0 +1,14 @@
+import { defineLink } from "@medusajs/framework/utils"
+import ProductModule from "@medusajs/medusa/product"
+import RestockModule from "../modules/restock"
+
+export default defineLink(
+  RestockModule.linkable.restockSubscription,
+  ProductModule.linkable.productVariant,
+  {
+    database: {
+      foreignKey: "variant_id",
+    },
+    readOnly: true,
+  }
+)

--- a/src/modules/restock/index.ts
+++ b/src/modules/restock/index.ts
@@ -1,0 +1,8 @@
+import { Module } from "@medusajs/framework/utils"
+import RestockModuleService from "./service"
+
+export const RESTOCK_MODULE = "restock"
+
+export default Module(RESTOCK_MODULE, {
+  service: RestockModuleService,
+})

--- a/src/modules/restock/models/restock-subscription.ts
+++ b/src/modules/restock/models/restock-subscription.ts
@@ -1,0 +1,19 @@
+import { model } from "@medusajs/framework/utils"
+
+const RestockSubscription = model
+  .define("restock_subscription", {
+    id: model.id().primaryKey(),
+    variant_id: model.text(),
+    sales_channel_id: model.text().nullable(),
+    email: model.text(),
+    customer_id: model.text().nullable(),
+  })
+  .indexes([
+    {
+      name: "IDX_RESTOCK_SUBSCRIPTION_UNIQUE",
+      on: ["variant_id", "sales_channel_id", "email"],
+      unique: true,
+    },
+  ])
+
+export default RestockSubscription

--- a/src/modules/restock/service.ts
+++ b/src/modules/restock/service.ts
@@ -1,0 +1,27 @@
+import { MedusaService, InjectManager, MedusaContext } from "@medusajs/framework/utils"
+import { Context } from "@medusajs/framework/types"
+import { EntityManager } from "@mikro-orm/postgresql"
+import RestockSubscription from "./models/restock-subscription"
+
+type UniqueSubscription = {
+  variant_id: string
+  sales_channel_id: string | null
+}
+
+class RestockModuleService extends MedusaService({
+  RestockSubscription,
+}) {
+  @InjectManager()
+  async getUniqueSubscriptions(@MedusaContext() context: Context = {}): Promise<UniqueSubscription[]> {
+    const manager = context.manager as EntityManager
+
+    const query = manager
+      .createQueryBuilder("restock_subscription", "rs")
+      .select(["variant_id", "sales_channel_id"])
+      .distinct()
+
+    return await query.execute<UniqueSubscription[]>()
+  }
+}
+
+export default RestockModuleService

--- a/src/workflows/create-restock-subscription/index.ts
+++ b/src/workflows/create-restock-subscription/index.ts
@@ -1,0 +1,50 @@
+import { createStep, createWorkflow, StepResponse, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
+import { RESTOCK_MODULE } from "../../modules/restock"
+
+type CreateRestockSubscriptionInput = {
+  variant_id: string
+  sales_channel_id?: string
+  customer?: {
+    id?: string
+    email?: string
+  }
+  email?: string
+}
+
+const createRestockSubscriptionStep = createStep(
+  "create-restock-subscription-step",
+  async (input: CreateRestockSubscriptionInput, { container }) => {
+    const restockService = container.resolve(RESTOCK_MODULE) as {
+      createRestockSubscriptions: (payload: {
+        variant_id: string
+        sales_channel_id?: string
+        customer_id?: string
+        email: string
+      }) => Promise<unknown>
+    }
+
+    const email = input.email ?? input.customer?.email
+
+    if (!email) {
+      throw new Error("Email is required to create a restock subscription")
+    }
+
+    const subscription = await restockService.createRestockSubscriptions({
+      variant_id: input.variant_id,
+      sales_channel_id: input.sales_channel_id,
+      customer_id: input.customer?.id,
+      email,
+    })
+
+    return new StepResponse(subscription)
+  }
+)
+
+export const createRestockSubscriptionWorkflow = createWorkflow(
+  "create-restock-subscription-workflow",
+  (input: CreateRestockSubscriptionInput) => {
+    const created = createRestockSubscriptionStep(input)
+
+    return new WorkflowResponse(created)
+  }
+)

--- a/src/workflows/send-restock-notifications/index.ts
+++ b/src/workflows/send-restock-notifications/index.ts
@@ -1,0 +1,47 @@
+import { useQueryGraphStep } from "@medusajs/medusa/core-flows"
+import { transform } from "@medusajs/framework/workflows-sdk"
+import { createWorkflow, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
+import { getDistinctSubscriptionsStep } from "./steps/get-distinct-subscriptions"
+import { getRestockedStep } from "./steps/get-restocked"
+import { sendRestockNotificationStep } from "./steps/send-restock-notification"
+import { deleteRestockSubscriptionsStep } from "./steps/delete-restock-subscriptions"
+
+export const sendRestockNotificationsWorkflow = createWorkflow(
+  "send-restock-notifications",
+  () => {
+    const distinctSubscriptions = getDistinctSubscriptionsStep()
+    const restocked = getRestockedStep(distinctSubscriptions)
+
+    const subscriptionFilters = transform({ restocked }, (data) => {
+      if (!data.restocked.length) {
+        return { id: "__none__" }
+      }
+
+      return {
+        $or: data.restocked.map((item) => ({
+          variant_id: item.variant_id,
+          sales_channel_id: item.sales_channel_id,
+        })),
+      }
+    })
+
+    const { data: subscriptions } = useQueryGraphStep({
+      entity: "restock_subscription",
+      fields: [
+        "id",
+        "email",
+        "variant_id",
+        "sales_channel_id",
+        "customer_id",
+        "product_variant.*",
+        "product_variant.product.*",
+      ],
+      filters: subscriptionFilters,
+    })
+
+    const sent = sendRestockNotificationStep(subscriptions as any)
+    deleteRestockSubscriptionsStep(sent as any)
+
+    return new WorkflowResponse({ sent_count: transform({ sent }, (data) => data.sent.length) })
+  }
+)

--- a/src/workflows/send-restock-notifications/steps/delete-restock-subscriptions.ts
+++ b/src/workflows/send-restock-notifications/steps/delete-restock-subscriptions.ts
@@ -1,0 +1,40 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import { RESTOCK_MODULE } from "../../../modules/restock"
+
+type RestockSubscription = {
+  id: string
+  variant_id: string
+  sales_channel_id?: string | null
+  email: string
+  customer_id?: string | null
+}
+
+export const deleteRestockSubscriptionsStep = createStep(
+  "delete-restock-subscriptions",
+  async (input: RestockSubscription[], { container }) => {
+    const restockService = container.resolve(RESTOCK_MODULE) as {
+      deleteRestockSubscriptions: (ids: string[]) => Promise<void>
+    }
+
+    const ids = input.map((subscription) => subscription.id)
+
+    if (ids.length) {
+      await restockService.deleteRestockSubscriptions(ids)
+    }
+
+    return new StepResponse(ids, input)
+  },
+  async (input, { container }) => {
+    if (!input?.length) {
+      return
+    }
+
+    const restockService = container.resolve(RESTOCK_MODULE) as {
+      createRestockSubscriptions: (data: Omit<RestockSubscription, "id">[]) => Promise<void>
+    }
+
+    await restockService.createRestockSubscriptions(
+      input.map(({ id: _id, ...subscription }) => subscription)
+    )
+  }
+)

--- a/src/workflows/send-restock-notifications/steps/get-distinct-subscriptions.ts
+++ b/src/workflows/send-restock-notifications/steps/get-distinct-subscriptions.ts
@@ -1,0 +1,20 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import { RESTOCK_MODULE } from "../../../modules/restock"
+
+export type DistinctSubscription = {
+  variant_id: string
+  sales_channel_id: string | null
+}
+
+export const getDistinctSubscriptionsStep = createStep(
+  "get-distinct-restock-subscriptions",
+  async (_, { container }) => {
+    const restockService = container.resolve(RESTOCK_MODULE) as {
+      getUniqueSubscriptions: () => Promise<DistinctSubscription[]>
+    }
+
+    const subscriptions = await restockService.getUniqueSubscriptions()
+
+    return new StepResponse(subscriptions)
+  }
+)

--- a/src/workflows/send-restock-notifications/steps/get-restocked.ts
+++ b/src/workflows/send-restock-notifications/steps/get-restocked.ts
@@ -1,0 +1,25 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import { getVariantAvailability } from "@medusajs/framework/utils"
+
+import { DistinctSubscription } from "./get-distinct-subscriptions"
+
+export const getRestockedStep = createStep(
+  "get-restocked-variants",
+  async (input: DistinctSubscription[], { container }) => {
+    const restocked: DistinctSubscription[] = []
+
+    for (const subscription of input) {
+      const [availability] = await getVariantAvailability(
+        container,
+        subscription.variant_id,
+        subscription.sales_channel_id ? { sales_channel_id: subscription.sales_channel_id } : {}
+      )
+
+      if (availability?.availability && availability.availability > 0) {
+        restocked.push(subscription)
+      }
+    }
+
+    return new StepResponse(restocked)
+  }
+)

--- a/src/workflows/send-restock-notifications/steps/send-restock-notification.ts
+++ b/src/workflows/send-restock-notifications/steps/send-restock-notification.ts
@@ -1,0 +1,55 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import { Modules } from "@medusajs/framework/utils"
+
+type RestockNotificationInput = {
+  id: string
+  email: string
+  variant_id: string
+  product_variant?: {
+    title?: string
+    product?: {
+      title?: string
+    }
+  }
+}
+
+export const sendRestockNotificationStep = createStep(
+  "send-restock-notification",
+  async (input: RestockNotificationInput[], { container }) => {
+    const notificationModuleService = container.resolve(Modules.NOTIFICATION) as {
+      createNotifications: (data: Record<string, unknown>) => Promise<unknown>
+    }
+
+    for (const subscription of input) {
+      await notificationModuleService.createNotifications({
+        to: subscription.email,
+        channel: "email",
+        template: "variant-restock",
+        data: {
+          subject: "NordHjem 商品已补货 | Item back in stock",
+          variant_id: subscription.variant_id,
+          variant_title: subscription.product_variant?.title,
+          product_title: subscription.product_variant?.product?.title,
+        },
+      })
+
+      if (process.env.TELEGRAM_BOT_TOKEN && process.env.TELEGRAM_CHAT_ID) {
+        const telegramUrl = `https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}/sendMessage`
+        const text = `🔔 Restock notice sent\nEmail: ${subscription.email}\nVariant: ${subscription.variant_id}`
+
+        await fetch(telegramUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            chat_id: process.env.TELEGRAM_CHAT_ID,
+            text,
+          }),
+        })
+      }
+    }
+
+    return new StepResponse(input)
+  }
+)


### PR DESCRIPTION
### Motivation
- Add a reusable restock notification feature so customers can subscribe to variant restock events and the system can notify subscribers when inventory is replenished.
- Integrate with Medusa v2 patterns (Module, Model, Workflows, Links, Jobs) to allow scalable processing and reuse of existing notification and product modules.

### Description
- Added a `restock` module with `RESTOCK_MODULE`, `RestockModuleService` extending `MedusaService`, and a `restock_subscription` model that includes `variant_id`, `sales_channel_id`, `email`, `customer_id` and a composite unique index.
- Implemented `getUniqueSubscriptions()` in the service using `@InjectManager()` + `@MedusaContext()` and `EntityManager.createQueryBuilder(...).distinct()` to fetch distinct `(variant_id, sales_channel_id)` pairs.
- Added a link `src/links/restock-variant.ts` to map `restockSubscription.variant_id` → `productVariant` as a read-only relation for query graph use.
- Exposed a Store API with zod validators (`variant_id` required, `email` and `sales_channel_id` optional), `POST /store/restock-subscriptions` route that runs `createRestockSubscriptionWorkflow`, and middleware registering `authenticate(..., { allowUnauthenticated: true })` plus `validateAndTransformBody`.
- Implemented `createRestockSubscriptionWorkflow` to create subscriptions via the restock service and a `sendRestockNotificationsWorkflow` composed of steps to: fetch distinct subscriptions, filter restocked variants using `getVariantAvailability`, send emails via the notification module and admin Telegram notices, and delete processed subscriptions with a compensation to recreate them on rollback; added an hourly job `check-restock` to run the workflow and registered the module in `medusa-config.ts`.

### Testing
- Attempted dependency installation with `npm install`, which failed due to registry access restrictions (HTTP 403), so full dependency installation could not be completed.
- Ran `npx tsc --noEmit` to perform a type check, which failed because `node_modules` are missing and therefore many module type declarations were not available, preventing successful compile-time validation in this environment.
- File creation and basic local linting-like checks were performed by reading the created files and running small scripted transforms; no unit or integration tests were executed due to the unavailable dependency environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae00fe02008333bee0c61d539c62d4)