### PR TITLE
feat(C-037a): M11 finance management — multi-currency reports, reconciliation, tax rates

### DIFF
--- a/src/api/admin/finance/reconciliation/route.ts
+++ b/src/api/admin/finance/reconciliation/route.ts
@@ -1,0 +1,131 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+type RawResultRow = Record<string, string | number | Date | null>
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: RawResultRow[] }>
+  }
+
+  const { date_from, date_to, currency_code = "usd" } = req.query as Record<string, string>
+
+  try {
+    const conditions: string[] = [
+      "o.canceled_at IS NULL",
+      "o.currency_code = ?",
+    ]
+    const params: unknown[] = [currency_code.toLowerCase()]
+
+    if (date_from) {
+      conditions.push("o.created_at >= ?::timestamptz")
+      params.push(date_from)
+    }
+
+    if (date_to) {
+      conditions.push("o.created_at < (?::date + interval '1 day')")
+      params.push(date_to)
+    }
+
+    const whereClause = `WHERE ${conditions.join(" AND ")}`
+
+    const query = `
+      SELECT
+        o.id AS order_id,
+        o.display_id,
+        o.created_at,
+        CASE
+          WHEN o.raw_total IS NOT NULL AND o.raw_total->>'value' IS NOT NULL
+            THEN (o.raw_total->>'value')::numeric
+          ELSE COALESCE(o.total, 0)
+        END AS order_amount,
+        COALESCE(p_agg.payment_amount, 0) AS payment_amount,
+        COALESCE(p_agg.payment_status, ps_agg.session_status, 'unknown') AS payment_status
+      FROM "order" o
+      JOIN order_payment_collection opc ON opc.order_id = o.id
+      JOIN payment_collection pc ON pc.id = opc.payment_collection_id
+      LEFT JOIN LATERAL (
+        SELECT
+          COALESCE(SUM(
+            CASE
+              WHEN p.raw_amount IS NOT NULL AND p.raw_amount->>'value' IS NOT NULL
+                THEN (p.raw_amount->>'value')::numeric
+              ELSE COALESCE(p.amount, 0)
+            END
+          ), 0) AS payment_amount,
+          MAX(p.status) AS payment_status
+        FROM payment p
+        WHERE p.payment_collection_id = pc.id
+      ) p_agg ON TRUE
+      LEFT JOIN LATERAL (
+        SELECT MAX(ps.status) AS session_status
+        FROM payment_session ps
+        WHERE ps.payment_collection_id = pc.id
+      ) ps_agg ON TRUE
+      ${whereClause}
+      ORDER BY o.created_at DESC
+    `
+
+    const result = await pgConnection.raw(query, params)
+    const rows = result?.rows ?? []
+
+    let matched = 0
+    let discrepancies = 0
+    let discrepancyAmount = 0
+
+    const items = rows.map((row) => {
+      const orderAmount = Number(row.order_amount ?? 0)
+      const paymentAmount = Number(row.payment_amount ?? 0)
+      const difference = Math.round((orderAmount - paymentAmount) * 100) / 100
+      const discrepancy = Math.abs(difference) > 0.01
+
+      if (discrepancy) {
+        discrepancies += 1
+        discrepancyAmount += Math.abs(difference)
+      } else {
+        matched += 1
+      }
+
+      return {
+        order_id: String(row.order_id),
+        display_id: Number(row.display_id ?? 0),
+        order_amount: orderAmount,
+        payment_amount: paymentAmount,
+        difference,
+        discrepancy,
+        payment_status: String(row.payment_status ?? "unknown"),
+        created_at: row.created_at,
+      }
+    })
+
+    return res.status(200).json({
+      total_orders: rows.length,
+      matched,
+      discrepancies,
+      discrepancy_amount: Math.round(discrepancyAmount * 100) / 100,
+      currency_code: currency_code.toLowerCase(),
+      items,
+      date_from: date_from ?? null,
+      date_to: date_to ?? null,
+    })
+  } catch (err: any) {
+    logger.error(`[finance-reconciliation] Query error: ${err.message}`)
+
+    if (err.message?.includes("does not exist")) {
+      return res.status(200).json({
+        total_orders: 0,
+        matched: 0,
+        discrepancies: 0,
+        discrepancy_amount: 0,
+        currency_code: currency_code.toLowerCase(),
+        items: [],
+        date_from: date_from ?? null,
+        date_to: date_to ?? null,
+        note: "Finance tables not initialized.",
+      })
+    }
+
+    return res.status(500).json({ error: "Failed to query finance reconciliation" })
+  }
+}

