### PR TITLE
fix(C-036): replace $N placeholders with ? for Knex compatibility in all analytics/finance routes

### DIFF
--- a/src/api/admin/analytics/sales-summary/route.ts
+++ b/src/api/admin/analytics/sales-summary/route.ts
@@ -28,21 +28,18 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     const conditions: string[] = [
       "o.canceled_at IS NULL",
       "o.payment_status = 'captured'",
-      "o.currency_code = $1",
+      "o.currency_code = ?",
     ]
     const params: any[] = [currency_code.toLowerCase()]
-    let paramIndex = 2
 
     if (date_from) {
-      conditions.push(`o.created_at >= $${paramIndex}::timestamptz`)
+      conditions.push("o.created_at >= ?::timestamptz")
       params.push(date_from)
-      paramIndex++
     }
 
     if (date_to) {
-      conditions.push(`o.created_at < ($${paramIndex}::date + interval '1 day')`)
+      conditions.push("o.created_at < (?::date + interval '1 day')")
       params.push(date_to)
-      paramIndex++
     }
 
     const whereClause = `WHERE ${conditions.join(" AND ")}`

--- a/src/api/admin/analytics/top-products/route.ts
+++ b/src/api/admin/analytics/top-products/route.ts
@@ -30,28 +30,25 @@ const buildConditions = (
 ): { whereClause: string; params: any[]; limitParam: string } => {
   const conditions: string[] = [
     "o.canceled_at IS NULL",
-    "o.currency_code = $1",
+    "o.currency_code = ?",
   ]
 
   const params: any[] = [currencyCode]
-  let paramIndex = 2
 
   if (dateFrom) {
-    conditions.push(`o.created_at >= $${paramIndex}::timestamptz`)
+    conditions.push("o.created_at >= ?::timestamptz")
     params.push(dateFrom)
-    paramIndex++
   }
 
   if (dateTo) {
-    conditions.push(`o.created_at < ($${paramIndex}::date + interval '1 day')`)
+    conditions.push("o.created_at < (?::date + interval '1 day')")
     params.push(dateTo)
-    paramIndex++
   }
 
   return {
     whereClause: `WHERE ${conditions.join(" AND ")}`,
     params,
-    limitParam: `$${paramIndex}`,
+    limitParam: "?",
   }
 }
 

--- a/src/api/admin/analytics/traffic/route.ts
+++ b/src/api/admin/analytics/traffic/route.ts
@@ -22,20 +22,16 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   try {
     const cartConditions: string[] = []
     const params: any[] = []
-    let paramIndex = 1
-
     if (date_from) {
-      cartConditions.push(`created_at >= $${paramIndex}::timestamptz`)
+      cartConditions.push("created_at >= ?::timestamptz")
       params.push(date_from)
-      paramIndex++
     }
 
     if (date_to) {
       cartConditions.push(
-        `created_at < ($${paramIndex}::date + interval '1 day')`
+        "created_at < (?::date + interval '1 day')"
       )
       params.push(date_to)
-      paramIndex++
     }
 
     const cartWhere = cartConditions.length

--- a/src/api/admin/finance/export/route.ts
+++ b/src/api/admin/finance/export/route.ts
@@ -96,20 +96,16 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     return res.status(400).json({ error: "Only csv format is supported" })
   }
 
-  const conditions: string[] = ["o.canceled_at IS NULL", "o.currency_code = $1"]
+  const conditions: string[] = ["o.canceled_at IS NULL", "o.currency_code = ?"]
   const params: any[] = [currency_code.toLowerCase()]
-  let paramIndex = 2
-
   if (date_from) {
-    conditions.push(`o.created_at >= $${paramIndex}::timestamptz`)
+    conditions.push("o.created_at >= ?::timestamptz")
     params.push(date_from)
-    paramIndex += 1
   }
 
   if (date_to) {
-    conditions.push(`o.created_at < ($${paramIndex}::date + interval '1 day')`)
+    conditions.push("o.created_at < (?::date + interval '1 day')")
     params.push(date_to)
-    paramIndex += 1
   }
 
   const whereClause = `WHERE ${conditions.join(" AND ")}`

--- a/src/api/admin/finance/summary/route.ts
+++ b/src/api/admin/finance/summary/route.ts
@@ -32,21 +32,17 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
 
     const conditions: string[] = [
       "o.canceled_at IS NULL",
-      "o.currency_code = $1",
+      "o.currency_code = ?",
     ]
     const params: unknown[] = [currency_code.toLowerCase()]
-    let paramIndex = 2
-
     if (date_from) {
-      conditions.push(`o.created_at >= $${paramIndex}::timestamptz`)
+      conditions.push("o.created_at >= ?::timestamptz")
       params.push(date_from)
-      paramIndex += 1
     }
 
     if (date_to) {
-      conditions.push(`o.created_at < ($${paramIndex}::date + interval '1 day')`)
+      conditions.push("o.created_at < (?::date + interval '1 day')")
       params.push(date_to)
-      paramIndex += 1
     }
 
     const whereClause = `WHERE ${conditions.join(" AND ")}`


### PR DESCRIPTION
### Motivation
- Knex's `raw` method expects `?` parameter placeholders, but several admin analytics/finance routes used PostgreSQL-style `$N` placeholders and `paramIndex` counters which prevented parameters from binding correctly.
- Convert placeholders to `?` and remove the index bookkeeping while preserving existing SQL semantics to restore compatibility with the project's PG connection wrapper.

### Description
- Replaced `$N` placeholders with `?` in the five target route files: `src/api/admin/analytics/sales-summary/route.ts`, `src/api/admin/analytics/top-products/route.ts`, `src/api/admin/analytics/traffic/route.ts`, `src/api/admin/finance/summary/route.ts`, and `src/api/admin/finance/export/route.ts`.
- Converted `o.currency_code = $1` to `o.currency_code = ?` and updated date filters to use `?::timestamptz` and `(?::date + interval '1 day')` where applicable, without changing filter logic.
- Removed all `paramIndex` variables and increment logic that existed solely to build `$N` placeholders.
- Updated `buildConditions` in `top-products` to return `limitParam: "?"` and retained existing parameter ordering so calls like `pgConnection.raw(query, [...params, safeLimit])` keep working.

### Testing
- Ran an automated search with `rg -n "\$[0-9]+|paramIndex|limitParam"` before and after the changes to locate occurrences and verify that no `$N` placeholders or `paramIndex` usage remain in the five modified files, and the check succeeded.
- Inspected the modified files to confirm only placeholder/tokenization changes were made and that SQL logic and parameter arrays passed to `pgConnection.raw` remain consistent, and the inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af2c8ea2788333bd0c25eaf799eb78)