### PR TITLE
feat(c-035f): add GDPR data_processing_log migration and admin query API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,7 @@ LOW_STOCK_ALERT_EMAIL=admin@your-domain.com
 # === Webhook Relay (n8n / Zapier / custom automation) ===
 WEBHOOK_RELAY_URL=
 WEBHOOK_RELAY_SECRET=
+
+# === GDPR Compliance ===
+# data_processing_log table is auto-created via:
+#   npx medusa exec src/scripts/create-data-processing-log.ts

--- a/src/api/admin/data-processing-log/route.ts
+++ b/src/api/admin/data-processing-log/route.ts
@@ -1,0 +1,80 @@
+/**
+ * Admin API: GET /admin/data-processing-log
+ *
+ * 允许管理员查看数据处理日志（GDPR 审计）。
+ * 支持分页和按类型/客户过滤。
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as any
+  const pgConnection = req.scope.resolve(
+    ContainerRegistrationKeys.PG_CONNECTION
+  ) as any
+
+  const {
+    customer_id,
+    action_type,
+    limit = "50",
+    offset = "0",
+  } = req.query as Record<string, string>
+
+  try {
+    let query = `SELECT * FROM data_processing_log WHERE 1=1`
+    const params: any[] = []
+    let paramIndex = 1
+
+    if (customer_id) {
+      query += ` AND customer_id = $${paramIndex}`
+      params.push(customer_id)
+      paramIndex++
+    }
+
+    if (action_type) {
+      query += ` AND action_type = $${paramIndex}`
+      params.push(action_type)
+      paramIndex++
+    }
+
+    query += ` ORDER BY created_at DESC LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`
+    params.push(parseInt(limit) || 50, parseInt(offset) || 0)
+
+    const result = await pgConnection.raw(query, params)
+
+    let countQuery = `SELECT COUNT(*) FROM data_processing_log WHERE 1=1`
+    const countParams: any[] = []
+    let countIndex = 1
+
+    if (customer_id) {
+      countQuery += ` AND customer_id = $${countIndex}`
+      countParams.push(customer_id)
+      countIndex++
+    }
+
+    if (action_type) {
+      countQuery += ` AND action_type = $${countIndex}`
+      countParams.push(action_type)
+    }
+
+    const countResult = await pgConnection.raw(countQuery, countParams)
+
+    return res.status(200).json({
+      logs: result?.rows || [],
+      count: parseInt(countResult?.rows?.[0]?.count || "0"),
+      limit: parseInt(limit) || 50,
+      offset: parseInt(offset) || 0,
+    })
+  } catch (err: any) {
+    if (err.message?.includes("does not exist")) {
+      return res.status(200).json({
+        logs: [],
+        count: 0,
+        note: "data_processing_log table not yet created. Run the migration script.",
+      })
+    }
+
+    logger.error(`[data-processing-log] Query error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to query logs" })
+  }
+}

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -22,5 +22,10 @@ export default defineMiddlewares({
         }),
       ],
     },
+    {
+      matcher: "/admin/data-processing-log",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
   ],
 })

--- a/src/scripts/create-data-processing-log.ts
+++ b/src/scripts/create-data-processing-log.ts
@@ -1,0 +1,66 @@
+/**
+ * Migration script to create data_processing_log table.
+ *
+ * Run with: npx medusa exec src/scripts/create-data-processing-log.ts
+ *
+ * This table records all GDPR-related data processing activities
+ * (exports, erasures) for compliance auditing.
+ */
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+export default async function createDataProcessingLog({
+  container,
+}: ExecArgs) {
+  const logger = container.resolve("logger") as any
+  const pgConnection = container.resolve(
+    ContainerRegistrationKeys.PG_CONNECTION
+  ) as any
+
+  logger.info("[data-processing-log] Creating data_processing_log table...")
+
+  try {
+    const tableExistsResult = await pgConnection.raw(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = 'public'
+        AND table_name = 'data_processing_log'
+      ) AS exists
+    `)
+
+    if (tableExistsResult?.rows?.[0]?.exists) {
+      logger.info(
+        "[data-processing-log] Table already exists, skipping creation"
+      )
+      return
+    }
+
+    await pgConnection.raw(`
+      CREATE TABLE data_processing_log (
+        id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+        customer_id VARCHAR(255) NOT NULL,
+        action_type VARCHAR(50) NOT NULL,
+        ip_address VARCHAR(45),
+        details JSONB DEFAULT '{}'::jsonb,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
+      )
+    `)
+
+    await pgConnection.raw(`
+      CREATE INDEX idx_dpl_customer_id ON data_processing_log (customer_id)
+    `)
+    await pgConnection.raw(`
+      CREATE INDEX idx_dpl_action_type ON data_processing_log (action_type)
+    `)
+    await pgConnection.raw(`
+      CREATE INDEX idx_dpl_created_at ON data_processing_log (created_at)
+    `)
+
+    logger.info("[data-processing-log] ✅ Table created successfully")
+  } catch (error: any) {
+    logger.error(
+      `[data-processing-log] Error creating table: ${error.message}`
+    )
+    throw error
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide an auditable, core-independent table to record GDPR data exports and erasures (Article 30) so export/delete flows can write compliance records.

### Description
- Add `src/scripts/create-data-processing-log.ts`, a Medusa-exec migration script that is idempotent and creates `data_processing_log` with `id UUID DEFAULT gen_random_uuid()`, `customer_id`, `action_type`, `ip_address`, `details JSONB DEFAULT '{}'::jsonb`, `created_at TIMESTAMPTZ`, and indexes on `customer_id`, `action_type`, and `created_at`.
- Add admin API `GET /admin/data-processing-log` at `src/api/admin/data-processing-log/route.ts` supporting `customer_id` and `action_type` filtering and `limit/offset` pagination, returning an empty result + `note` when the table does not exist.
- Register the route-level middleware in `src/api/middlewares.ts` to require `user` authentication for the `/admin/data-processing-log` GET route.
- Document the migration command in `.env.example` showing how to create the table via `npx medusa exec src/scripts/create-data-processing-log.ts`.

### Testing
- Ran `npm run build` which failed in this environment because the `medusa` CLI is not available (`medusa: not found`).
- Ran `npx tsc --noEmit` which failed due to missing local dependency/type resolution (module/type errors unrelated to the small change in this PR).
- Code-level protections implemented: migration checks `information_schema.tables` to be idempotent so repeated runs will skip creation (validated by code inspection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aef62b1d4c8333b4d300b00504e4b7)