--- a/src/api/admin/finance/reports/route.ts
+++ b/src/api/admin/finance/reports/route.ts
@@ -1,0 +1,140 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+type RawResultRow = Record<string, string | number | Date | null>
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: RawResultRow[] }>
+  }
+
+  const { date_from, date_to, granularity = "month", currency } = req.query as Record<
+    string,
+    string
+  >
+
+  try {
+    const validGranularities = ["day", "week", "month"]
+    const gran = validGranularities.includes(granularity) ? granularity : "month"
+
+    const currencies = (currency || "")
+      .split(",")
+      .map((item) => item.trim().toLowerCase())
+      .filter(Boolean)
+
+    const conditions: string[] = ["o.canceled_at IS NULL"]
+    const params: unknown[] = []
+
+    if (currencies.length > 0) {
+      const placeholders = currencies.map(() => "?").join(", ")
+      conditions.push(`o.currency_code IN (${placeholders})`)
+      params.push(...currencies)
+    }
+
+    if (date_from) {
+      conditions.push("o.created_at >= ?::timestamptz")
+      params.push(date_from)
+    }
+
+    if (date_to) {
+      conditions.push("o.created_at < (?::date + interval '1 day')")
+      params.push(date_to)
+    }
+
+    const whereClause = `WHERE ${conditions.join(" AND ")}`
+    const totalExpr = `
+      CASE
+        WHEN o.raw_total IS NOT NULL AND o.raw_total->>'value' IS NOT NULL
+          THEN (o.raw_total->>'value')::numeric
+        ELSE COALESCE(o.total, 0)
+      END
+    `
+    const refundExpr = `
+      CASE
+        WHEN o.raw_refunded_total IS NOT NULL AND o.raw_refunded_total->>'value' IS NOT NULL
+          THEN (o.raw_refunded_total->>'value')::numeric
+        ELSE COALESCE(o.refunded_total, 0)
+      END
+    `
+
+    const query = `
+      SELECT
+        o.currency_code,
+        date_trunc('${gran}', o.created_at) AS period,
+        COALESCE(SUM(${totalExpr}), 0) AS revenue,
+        COALESCE(SUM(${refundExpr}), 0) AS refunds,
+        COALESCE(SUM(${totalExpr}) - SUM(${refundExpr}), 0) AS net,
+        COUNT(*)::int AS order_count
+      FROM "order" o
+      ${whereClause}
+      GROUP BY o.currency_code, period
+      ORDER BY o.currency_code ASC, period ASC
+    `
+
+    const result = await pgConnection.raw(query, params)
+    const rows = result?.rows ?? []
+
+    const byCurrency = new Map<
+      string,
+      {
+        currency_code: string
+        revenue: number
+        refunds: number
+        net_profit: number
+        order_count: number
+        data_points: { period: string; revenue: number; refunds: number; net: number }[]
+      }
+    >()
+
+    for (const row of rows) {
+      const currencyCode = String(row.currency_code || "").toLowerCase()
+      if (!currencyCode) {
+        continue
+      }
+
+      if (!byCurrency.has(currencyCode)) {
+        byCurrency.set(currencyCode, {
+          currency_code: currencyCode,
+          revenue: 0,
+          refunds: 0,
+          net_profit: 0,
+          order_count: 0,
+          data_points: [],
+        })
+      }
+
+      const entry = byCurrency.get(currencyCode)!
+      const revenue = Number(row.revenue ?? 0)
+      const refunds = Number(row.refunds ?? 0)
+      const net = Number(row.net ?? 0)
+      const orderCount = Number(row.order_count ?? 0)
+      const period = new Date(String(row.period)).toISOString().slice(0, 10)
+
+      entry.revenue += revenue
+      entry.refunds += refunds
+      entry.net_profit += net
+      entry.order_count += orderCount
+      entry.data_points.push({ period, revenue, refunds, net })
+    }
+
+    return res.status(200).json({
+      currencies: Array.from(byCurrency.values()),
+      date_from: date_from ?? null,
+      date_to: date_to ?? null,
+    })
+  } catch (err: any) {
+    logger.error(`[finance-reports] Query error: ${err.message}`)
+
+    if (err.message?.includes("does not exist")) {
+      return res.status(200).json({
+        currencies: [],
+        date_from: date_from ?? null,
+        date_to: date_to ?? null,
+        note: "Finance tables not initialized.",
+      })
+    }
+
+    return res.status(500).json({ error: "Failed to query finance reports" })
+  }
+}

