### PR TITLE
Add claim/exchange/refund subscribers and email templates

### DIFF
--- a/src/modules/resend-notification/service.ts
+++ b/src/modules/resend-notification/service.ts
@@ -74,6 +74,12 @@ class ResendNotificationProviderService extends AbstractNotificationProviderServ
         return this.returnRequestedHtml(data)
       case "return-received":
         return this.returnReceivedHtml(data)
+      case "claim-created":
+        return this.claimCreatedHtml(data)
+      case "exchange-created":
+        return this.exchangeCreatedHtml(data)
+      case "refund-completed":
+        return this.refundCompletedHtml(data)
       case "customer-welcome":
         return this.customerWelcomeHtml(data)
       case "abandoned-cart":
@@ -286,6 +292,90 @@ class ResendNotificationProviderService extends AbstractNotificationProviderServ
     <div style="margin:15px 0;padding:15px;background:#f5f5f0;border-radius:4px;text-align:center;">
       <p style="margin:0;font-size:16px;color:#2C3E2D;"><strong>退款处理中 | Refund in Progress</strong></p>
       <p style="margin:8px 0 0;color:#666;">退款将在 5-10 个工作日内退回原支付方式<br>Refund will be returned to your original payment method within 5-10 business days</p>
+    </div>
+  </div>
+  <div style="text-align:center;padding:20px 0;border-top:1px solid #e5e5e5;color:#999;font-size:12px;">
+    <p>NordHjem — 北欧生活，永恒设计</p>
+    <p>如有问题请回复此邮件 | Reply to this email for support</p>
+  </div>
+</body>
+</html>`
+  }
+
+  private claimCreatedHtml(data: Record<string, any>): string {
+    const order = data.order || {}
+
+    return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#2C3E2D;">
+  <div style="text-align:center;padding:20px 0;border-bottom:2px solid #2C3E2D;">
+    <h1 style="margin:0;font-size:24px;color:#2C3E2D;">NordHjem</h1>
+    <p style="margin:5px 0 0;color:#666;">Nordic Living, Timeless Design</p>
+  </div>
+  <div style="padding:20px 0;">
+    <h2 style="color:#2C3E2D;">索赔申请已确认 | Claim Confirmed</h2>
+    <p>订单号 Order #${order.display_id || "N/A"}</p>
+    <p>您的索赔申请已收到并确认，我们的客户服务团队正在处理。<br>Your claim request has been received and confirmed. Our team is now reviewing and processing it.</p>
+    <div style="margin:15px 0;padding:15px;background:#f5f5f0;border-radius:4px;text-align:center;">
+      <p style="margin:0;font-size:16px;color:#2C3E2D;"><strong>处理中 | Under Review</strong></p>
+      <p style="margin:8px 0 0;color:#666;">我们将尽快通过邮件通知您后续进展<br>We will email you with updates as soon as possible</p>
+    </div>
+  </div>
+  <div style="text-align:center;padding:20px 0;border-top:1px solid #e5e5e5;color:#999;font-size:12px;">
+    <p>NordHjem — 北欧生活，永恒设计</p>
+    <p>如有问题请回复此邮件 | Reply to this email for support</p>
+  </div>
+</body>
+</html>`
+  }
+
+  private exchangeCreatedHtml(data: Record<string, any>): string {
+    const order = data.order || {}
+
+    return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#2C3E2D;">
+  <div style="text-align:center;padding:20px 0;border-bottom:2px solid #2C3E2D;">
+    <h1 style="margin:0;font-size:24px;color:#2C3E2D;">NordHjem</h1>
+    <p style="margin:5px 0 0;color:#666;">Nordic Living, Timeless Design</p>
+  </div>
+  <div style="padding:20px 0;">
+    <h2 style="color:#2C3E2D;">换货申请已确认 | Exchange Confirmed</h2>
+    <p>订单号 Order #${order.display_id || "N/A"}</p>
+    <p>您的换货申请已收到并确认，新商品将尽快发出。<br>Your exchange request has been received and confirmed. The replacement item will be shipped as soon as possible.</p>
+    <div style="margin:15px 0;padding:15px;background:#f5f5f0;border-radius:4px;text-align:center;">
+      <p style="margin:0;font-size:16px;color:#2C3E2D;"><strong>准备发货 | Preparing Shipment</strong></p>
+      <p style="margin:8px 0 0;color:#666;">发货后您将收到包含追踪信息的邮件<br>You will receive a tracking email once the replacement ships</p>
+    </div>
+  </div>
+  <div style="text-align:center;padding:20px 0;border-top:1px solid #e5e5e5;color:#999;font-size:12px;">
+    <p>NordHjem — 北欧生活，永恒设计</p>
+    <p>如有问题请回复此邮件 | Reply to this email for support</p>
+  </div>
+</body>
+</html>`
+  }
+
+  private refundCompletedHtml(data: Record<string, any>): string {
+    const order = data.order || {}
+
+    return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#2C3E2D;">
+  <div style="text-align:center;padding:20px 0;border-bottom:2px solid #2C3E2D;">
+    <h1 style="margin:0;font-size:24px;color:#2C3E2D;">NordHjem</h1>
+    <p style="margin:5px 0 0;color:#666;">Nordic Living, Timeless Design</p>
+  </div>
+  <div style="padding:20px 0;">
+    <h2 style="color:#2C3E2D;">退款已完成 | Refund Completed</h2>
+    <p>订单号 Order #${order.display_id || "N/A"}</p>
+    <p>您的退款已完成，并已退回原支付方式。<br>Your refund has been completed and returned to your original payment method.</p>
+    <div style="margin:15px 0;padding:15px;background:#f5f5f0;border-radius:4px;text-align:center;">
+      <p style="margin:0;font-size:16px;color:#2C3E2D;"><strong>退款到账时间 | Refund Timeline</strong></p>
+      <p style="margin:8px 0 0;color:#666;">通常将在 5-10 个工作日内到账<br>Funds typically appear within 5-10 business days</p>
     </div>
   </div>
   <div style="text-align:center;padding:20px 0;border-top:1px solid #e5e5e5;color:#999;font-size:12px;">

--- a/src/subscribers/claim-created.ts
+++ b/src/subscribers/claim-created.ts
@@ -1,0 +1,33 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { Modules } from "@medusajs/framework/utils"
+
+export default async function claimCreatedHandler({
+  event,
+  container,
+}: SubscriberArgs<{ order_id: string; claim_id: string }>) {
+  const notificationService = container.resolve(Modules.NOTIFICATION)
+  const orderService = container.resolve(Modules.ORDER)
+
+  const order = await orderService.retrieveOrder(event.data.order_id, {
+    relations: ["items", "shipping_address"],
+  })
+
+  if (!order.email) {
+    return
+  }
+
+  await notificationService.createNotifications({
+    to: order.email,
+    channel: "email",
+    template: "claim-created",
+    data: {
+      order,
+      claimId: event.data.claim_id,
+      subject: `NordHjem 索赔确认 | Claim Confirmed #${order.display_id}`,
+    },
+  })
+}
+
+export const config: SubscriberConfig = {
+  event: "order.claim_created",
+}

