### PR TITLE
feat: add multi-currency seed script (USD/EUR/GBP)

### DIFF
--- a/src/scripts/seed-currencies.ts
+++ b/src/scripts/seed-currencies.ts
@@ -1,0 +1,74 @@
+import { ExecArgs } from "@medusajs/framework/types"
+
+type StoreRecord = {
+  id: string
+  supported_currencies?: { currency_code: string }[]
+}
+
+export default async function seedCurrencies({ container }: ExecArgs) {
+  const logger = container.resolve("logger") as {
+    info: (msg: string) => void
+    warn: (msg: string) => void
+    error: (msg: string) => void
+  }
+
+  logger.info("[seed-currencies] Starting currency configuration...")
+
+  const targetCurrencies = ["usd", "eur", "gbp"]
+
+  let storeModule: any
+
+  try {
+    storeModule = container.resolve("store")
+  } catch (error: any) {
+    logger.error(
+      `[seed-currencies] Store Module unavailable: ${error?.message ?? "unknown error"}`
+    )
+    return
+  }
+
+  try {
+    // Medusa v2 generally has a single default store; list defensively to support API shape variations.
+    const listResult = await storeModule.listStores()
+
+    const stores: StoreRecord[] = Array.isArray(listResult)
+      ? Array.isArray(listResult[0])
+        ? listResult[0]
+        : listResult
+      : []
+
+    if (!stores.length) {
+      logger.error("[seed-currencies] No store found. Skipping currency seed.")
+      return
+    }
+
+    const store = stores[0]
+
+    await storeModule.updateStores(store.id, {
+      supported_currencies: targetCurrencies.map((currencyCode, index) => ({
+        currency_code: currencyCode.toLowerCase(),
+        is_default: currencyCode === "usd",
+        order: index,
+      })),
+    })
+
+    logger.info(
+      `[seed-currencies] Store currencies updated: ${targetCurrencies.join(", ")}`
+    )
+
+    const updatedStore = (await storeModule.retrieveStore(store.id, {
+      relations: ["supported_currencies"],
+    })) as StoreRecord
+
+    const currencyCodes =
+      updatedStore.supported_currencies?.map((currency) => currency.currency_code) ?? []
+
+    logger.info(`[seed-currencies] Verified currencies: ${currencyCodes.join(", ")}`)
+    logger.info(
+      "[seed-currencies] ✅ Currency seed complete. Stripe automatically supports all Medusa-configured currencies."
+    )
+  } catch (error: any) {
+    logger.error(`[seed-currencies] Error: ${error?.message ?? "unknown error"}`)
+    throw error
+  }
+}


### PR DESCRIPTION
### Motivation
- Automate configuring the Medusa Store to support multiple currencies (USD/EUR/GBP) so the platform and Stripe payments accept these currencies.
- Make the seed idempotent and robust by using the Medusa v2 Store Module API and handling missing store/module cases gracefully.

### Description
- Add `src/scripts/seed-currencies.ts`, a Medusa exec script that sets `supported_currencies` to `usd`, `eur`, and `gbp` and marks `usd` as the default.
- Resolve `store` and `logger` from the execution `container` and defensively handle the Store Module being unavailable by logging and exiting.
- Use `listStores()` while supporting possible API shape variations to find the default store and call `updateStores()` with lowercased ISO 4217 codes and ordering to ensure idempotent overwrite behavior.
- Re-fetch the store via `retrieveStore(..., { relations: ["supported_currencies"] })` and log verification info, and log errors on unexpected failures.

### Testing
- Ran TypeScript compile check via `npx tsc --noEmit`, which failed due to project-wide type/dependency resolution errors unrelated to the new script (no single-file runtime/type issues were isolated).
- No automated unit tests were added; the script is intended to be executed with `npx medusa exec src/scripts/seed-currencies.ts` in a running Medusa environment for functional verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aef665375c8333ac95633e99c31f02)