### PR TITLE
feat/c-036e-finance-summary-api

### DIFF
--- a/src/api/admin/finance/summary/route.ts
+++ b/src/api/admin/finance/summary/route.ts
@@ -1,0 +1,158 @@
+/**
+ * Admin API: GET /admin/finance/summary
+ *
+ * 返回财务汇总：总收入、总退款、净收入、Stripe 手续费估算、待处理退款。
+ * Stripe 手续费按 2.9% + $0.30 每笔订单估算。
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+type RawResultRow = Record<string, string | number | Date | null>
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as {
+    error: (message: string) => void
+  }
+  const pgConnection = req.scope.resolve(
+    ContainerRegistrationKeys.PG_CONNECTION
+  ) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: RawResultRow[] }>
+  }
+
+  const {
+    date_from,
+    date_to,
+    granularity = "month",
+    currency_code = "usd",
+  } = req.query as Record<string, string>
+
+  try {
+    const validGranularities = ["day", "week", "month"]
+    const gran = validGranularities.includes(granularity) ? granularity : "month"
+
+    const conditions: string[] = [
+      "o.canceled_at IS NULL",
+      "o.currency_code = $1",
+    ]
+    const params: unknown[] = [currency_code.toLowerCase()]
+    let paramIndex = 2
+
+    if (date_from) {
+      conditions.push(`o.created_at >= $${paramIndex}::timestamptz`)
+      params.push(date_from)
+      paramIndex += 1
+    }
+
+    if (date_to) {
+      conditions.push(`o.created_at < ($${paramIndex}::date + interval '1 day')`)
+      params.push(date_to)
+      paramIndex += 1
+    }
+
+    const whereClause = `WHERE ${conditions.join(" AND ")}`
+    const truncExpr = `date_trunc('${gran}', o.created_at)`
+
+    const totalExpr = `
+      CASE
+        WHEN o.raw_total IS NOT NULL AND o.raw_total->>'value' IS NOT NULL
+          THEN (o.raw_total->>'value')::numeric
+        ELSE COALESCE(o.total, 0)
+      END
+    `
+
+    const refundExpr = `
+      CASE
+        WHEN o.raw_refunded_total IS NOT NULL AND o.raw_refunded_total->>'value' IS NOT NULL
+          THEN (o.raw_refunded_total->>'value')::numeric
+        ELSE COALESCE(o.refunded_total, 0)
+      END
+    `
+
+    const dataPointsQuery = `
+      SELECT
+        ${truncExpr} AS period,
+        COALESCE(SUM(${totalExpr}), 0) AS revenue,
+        COALESCE(SUM(${refundExpr}), 0) AS refunds,
+        COALESCE(SUM(${totalExpr}) - SUM(${refundExpr}), 0) AS net
+      FROM "order" o
+      ${whereClause}
+      GROUP BY period
+      ORDER BY period DESC
+    `
+
+    const dataPointsResult = await pgConnection.raw(dataPointsQuery, params)
+    const dataPoints = (dataPointsResult?.rows ?? []).map((row) => ({
+      period: row.period,
+      revenue: Number(row.revenue ?? 0),
+      refunds: Number(row.refunds ?? 0),
+      net: Number(row.net ?? 0),
+    }))
+
+    const totalRevenue = dataPoints.reduce((sum, point) => sum + point.revenue, 0)
+    const totalRefunds = dataPoints.reduce((sum, point) => sum + point.refunds, 0)
+    const netRevenue = totalRevenue - totalRefunds
+
+    const feeQuery = `
+      SELECT
+        COALESCE(SUM(${totalExpr} * 0.029 + 0.30), 0) AS estimated_fees
+      FROM "order" o
+      ${whereClause}
+    `
+    const feeResult = await pgConnection.raw(feeQuery, params)
+    const estimatedFeesRaw = feeResult?.rows?.[0]?.estimated_fees
+    const estimatedStripeFees = Math.round(Number(estimatedFeesRaw ?? 0) * 100) / 100
+
+    let pendingRefunds = 0
+    try {
+      const pendingQuery = `
+        SELECT
+          COALESCE(SUM(
+            CASE
+              WHEN r.raw_refund_amount IS NOT NULL AND r.raw_refund_amount->>'value' IS NOT NULL
+                THEN (r.raw_refund_amount->>'value')::numeric
+              ELSE COALESCE(r.refund_amount, 0)
+            END
+          ), 0) AS pending
+        FROM return r
+        JOIN "order" o ON r.order_id = o.id
+        ${whereClause}
+        AND r.status IN ('requested', 'received')
+      `
+      const pendingResult = await pgConnection.raw(pendingQuery, params)
+      pendingRefunds = Number(pendingResult?.rows?.[0]?.pending ?? 0)
+    } catch {
+      pendingRefunds = 0
+    }
+
+    return res.status(200).json({
+      total_revenue: totalRevenue,
+      total_refunds: totalRefunds,
+      net_revenue: netRevenue,
+      estimated_stripe_fees: estimatedStripeFees,
+      pending_refunds: pendingRefunds,
+      currency_code: currency_code.toLowerCase(),
+      data_points: dataPoints,
+      date_from: date_from ?? null,
+      date_to: date_to ?? null,
+    })
+  } catch (err: any) {
+    logger.error(`[finance-summary] Query error: ${err.message}`)
+
+    if (err.message?.includes("does not exist")) {
+      return res.status(200).json({
+        total_revenue: 0,
+        total_refunds: 0,
+        net_revenue: 0,
+        estimated_stripe_fees: 0,
+        pending_refunds: 0,
+        currency_code: currency_code.toLowerCase(),
+        data_points: [],
+        date_from: date_from ?? null,
+        date_to: date_to ?? null,
+        note: "Order table not initialized.",
+      })
+    }
+
+    return res.status(500).json({ error: "Failed to query finance summary" })
+  }
+}

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -53,5 +53,10 @@ export default defineMiddlewares({
       method: "GET",
       middlewares: [authenticate("user", ["bearer", "session"])],
     },
+    {
+      matcher: "/admin/finance/*",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
   ],
 })


### PR DESCRIPTION
### Motivation
- 提供一个管理员侧的财务汇总 API `GET /admin/finance/summary`，按时间区间和粒度汇总收入/退款/净收入并估算 Stripe 手续费（2.9% + $0.30/笔），以便后台财务报表使用。
- 兼容 Medusa 中可能存在的原始 JSON 金额字段（`raw_total` / `raw_refunded_total`）与数值列（`total` / `refunded_total`），并统计 `requested` / `received` 状态的待处理退款。

### Description
- 新增路由文件 `src/api/admin/finance/summary/route.ts`，实现基于 Postgres 的聚合查询，按 `granularity`（`day|week|month`）、`date_from`、`date_to` 和 `currency_code` 过滤并返回 `data_points` 与总体汇总字段。
- 在 SQL 层用 `CASE` 同时读取 `raw_*` JSON 字段和回退列，并计算 `estimated_stripe_fees` 为 `SUM(order_total * 0.029 + 0.30)`（以 major units 计），最终结果以两位小数返回。
- 查询待处理退款时连接 `return` 表并仅计入 `status IN ('requested','received')`，对不存在的 `return` 表使用 `try/catch` 安全降级为 0。
- 更新中间件配置 `src/api/middlewares.ts`，在 routes 列表末尾追加 `matcher: "/admin/finance/*"` 的 GET 鉴权以保护本次接口（不移除或修改现有路由）。

### Testing
- 运行类型检查 `npx tsc --noEmit`，该命令在当前环境中失败并返回仓库范围的依赖/类型解析错误，错误与本次改动无直接关系且为预存在仓库的类型问题 (failed)。
- 未有额外自动化单元测试或集成测试在此变更中新增或执行 (no other automated tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af26aa85748333bc637d26e5a9dbaf)