--- a/src/subscribers/exchange-created.ts
+++ b/src/subscribers/exchange-created.ts
@@ -1,0 +1,33 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { Modules } from "@medusajs/framework/utils"
+
+export default async function exchangeCreatedHandler({
+  event,
+  container,
+}: SubscriberArgs<{ order_id: string; exchange_id: string }>) {
+  const notificationService = container.resolve(Modules.NOTIFICATION)
+  const orderService = container.resolve(Modules.ORDER)
+
+  const order = await orderService.retrieveOrder(event.data.order_id, {
+    relations: ["items", "shipping_address"],
+  })
+
+  if (!order.email) {
+    return
+  }
+
+  await notificationService.createNotifications({
+    to: order.email,
+    channel: "email",
+    template: "exchange-created",
+    data: {
+      order,
+      exchangeId: event.data.exchange_id,
+      subject: `NordHjem 换货确认 | Exchange Confirmed #${order.display_id}`,
+    },
+  })
+}
+
+export const config: SubscriberConfig = {
+  event: "order.exchange_created",
+}

--- a/src/subscribers/refund-completed.ts
+++ b/src/subscribers/refund-completed.ts
@@ -1,0 +1,41 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { Modules } from "@medusajs/framework/utils"
+
+export default async function refundCompletedHandler({
+  event,
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  const notificationService = container.resolve(Modules.NOTIFICATION)
+  const paymentService = container.resolve(Modules.PAYMENT) as any
+  const orderService = container.resolve(Modules.ORDER) as any
+
+  const payment = await paymentService.retrievePayment(event.data.id)
+
+  if (!payment?.payment_collection_id) {
+    return
+  }
+
+  const [order] = await orderService.listOrders(
+    { payment_collection_id: payment.payment_collection_id },
+    { relations: ["items", "shipping_address"], take: 1 }
+  )
+
+  if (!order?.email) {
+    return
+  }
+
+  await notificationService.createNotifications({
+    to: order.email,
+    channel: "email",
+    template: "refund-completed",
+    data: {
+      order,
+      payment,
+      subject: `NordHjem 退款完成 | Refund Completed #${order.display_id}`,
+    },
+  })
+}
+
+export const config: SubscriberConfig = {
+  event: "payment.refunded",
+}


### PR DESCRIPTION
### Motivation

- Add missing email notifications so customers are informed when a claim, exchange, or refund completes. 
- Keep email presentation consistent with existing NordHjem templates and bilingual copy. 

### Description

- Add three new subscribers: `src/subscribers/claim-created.ts` (listens to `order.claim_created`), `src/subscribers/exchange-created.ts` (listens to `order.exchange_created`), and `src/subscribers/refund-completed.ts` (listens to `payment.refunded`), each fetching the relevant `order`/`payment` and sending a notification via `Modules.NOTIFICATION`. 
- For `refund-completed` the subscriber resolves the `order` via the payment's `payment_collection_id` and skips if no order email is present. 
- Extend `src/modules/resend-notification/service.ts` `generateHtml` switch with `claim-created`, `exchange-created`, and `refund-completed` cases and implement `claimCreatedHtml`, `exchangeCreatedHtml`, and `refundCompletedHtml` functions using the existing NordHjem style (`#2C3E2D` primary color, `#FAFAF8` button text) and bilingual copy consistent with other templates. 

### Testing

- Ran `npm run build` to validate compilation, which failed due to an existing TypeScript typing error in `src/jobs/low-stock-alert.ts` unrelated to these changes; the added files and template functions were included in the build attempt but the failure blocks a full successful build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae4436d5688333a7b2d9459a339601)