### PR TITLE
feat: Harden Stripe webhooks — audit middleware + signature-verified events endpoint

### DIFF
--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -1,8 +1,14 @@
 import { defineMiddlewares, authenticate, validateAndTransformBody } from "@medusajs/framework/http"
+import { stripeWebhookAuditMiddleware } from "./middlewares/stripe-webhook-audit"
 import { StoreCreateRestockSubscription } from "./store/restock-subscriptions/validators"
 
 export default defineMiddlewares({
   routes: [
+    {
+      matcher: "/hooks/payment/stripe_stripe",
+      method: "POST",
+      middlewares: [stripeWebhookAuditMiddleware],
+    },
     {
       matcher: "/store/restock-subscriptions",
       method: "POST",

--- a/src/api/middlewares/stripe-webhook-audit.ts
+++ b/src/api/middlewares/stripe-webhook-audit.ts
@@ -1,0 +1,53 @@
+import type {
+  MedusaNextFunction,
+  MedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+
+export async function stripeWebhookAuditMiddleware(
+  req: MedusaRequest,
+  res: MedusaResponse,
+  next: MedusaNextFunction
+) {
+  const logger = req.scope.resolve("logger") as {
+    error: (msg: string) => void
+    info: (msg: string) => void
+  }
+  const startTime = Date.now()
+
+  const signature = req.headers["stripe-signature"]
+  if (!signature) {
+    logger.error(
+      `[stripe-webhook-audit] ❌ REJECTED: Missing stripe-signature header from ${req.ip}`
+    )
+    res.status(400).json({ error: "Missing stripe-signature header" })
+    return
+  }
+
+  const body = req.body as Record<string, unknown> | undefined
+  const eventType = typeof body?.type === "string" ? body.type : "unknown"
+  const eventId = typeof body?.id === "string" ? body.id : "unknown"
+
+  logger.info(
+    `[stripe-webhook-audit] Incoming webhook: event=${eventType} id=${eventId} ip=${req.ip}`
+  )
+
+  const originalJson = res.json.bind(res)
+  const originalStatus = res.status.bind(res)
+  let responseStatus = res.statusCode || 200
+
+  res.status = (code: number) => {
+    responseStatus = code
+    return originalStatus(code)
+  }
+
+  res.json = (data: unknown) => {
+    const duration = Date.now() - startTime
+    logger.info(
+      `[stripe-webhook-audit] Processed: event=${eventType} id=${eventId} status=${responseStatus} duration=${duration}ms`
+    )
+    return originalJson(data)
+  }
+
+  next()
+}

--- a/src/api/store/stripe-events/route.ts
+++ b/src/api/store/stripe-events/route.ts
@@ -1,0 +1,56 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import Stripe from "stripe"
+
+export async function POST(
+  req: MedusaRequest,
+  res: MedusaResponse
+) {
+  const logger = req.scope.resolve("logger") as {
+    error: (msg: string) => void
+    info: (msg: string) => void
+  }
+
+  const signature = req.headers["stripe-signature"] as string | undefined
+  if (!signature) {
+    logger.error(`[stripe-events] Rejected: no stripe-signature from ${req.ip}`)
+    return res.status(400).json({ error: "Missing stripe-signature" })
+  }
+
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
+  if (!webhookSecret) {
+    logger.error("[stripe-events] STRIPE_WEBHOOK_SECRET not configured")
+    return res.status(500).json({ error: "Webhook not configured" })
+  }
+
+  try {
+    const rawBody =
+      typeof req.body === "string" ? req.body : JSON.stringify(req.body)
+
+    const stripe = new Stripe(process.env.STRIPE_API_KEY || "", {
+      apiVersion: "2025-02-24.acacia",
+    })
+
+    const event = stripe.webhooks.constructEvent(rawBody, signature, webhookSecret)
+
+    logger.info(`[stripe-events] ✅ Verified event: type=${event.type} id=${event.id}`)
+
+    const logEntry = {
+      event_id: event.id,
+      event_type: event.type,
+      created: new Date(event.created * 1000).toISOString(),
+      livemode: event.livemode,
+      ip: req.ip,
+      timestamp: new Date().toISOString(),
+    }
+
+    logger.info(`[stripe-events] Event data: ${JSON.stringify(logEntry)}`)
+
+    return res.status(200).json({ received: true, event_id: event.id })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : JSON.stringify(err)
+    logger.error(
+      `[stripe-events] ❌ Signature verification failed from ${req.ip}: ${message}`
+    )
+    return res.status(400).json({ error: "Invalid signature" })
+  }
+}


### PR DESCRIPTION
### Motivation
- Harden Stripe webhook handling by rejecting requests without `stripe-signature`, recording an audit trail for all webhook events, and providing an optional separate endpoint for non-payment Stripe events that enforces signature verification via `STRIPE_WEBHOOK_SECRET`.

### Description
- Add `src/api/middlewares/stripe-webhook-audit.ts` which implements `stripeWebhookAuditMiddleware` to reject missing `stripe-signature`, log incoming event metadata and final status/duration, and then forward to Medusa's built-in Stripe handler.
- Add `src/api/store/stripe-events/route.ts` implementing `POST /store/stripe-events` that verifies Stripe signatures using `stripe.webhooks.constructEvent(...)`, logs verified event details, returns `400` on invalid signatures, and returns `500` when `STRIPE_WEBHOOK_SECRET` is not configured.
- Register the audit middleware in `src/api/middlewares.ts` so it runs for `POST /hooks/payment/stripe_stripe` before the existing built-in handler.

### Testing
- Ran `npm run build` which failed in this environment because the `medusa` CLI is not available (`sh: 1: medusa: not found`).
- Ran `npx tsc --noEmit` which failed due to missing project dependencies and type declarations (Medusa/Stripe types), so TypeScript checks could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aef6850c7883339ca12b379689bcfa)