### PR TITLE
feat/oms-order-management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,10 @@ STORE_CORS=http://localhost:8000,https://your-storefront.com
 ADMIN_CORS=http://localhost:9000
 AUTH_CORS=http://localhost:8000,https://your-storefront.com
 STRIPE_API_KEY=sk_test_xxx
+
+# === Stripe Webhook ===
 STRIPE_WEBHOOK_SECRET=whsec_xxx
+
 RESEND_API_KEY=re_xxx
 RESEND_FROM_EMAIL=NordHjem <noreply@your-domain.com>
 RESEND_REPLY_TO=support@your-domain.com
@@ -14,3 +17,7 @@ TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
 LOW_STOCK_THRESHOLD=10
 LOW_STOCK_ALERT_EMAIL=admin@your-domain.com
+
+# === Webhook Relay (n8n / Zapier / custom automation) ===
+WEBHOOK_RELAY_URL=
+WEBHOOK_RELAY_SECRET=

--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -47,6 +47,7 @@ module.exports = defineConfig({
             id: "stripe",
             options: {
               apiKey: process.env.STRIPE_API_KEY,
+              webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
               capture: true,
             },
           },

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -13,5 +13,14 @@ export default defineMiddlewares({
         validateAndTransformBody(StoreCreateRestockSubscription),
       ],
     },
+    {
+      matcher: "/store/orders/:id/tracking",
+      method: "GET",
+      middlewares: [
+        authenticate("customer", ["bearer", "session"], {
+          allowUnauthenticated: true,
+        }),
+      ],
+    },
   ],
 })

--- a/src/api/store/orders/[id]/tracking/route.ts
+++ b/src/api/store/orders/[id]/tracking/route.ts
@@ -1,0 +1,64 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+
+export async function GET(
+  req: MedusaRequest,
+  res: MedusaResponse
+) {
+  const { id } = req.params
+  const logger = req.scope.resolve("logger") as {
+    error: (m: string) => void
+  }
+
+  try {
+    const orderService = req.scope.resolve(Modules.ORDER)
+
+    const order = await orderService.retrieveOrder(id, {
+      select: ["id", "display_id", "status"],
+      relations: ["fulfillments", "fulfillments.labels", "fulfillments.items"],
+    })
+
+    if (!order) {
+      return res.status(404).json({ message: "Order not found" })
+    }
+
+    const trackingInfo = ((order as any).fulfillments ?? []).map((f: any) => {
+      const trackingNumber =
+        f.tracking_links?.[0]?.tracking_number ??
+        f.labels?.[0]?.tracking_number ??
+        null
+
+      const carrier =
+        f.tracking_links?.[0]?.carrier ??
+        f.provider_id ??
+        null
+
+      let trackingUrl: string | null = null
+      if (trackingNumber) {
+        trackingUrl = `https://t.17track.net/en/track?nums=${encodeURIComponent(trackingNumber)}`
+      }
+
+      return {
+        fulfillment_id: f.id,
+        status: f.delivery_status || f.shipped_at ? "shipped" : "processing",
+        shipped_at: f.shipped_at || f.created_at,
+        tracking_number: trackingNumber,
+        carrier,
+        tracking_url: trackingUrl,
+        items_count: f.items?.length ?? 0,
+      }
+    })
+
+    return res.json({
+      order_id: order.id,
+      display_id: order.display_id,
+      order_status: order.status,
+      fulfillments: trackingInfo,
+    })
+  } catch (error) {
+    const errMsg =
+      error instanceof Error ? error.message : JSON.stringify(error)
+    logger.error(`[tracking-api] Failed for order ${id}: ${errMsg}`)
+    return res.status(500).json({ message: "Internal server error" })
+  }
+}

--- a/src/subscribers/order-webhook-relay.ts
+++ b/src/subscribers/order-webhook-relay.ts
@@ -1,0 +1,62 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+
+export default async function orderWebhookRelayHandler({
+  event,
+  container,
+}: SubscriberArgs<Record<string, unknown>>) {
+  const webhookUrl = process.env.WEBHOOK_RELAY_URL
+  if (!webhookUrl) {
+    return
+  }
+
+  const logger = container.resolve("logger") as {
+    info: (m: string) => void
+    error: (m: string) => void
+  }
+
+  const eventName = (event as any).name || "unknown"
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-NordHjem-Event": eventName,
+        ...(process.env.WEBHOOK_RELAY_SECRET
+          ? { "X-Webhook-Secret": process.env.WEBHOOK_RELAY_SECRET }
+          : {}),
+      },
+      body: JSON.stringify({
+        event: eventName,
+        data: event.data,
+        timestamp: new Date().toISOString(),
+        source: "nordhjem-medusa",
+      }),
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) {
+      logger.error(
+        `[webhook-relay] Failed to relay ${eventName}: HTTP ${response.status}`
+      )
+    } else {
+      logger.info(`[webhook-relay] Relayed ${eventName} → ${response.status}`)
+    }
+  } catch (error) {
+    const errMsg =
+      error instanceof Error ? error.message : JSON.stringify(error)
+    logger.error(`[webhook-relay] Error relaying ${eventName}: ${errMsg}`)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: [
+    "order.placed",
+    "order.canceled",
+    "order.fulfillment_created",
+    "order.claim_created",
+    "order.exchange_created",
+    "order.return_requested",
+    "order.refund_created",
+  ],
+}


### PR DESCRIPTION
### Motivation
- Complete core OMS gaps by enabling Stripe webhook secret configuration so incoming Stripe events can be verified.
- Provide an event relay subscriber to forward Medusa order events to external automation endpoints (n8n/Zapier/custom) for downstream workflows.
- Expose a simple store-facing tracking API so storefronts or customers can query fulfillment tracking information per order.
- Add environment variables for webhook and relay configuration to make the new features configurable.

### Description
- Added `webhookSecret: process.env.STRIPE_WEBHOOK_SECRET` to the Stripe payment provider options in `medusa-config.ts` to enable webhook verification.
- Implemented `src/subscribers/order-webhook-relay.ts`, a subscriber that posts selected order events to `WEBHOOK_RELAY_URL` and includes an optional `X-Webhook-Secret` header when `WEBHOOK_RELAY_SECRET` is set.
- Added a store API endpoint `GET /store/orders/:id/tracking` at `src/api/store/orders/[id]/tracking/route.ts` that returns fulfillment-level tracking details (tracking number, carrier, tracking URL, status, shipped time, and item counts).
- Registered the new tracking route in `src/api/middlewares.ts` with the same customer authentication policy used by existing store routes, and updated `.env.example` with `STRIPE_WEBHOOK_SECRET`, `WEBHOOK_RELAY_URL`, and `WEBHOOK_RELAY_SECRET` entries.

### Testing
- Ran TypeScript type-checking with `npx tsc --noEmit`, which completed successfully after final adjustments. 
- Attempted full build with `npm run build` (which invokes `medusa build`), which failed in the current environment due to a missing `node_modules/cliui/build/index.cjs` artifact unrelated to the implemented changes.
- Linted and compiled the modified TypeScript files locally as part of `npx tsc` validation and confirmed no remaining type errors in the changed files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae7c49ed648333afc8ecf3dc6346a7)