--- a/src/api/admin/finance/summary/route.ts
+++ b/src/api/admin/finance/summary/route.ts
@@ -22,13 +22,15 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   const {
     date_from,
     date_to,
-    granularity = "month",
+    granularity,
+    period,
     currency_code = "usd",
   } = req.query as Record<string, string>
 
   try {
     const validGranularities = ["day", "week", "month"]
-    const gran = validGranularities.includes(granularity) ? granularity : "month"
+    const normalizedGranularity = granularity || ({ daily: "day", weekly: "week", monthly: "month" } as Record<string, string>)[period] || period
+    const gran = validGranularities.includes(normalizedGranularity) ? normalizedGranularity : "month"
 
     const conditions: string[] = [
       "o.canceled_at IS NULL",

--- a/src/api/admin/finance/tax-rates/[id]/route.ts
+++ b/src/api/admin/finance/tax-rates/[id]/route.ts
@@ -1,0 +1,107 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+type RawResultRow = Record<string, string | number | Date | null>
+
+export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: RawResultRow[] }>
+  }
+
+  const id = req.params.id
+  const body = (req.body ?? {}) as Record<string, unknown>
+
+  try {
+    try {
+      const taxService = req.scope.resolve("tax") as any
+      if (taxService?.updateTaxRates) {
+        const updated = await taxService.updateTaxRates([
+          {
+            id,
+            ...body,
+          },
+        ])
+
+        return res.status(200).json({ tax_rate: updated?.[0] ?? updated })
+      }
+    } catch {
+      // fallback to SQL below
+    }
+
+    const query = `
+      UPDATE tax_rate
+      SET
+        name = COALESCE(?, name),
+        code = COALESCE(?, code),
+        rate = COALESCE(?, rate),
+        is_default = COALESCE(?, is_default),
+        is_combinable = COALESCE(?, is_combinable),
+        tax_region_id = COALESCE(?, tax_region_id),
+        updated_at = NOW()
+      WHERE id = ?
+      RETURNING *
+    `
+
+    const result = await pgConnection.raw(query, [
+      body.name ?? null,
+      body.code ?? null,
+      body.rate ?? null,
+      body.is_default ?? null,
+      body.is_combinable ?? null,
+      body.tax_region_id ?? null,
+      id,
+    ])
+
+    return res.status(200).json({ tax_rate: result?.rows?.[0] ?? null })
+  } catch (err: any) {
+    logger.error(`[finance-tax-rates] PATCH error: ${err.message}`)
+
+    if (err.message?.includes("does not exist")) {
+      return res.status(200).json({
+        tax_rate: null,
+        note: "Tax tables not initialized.",
+      })
+    }
+
+    return res.status(500).json({ error: "Failed to update tax rate" })
+  }
+}
+
+export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: RawResultRow[] }>
+  }
+
+  const id = req.params.id
+
+  try {
+    try {
+      const taxService = req.scope.resolve("tax") as any
+      if (taxService?.deleteTaxRates) {
+        await taxService.deleteTaxRates([id])
+        return res.status(200).json({ id, deleted: true })
+      }
+    } catch {
+      // fallback to SQL below
+    }
+
+    const query = `DELETE FROM tax_rate WHERE id = ? RETURNING id`
+    const result = await pgConnection.raw(query, [id])
+
+    return res.status(200).json({ id: result?.rows?.[0]?.id ?? id, deleted: true })
+  } catch (err: any) {
+    logger.error(`[finance-tax-rates] DELETE error: ${err.message}`)
+
+    if (err.message?.includes("does not exist")) {
+      return res.status(200).json({
+        id,
+        deleted: false,
+        note: "Tax tables not initialized.",
+      })
+    }
+
+    return res.status(500).json({ error: "Failed to delete tax rate" })
+  }
+}

