### PR TITLE
fix(C-036a): remove invalid 'order' field from seed-currencies.ts

### DIFF
--- a/src/scripts/seed-currencies.ts
+++ b/src/scripts/seed-currencies.ts
@@ -45,10 +45,9 @@ export default async function seedCurrencies({ container }: ExecArgs) {
     const store = stores[0]
 
     await storeModule.updateStores(store.id, {
-      supported_currencies: targetCurrencies.map((currencyCode, index) => ({
+      supported_currencies: targetCurrencies.map((currencyCode) => ({
         currency_code: currencyCode.toLowerCase(),
         is_default: currencyCode === "usd",
-        order: index,
       })),
     })
 


### PR DESCRIPTION
### Motivation
- Remove an invalid `order` property from the `supported_currencies` payload so the seed script only sends supported fields to the store API and avoid passing the unused `index` parameter.

### Description
- Changed the mapping call from `targetCurrencies.map((currencyCode, index) => ...)` to `targetCurrencies.map((currencyCode) => ...)` in `src/scripts/seed-currencies.ts`.
- Removed the `order` field and preserved `currency_code` and `is_default` in each currency object.
- Only `src/scripts/seed-currencies.ts` was modified.

### Testing
- Ran `git diff -- src/scripts/seed-currencies.ts` to verify the exact change and `git status --short` to confirm repository state, and both commands completed successfully.
- Committed the change with message `fix(C-036a): remove invalid order field from seed-currencies`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af2a1ea15083339f24f704cbe3d021)