### PR TITLE
feat/c-036f-finance-export-api

### DIFF
--- a/src/api/admin/finance/export/route.ts
+++ b/src/api/admin/finance/export/route.ts
@@ -1,0 +1,220 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+function escCsv(val: unknown): string {
+  if (val === null || val === undefined) return ""
+
+  const str = String(val)
+
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return '"' + str.replace(/"/g, '""') + '"'
+  }
+
+  return str
+}
+
+function extractAmount(rawField: unknown, plainField: unknown): number {
+  if (rawField && typeof rawField === "object" && "value" in rawField) {
+    return parseFloat(String((rawField as { value: unknown }).value)) || 0
+  }
+
+  if (typeof rawField === "string") {
+    try {
+      const parsed = JSON.parse(rawField)
+      if (parsed?.value !== undefined) {
+        return parseFloat(String(parsed.value)) || 0
+      }
+    } catch {
+      // ignore non-JSON raw amount value
+    }
+  }
+
+  return parseFloat(String(plainField ?? 0)) || 0
+}
+
+const CSV_HEADERS = [
+  "order_id",
+  "date",
+  "customer_email",
+  "items",
+  "subtotal",
+  "shipping",
+  "tax",
+  "total",
+  "payment_method",
+  "payment_status",
+  "refund_amount",
+  "refund_status",
+]
+
+function buildCsv(rows: any[], fallbackItemsText = ""): string {
+  let csv = CSV_HEADERS.join(",") + "\n"
+
+  for (const row of rows) {
+    const subtotal = extractAmount(row.raw_subtotal, row.subtotal)
+    const shipping = extractAmount(row.raw_shipping_total, row.shipping_total)
+    const tax = extractAmount(row.raw_tax_total, row.tax_total)
+    const total = extractAmount(row.raw_total, row.total)
+    const refundAmount = extractAmount(row.raw_refunded_total, row.refunded_total)
+
+    const line = [
+      escCsv(row.order_id),
+      escCsv(row.date ? new Date(row.date).toISOString() : ""),
+      escCsv(row.customer_email),
+      escCsv(row.items ?? fallbackItemsText),
+      escCsv(subtotal),
+      escCsv(shipping),
+      escCsv(tax),
+      escCsv(total),
+      escCsv(row.payment_provider || "stripe"),
+      escCsv(row.payment_status || "unknown"),
+      escCsv(refundAmount),
+      escCsv(refundAmount > 0 ? "refunded" : "none"),
+    ].join(",")
+
+    csv += `${line}\n`
+  }
+
+  return csv
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as {
+    error: (message: string) => void
+  }
+
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: any[]) => Promise<{ rows?: any[] }>
+  }
+
+  const { date_from, date_to, currency_code = "usd", format = "csv" } = req.query as Record<
+    string,
+    string
+  >
+
+  if (format.toLowerCase() !== "csv") {
+    return res.status(400).json({ error: "Only csv format is supported" })
+  }
+
+  const conditions: string[] = ["o.canceled_at IS NULL", "o.currency_code = $1"]
+  const params: any[] = [currency_code.toLowerCase()]
+  let paramIndex = 2
+
+  if (date_from) {
+    conditions.push(`o.created_at >= $${paramIndex}::timestamptz`)
+    params.push(date_from)
+    paramIndex += 1
+  }
+
+  if (date_to) {
+    conditions.push(`o.created_at < ($${paramIndex}::date + interval '1 day')`)
+    params.push(date_to)
+    paramIndex += 1
+  }
+
+  const whereClause = `WHERE ${conditions.join(" AND ")}`
+
+  try {
+    const query = `
+      SELECT
+        o.id AS order_id,
+        o.created_at AS date,
+        o.email AS customer_email,
+        o.raw_subtotal,
+        o.subtotal,
+        o.raw_shipping_total,
+        o.shipping_total,
+        o.raw_tax_total,
+        o.tax_total,
+        o.raw_total,
+        o.total,
+        o.raw_refunded_total,
+        o.refunded_total,
+        o.payment_status,
+        (
+          SELECT STRING_AGG(
+            CONCAT(li.title, ' (x', li.quantity, ')'),
+            '; '
+          )
+          FROM order_line_item li
+          WHERE li.order_id = o.id
+        ) AS items,
+        (
+          SELECT p.provider_id
+          FROM payment p
+          JOIN payment_collection pc ON p.payment_collection_id = pc.id
+          WHERE pc.id = (
+            SELECT pc2.id
+            FROM payment_collection pc2
+            WHERE pc2.id IN (
+              SELECT opc.payment_collection_id
+              FROM order_payment_collection opc
+              WHERE opc.order_id = o.id
+            )
+            LIMIT 1
+          )
+          LIMIT 1
+        ) AS payment_provider
+      FROM "order" o
+      ${whereClause}
+      ORDER BY o.created_at DESC
+    `
+
+    const result = await pgConnection.raw(query, params)
+    const csv = buildCsv(result?.rows || [])
+
+    const today = new Date().toISOString().split("T")[0]
+    res.setHeader("Content-Type", "text/csv; charset=utf-8")
+    res.setHeader("Content-Disposition", `attachment; filename="nordhjem-finance-export-${today}.csv"`)
+
+    return res.status(200).send(csv)
+  } catch (err: any) {
+    logger.error(`[finance-export] Query error: ${err.message}`)
+
+    if (err.message?.includes("order_line_item") && err.message?.includes("does not exist")) {
+      try {
+        const fallbackQuery = `
+          SELECT
+            o.id AS order_id,
+            o.created_at AS date,
+            o.email AS customer_email,
+            o.raw_subtotal,
+            o.subtotal,
+            o.raw_shipping_total,
+            o.shipping_total,
+            o.raw_tax_total,
+            o.tax_total,
+            o.raw_total,
+            o.total,
+            o.raw_refunded_total,
+            o.refunded_total,
+            o.payment_status
+          FROM "order" o
+          ${whereClause}
+          ORDER BY o.created_at DESC
+        `
+
+        const fallbackResult = await pgConnection.raw(fallbackQuery, params)
+        const csv = buildCsv(fallbackResult?.rows || [], "(line items unavailable)")
+
+        const today = new Date().toISOString().split("T")[0]
+        res.setHeader("Content-Type", "text/csv; charset=utf-8")
+        res.setHeader(
+          "Content-Disposition",
+          `attachment; filename="nordhjem-finance-export-${today}.csv"`
+        )
+
+        return res.status(200).send(csv)
+      } catch (fallbackErr: any) {
+        logger.error(`[finance-export] Fallback error: ${fallbackErr.message}`)
+      }
+    }
+
+    if (err.message?.includes("does not exist")) {
+      res.setHeader("Content-Type", "text/csv; charset=utf-8")
+      return res.status(200).send(`${CSV_HEADERS.join(",")}\n`)
+    }
+
+    return res.status(500).json({ error: "Failed to export finance data" })
+  }
+}


### PR DESCRIPTION
### Motivation
- 提供管理端导出完整交易记录为 CSV 的能力，支持按时间区间和货币过滤并兼容现有数据库字段格式以便财务分析和审计。

### Description
- 新增 Admin 路由 `GET /admin/finance/export`（文件 `src/api/admin/finance/export/route.ts`），根据 `format`, `date_from`, `date_to`, `currency_code` 查询并导出 CSV。 
- 实现 CSV 字段安全转义 `escCsv`、`raw_*` JSON 与普通金额列兼容的 `extractAmount`、以及按 UTC ISO 输出的 `date` 字段。 
- 使用 PostgreSQL 主查询聚合订单行项目并查找支付提供商，包含当 `order_line_item` 表不存在时的回退查询与最终兜底（只返回表头）逻辑。 
- 为该路由在 `src/api/middlewares.ts` 中注册了管理员鉴权规则（`authenticate("user", ["bearer", "session"])`），以确保未认证请求返回 401。 

### Testing
- 尝试运行构建命令 `npm run build`，构建失败因为运行环境中缺少 `medusa` CLI（`sh: 1: medusa: not found`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af26b46a288333a980a197d28c5341)