--- a/src/api/admin/finance/tax-rates/route.ts
+++ b/src/api/admin/finance/tax-rates/route.ts
@@ -1,0 +1,140 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+type RawResultRow = Record<string, string | number | Date | null>
+
+const mapTaxRateRow = (row: RawResultRow) => ({
+  id: String(row.id ?? ""),
+  name: String(row.name ?? ""),
+  code: row.code ? String(row.code) : null,
+  rate: Number(row.rate ?? 0),
+  is_default: Boolean(row.is_default ?? false),
+  is_combinable: Boolean(row.is_combinable ?? false),
+  tax_region_id: row.tax_region_id ? String(row.tax_region_id) : null,
+  tax_region_name: row.tax_region_name ? String(row.tax_region_name) : null,
+  created_at: row.created_at ?? null,
+  updated_at: row.updated_at ?? null,
+})
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: RawResultRow[] }>
+  }
+
+  try {
+    try {
+      const taxService = req.scope.resolve("tax") as any
+      if (taxService?.listTaxRegions) {
+        const regions = await taxService.listTaxRegions({}, { relations: ["rates"] })
+        const rates = (regions || []).flatMap((region: any) =>
+          (region.rates || []).map((rate: any) => ({
+            id: rate.id,
+            name: rate.name,
+            code: rate.code ?? null,
+            rate: Number(rate.rate ?? 0),
+            is_default: Boolean(rate.is_default ?? false),
+            is_combinable: Boolean(rate.is_combinable ?? false),
+            tax_region_id: region.id,
+            tax_region_name: region.name ?? null,
+            created_at: rate.created_at ?? null,
+            updated_at: rate.updated_at ?? null,
+          }))
+        )
+
+        return res.status(200).json({ tax_rates: rates })
+      }
+    } catch {
+      // fallback to SQL below
+    }
+
+    const query = `
+      SELECT
+        tr.id,
+        tr.name,
+        tr.code,
+        tr.rate,
+        tr.is_default,
+        tr.is_combinable,
+        tr.tax_region_id,
+        trg.name AS tax_region_name,
+        tr.created_at,
+        tr.updated_at
+      FROM tax_rate tr
+      LEFT JOIN tax_region trg ON trg.id = tr.tax_region_id
+      ORDER BY tr.created_at DESC
+    `
+
+    const result = await pgConnection.raw(query)
+    return res.status(200).json({ tax_rates: (result?.rows ?? []).map(mapTaxRateRow) })
+  } catch (err: any) {
+    logger.error(`[finance-tax-rates] GET error: ${err.message}`)
+
+    if (err.message?.includes("does not exist")) {
+      return res.status(200).json({
+        tax_rates: [],
+        note: "Tax tables not initialized.",
+      })
+    }
+
+    return res.status(500).json({ error: "Failed to list tax rates" })
+  }
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: RawResultRow[] }>
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+
+  try {
+    try {
+      const taxService = req.scope.resolve("tax") as any
+      if (taxService?.createTaxRates) {
+        const created = await taxService.createTaxRates([
+          {
+            name: body.name,
+            code: body.code,
+            rate: body.rate,
+            is_default: body.is_default,
+            is_combinable: body.is_combinable,
+            tax_region_id: body.tax_region_id,
+          },
+        ])
+
+        return res.status(200).json({ tax_rate: created?.[0] ?? created })
+      }
+    } catch {
+      // fallback to SQL below
+    }
+
+    const query = `
+      INSERT INTO tax_rate (name, code, rate, is_default, is_combinable, tax_region_id)
+      VALUES (?, ?, ?, ?, ?, ?)
+      RETURNING *
+    `
+    const result = await pgConnection.raw(query, [
+      body.name ?? null,
+      body.code ?? null,
+      body.rate ?? 0,
+      body.is_default ?? false,
+      body.is_combinable ?? false,
+      body.tax_region_id ?? null,
+    ])
+
+    return res.status(200).json({ tax_rate: result?.rows?.[0] ?? null })
+  } catch (err: any) {
+    logger.error(`[finance-tax-rates] POST error: ${err.message}`)
+
+    if (err.message?.includes("does not exist")) {
+      return res.status(200).json({
+        tax_rate: null,
+        note: "Tax tables not initialized.",
+      })
+    }
+
+    return res.status(500).json({ error: "Failed to create tax rate" })
+  }
+}

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -54,6 +54,16 @@ export default defineMiddlewares({
       middlewares: [authenticate("user", ["bearer", "session"])],
     },
     {
+      matcher: "/admin/finance/tax-rates",
+      method: ["GET", "POST"],
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/finance/tax-rates/:id",
+      method: ["PATCH", "DELETE"],
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
       matcher: "/admin/finance/*",
       method: "GET",
       middlewares: [authenticate("user", ["bearer", "session"])],

--- a/src/subscribers/finance-event-relay.ts
+++ b/src/subscribers/finance-event-relay.ts
@@ -1,0 +1,53 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+
+export default async function financeEventRelayHandler({
+  event,
+  container,
+}: SubscriberArgs<Record<string, unknown>>) {
+  const webhookUrl = process.env.WEBHOOK_RELAY_URL
+  if (!webhookUrl) {
+    return
+  }
+
+  const logger = container.resolve("logger") as {
+    info: (m: string) => void
+    error: (m: string) => void
+  }
+
+  const eventName = (event as any).name || "unknown"
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-NordHjem-Event": eventName,
+        ...(process.env.WEBHOOK_RELAY_SECRET
+          ? { "X-Webhook-Secret": process.env.WEBHOOK_RELAY_SECRET }
+          : {}),
+      },
+      body: JSON.stringify({
+        event: eventName,
+        data: event.data,
+        metadata: (event as any).metadata ?? null,
+        timestamp: new Date().toISOString(),
+      }),
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) {
+      logger.error(
+        `[finance-event-relay] Failed to relay ${eventName}: HTTP ${response.status}`
+      )
+    } else {
+      logger.info(`[finance-event-relay] Relayed ${eventName} → ${response.status}`)
+    }
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : JSON.stringify(error)
+    logger.error(`[finance-event-relay] Error relaying ${eventName}: ${errMsg}`)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: ["order.placed", "order.refund_created"],
+}


### PR DESCRIPTION
### Motivation
- Provide multi-currency financial reporting, reconciliation between orders and payments, and a managed CRUD surface for tax rates to support accounting and tax workflows.
- Keep amount extraction consistent with existing `finance/summary` logic by preferring `raw_*->>'value'` and falling back to numeric fields, and ensure SQL uses Knex-compatible `?` placeholders.
- Add event relaying for key finance events so external systems (n8n/webhooks) can be notified of `order.placed` and `order.refund_created` events.

### Description
- Added `GET /admin/finance/reports` in `src/api/admin/finance/reports/route.ts` implementing multi-currency aggregation (per-currency `revenue`, `refunds`, `net_profit`, `order_count`) with `date_from/date_to` and `granularity` (day/week/month) support and per-period `data_points` output.
- Added `GET /admin/finance/reconciliation` in `src/api/admin/finance/reconciliation/route.ts` that joins `order`, `order_payment_collection`, `payment_collection`, `payment`, and `payment_session` to compare `order` amounts vs collected payments and flag `discrepancy` when difference > 0.01.
- Implemented tax-rate thin CRUD wrapper using Medusa Tax Module service with SQL fallback in `src/api/admin/finance/tax-rates/route.ts` and `src/api/admin/finance/tax-rates/[id]/route.ts` exposing `GET/POST` and `PATCH/DELETE` respectively.
- Enhanced `GET /admin/finance/summary` in `src/api/admin/finance/summary/route.ts` to accept `period` as an alias (`daily|weekly|monthly`) while preserving existing `granularity` behavior and reusing the same `raw_*` fallback logic.
- Updated middleware rules in `src/api/middlewares.ts` to require admin authentication for `tax-rates` `POST/PATCH/DELETE` (and GET) while keeping existing `GET /admin/finance/*` protection for other finance GET endpoints.
- Added `src/subscribers/finance-event-relay.ts` subscriber which relays `order.placed` and `order.refund_created` events to `process.env.WEBHOOK_RELAY_URL` with `event`, `data`, `metadata`, and `timestamp`, silently skipping if URL is not set.
- Error handling: endpoints return `200` + empty payload with a `note` when caught errors include `does not exist`, and otherwise return `500` on unexpected failures.

### Testing
- Ran `npm run build`, which failed in this environment with `medusa: not found` so a full build could not be validated here (expected in CI with dependencies).
- Ran `npx tsc --noEmit`, which failed due to missing installed project dependencies/types (e.g. `@medusajs/*`) in the current environment; type-checking should pass in CI where dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af36eb9a248333bf07466953be8cda)