### PR TITLE
feat(C-037b): M5 after-sales — ticket system, return status events, customer messaging

### DIFF
--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -22,6 +22,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/restock",
     },
     {
+      resolve: "./src/modules/ticket",
+    },
+    {
       resolve: "@medusajs/medusa/notification",
       options: {
         providers: [

--- a/src/api/admin/tickets/[id]/messages/route.ts
+++ b/src/api/admin/tickets/[id]/messages/route.ts
@@ -1,0 +1,67 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+import { TICKET_MODULE } from "../../../../../modules/ticket"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const ticketService = req.scope.resolve(TICKET_MODULE) as any
+
+  try {
+    await ticketService.retrieveTicket(req.params.id)
+    const messages = await ticketService.listTicketMessages(
+      { ticket_id: req.params.id },
+      { order: { created_at: "ASC" } }
+    )
+
+    return res.status(200).json({ messages })
+  } catch (err: any) {
+    if (err.message?.includes("does not exist")) {
+      return res.status(200).json({ note: "ticket tables not yet created. Run migrations." })
+    }
+
+    if (err.message?.toLowerCase().includes("not found")) {
+      return res.status(404).json({ error: "Ticket not found" })
+    }
+
+    return res.status(500).json({ error: "Failed to list messages" })
+  }
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const ticketService = req.scope.resolve(TICKET_MODULE) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  const { sender_type, sender_id, body, metadata } = req.body as Record<string, any>
+
+  if (!body?.trim()) {
+    return res.status(400).json({ error: "Message body required" })
+  }
+
+  if (!["customer", "admin"].includes(sender_type)) {
+    return res.status(400).json({ error: "Invalid sender_type" })
+  }
+
+  try {
+    await ticketService.retrieveTicket(req.params.id)
+
+    const message = await ticketService.createTicketMessages({
+      ticket_id: req.params.id,
+      sender_type,
+      sender_id: sender_id || null,
+      body,
+      metadata: metadata || null,
+    })
+
+    await eventBus.emit("ticket.message_sent", {
+      id: message.id,
+      ticket_id: req.params.id,
+    })
+
+    return res.status(200).json({ message })
+  } catch (err: any) {
+    if (err.message?.toLowerCase().includes("not found")) {
+      return res.status(404).json({ error: "Ticket not found" })
+    }
+
+    return res.status(500).json({ error: "Failed to send message" })
+  }
+}

--- a/src/api/admin/tickets/[id]/route.ts
+++ b/src/api/admin/tickets/[id]/route.ts
@@ -1,0 +1,88 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+import { TICKET_MODULE } from "../../../../modules/ticket"
+
+const ALLOWED_TRANSITIONS: Record<string, string[]> = {
+  open: ["in_progress", "resolved", "closed"],
+  in_progress: ["resolved", "closed"],
+  resolved: ["closed", "open"],
+  closed: ["open"],
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const ticketService = req.scope.resolve(TICKET_MODULE) as any
+
+  try {
+    const ticket = await ticketService.retrieveTicket(req.params.id)
+    const messages = await ticketService.listTicketMessages(
+      { ticket_id: req.params.id },
+      { order: { created_at: "ASC" } }
+    )
+
+    return res.status(200).json({ ticket, messages })
+  } catch (err: any) {
+    if (err.message?.includes("does not exist")) {
+      return res.status(200).json({ note: "ticket tables not yet created. Run migrations." })
+    }
+
+    if (err.message?.toLowerCase().includes("not found")) {
+      return res.status(404).json({ error: "Ticket not found" })
+    }
+
+    return res.status(500).json({ error: "Failed to retrieve ticket" })
+  }
+}
+
+export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
+  const ticketService = req.scope.resolve(TICKET_MODULE) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  try {
+    const ticket = await ticketService.retrieveTicket(req.params.id)
+    const nextStatus = req.body?.status as string | undefined
+
+    const patch: Record<string, unknown> = {
+      ...(req.body?.priority ? { priority: req.body.priority } : {}),
+      ...(req.body?.subject ? { subject: req.body.subject } : {}),
+      ...(req.body?.description !== undefined ? { description: req.body.description } : {}),
+      ...(req.body?.metadata !== undefined ? { metadata: req.body.metadata } : {}),
+      ...(nextStatus ? { status: nextStatus } : {}),
+    }
+
+    if (nextStatus && nextStatus !== ticket.status) {
+      if (!ALLOWED_TRANSITIONS[ticket.status]?.includes(nextStatus)) {
+        return res.status(400).json({ error: "Invalid status transition" })
+      }
+
+      if (nextStatus === "resolved") {
+        patch.resolved_at = new Date()
+      }
+
+      if (nextStatus === "closed") {
+        patch.closed_at = new Date()
+      }
+
+      if (nextStatus === "open") {
+        patch.closed_at = null
+      }
+    }
+
+    const updated = await ticketService.updateTickets(req.params.id, patch)
+
+    if (nextStatus && nextStatus !== ticket.status) {
+      await eventBus.emit("ticket.status_changed", {
+        id: ticket.id,
+        old_status: ticket.status,
+        new_status: nextStatus,
+      })
+    }
+
+    return res.status(200).json({ ticket: updated })
+  } catch (err: any) {
+    if (err.message?.toLowerCase().includes("not found")) {
+      return res.status(404).json({ error: "Ticket not found" })
+    }
+
+    return res.status(500).json({ error: "Failed to update ticket" })
+  }
+}

--- a/src/api/admin/tickets/route.ts
+++ b/src/api/admin/tickets/route.ts
@@ -1,0 +1,79 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+import { TICKET_MODULE } from "../../../modules/ticket"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const ticketService = req.scope.resolve(TICKET_MODULE) as any
+
+  const { status, type, order_id, limit = "20", offset = "0" } = req.query as Record<string, string>
+
+  try {
+    const filters: Record<string, unknown> = {}
+    if (status) filters.status = status
+    if (type) filters.type = type
+    if (order_id) filters.order_id = order_id
+
+    const safeLimit = Number.parseInt(limit, 10) || 20
+    const safeOffset = Number.parseInt(offset, 10) || 0
+
+    const [tickets, count] = await ticketService.listAndCountTickets(filters, {
+      take: safeLimit,
+      skip: safeOffset,
+      order: { created_at: "DESC" },
+    })
+
+    return res.status(200).json({
+      tickets,
+      count,
+      limit: safeLimit,
+      offset: safeOffset,
+    })
+  } catch (err: any) {
+    if (err.message?.includes("does not exist")) {
+      return res.status(200).json({
+        tickets: [],
+        count: 0,
+        note: "ticket tables not yet created. Run migrations.",
+      })
+    }
+
+    return res.status(500).json({ error: "Failed to list tickets" })
+  }
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const ticketService = req.scope.resolve(TICKET_MODULE) as any
+  const orderService = req.scope.resolve(Modules.ORDER) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  const { order_id, customer_id, type, subject, description, priority, metadata } = req.body as Record<string, any>
+
+  if (!order_id || !type || !subject) {
+    return res.status(400).json({ error: "order_id, type and subject are required" })
+  }
+
+  try {
+    await orderService.retrieveOrder(order_id)
+  } catch {
+    return res.status(400).json({ error: "Order not found" })
+  }
+
+  try {
+    const ticket = await ticketService.createTickets({
+      order_id,
+      customer_id: customer_id || null,
+      type,
+      subject,
+      description: description || null,
+      priority: priority || "medium",
+      metadata: metadata || null,
+      status: "open",
+    })
+
+    await eventBus.emit("ticket.created", { id: ticket.id })
+
+    return res.status(200).json({ ticket })
+  } catch {
+    return res.status(500).json({ error: "Failed to create ticket" })
+  }
+}

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -68,5 +68,20 @@ export default defineMiddlewares({
       method: "GET",
       middlewares: [authenticate("user", ["bearer", "session"])],
     },
+    {
+      matcher: "/admin/tickets",
+      method: ["GET", "POST"],
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/tickets/:id",
+      method: ["GET", "PATCH"],
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/tickets/:id/messages",
+      method: ["GET", "POST"],
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
   ],
 })

--- a/src/modules/ticket/index.ts
+++ b/src/modules/ticket/index.ts
@@ -1,0 +1,6 @@
+import { Module } from "@medusajs/framework/utils"
+import TicketModuleService from "./service"
+
+export const TICKET_MODULE = "ticketModuleService"
+
+export default Module(TICKET_MODULE, { service: TicketModuleService })

--- a/src/modules/ticket/migrations/Migration202603090001.ts
+++ b/src/modules/ticket/migrations/Migration202603090001.ts
@@ -1,0 +1,50 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration202603090001 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "ticket" (
+        "id" text NOT NULL,
+        "order_id" text NOT NULL,
+        "customer_id" text NULL,
+        "type" text CHECK ("type" IN ('return', 'exchange', 'complaint', 'inquiry')) NOT NULL,
+        "status" text CHECK ("status" IN ('open', 'in_progress', 'resolved', 'closed')) NOT NULL DEFAULT 'open',
+        "priority" text CHECK ("priority" IN ('low', 'medium', 'high', 'urgent')) NOT NULL DEFAULT 'medium',
+        "subject" text NOT NULL,
+        "description" text NULL,
+        "metadata" jsonb NULL,
+        "resolved_at" timestamptz NULL,
+        "closed_at" timestamptz NULL,
+        "created_at" timestamptz NOT NULL DEFAULT now(),
+        "updated_at" timestamptz NOT NULL DEFAULT now(),
+        "deleted_at" timestamptz NULL,
+        CONSTRAINT "ticket_pkey" PRIMARY KEY ("id")
+      );
+    `)
+
+    this.addSql(`
+      CREATE TABLE IF NOT EXISTS "ticket_message" (
+        "id" text NOT NULL,
+        "ticket_id" text NOT NULL,
+        "sender_type" text CHECK ("sender_type" IN ('customer', 'admin')) NOT NULL,
+        "sender_id" text NULL,
+        "body" text NOT NULL,
+        "metadata" jsonb NULL,
+        "created_at" timestamptz NOT NULL DEFAULT now(),
+        "updated_at" timestamptz NOT NULL DEFAULT now(),
+        "deleted_at" timestamptz NULL,
+        CONSTRAINT "ticket_message_pkey" PRIMARY KEY ("id")
+      );
+    `)
+
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_ticket_order_id" ON "ticket" ("order_id");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_ticket_status" ON "ticket" ("status");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_ticket_type" ON "ticket" ("type");`)
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_ticket_message_ticket_id" ON "ticket_message" ("ticket_id");`)
+  }
+
+  override async down(): Promise<void> {
+    this.addSql('DROP TABLE IF EXISTS "ticket_message" CASCADE;')
+    this.addSql('DROP TABLE IF EXISTS "ticket" CASCADE;')
+  }
+}

--- a/src/modules/ticket/models/ticket-message.ts
+++ b/src/modules/ticket/models/ticket-message.ts
@@ -1,0 +1,12 @@
+import { model } from "@medusajs/framework/utils"
+
+const TicketMessage = model.define("ticket_message", {
+  id: model.id().primaryKey(),
+  ticket_id: model.text(),
+  sender_type: model.enum(["customer", "admin"]),
+  sender_id: model.text().nullable(),
+  body: model.text(),
+  metadata: model.json().nullable(),
+})
+
+export default TicketMessage

--- a/src/modules/ticket/models/ticket.ts
+++ b/src/modules/ticket/models/ticket.ts
@@ -1,0 +1,19 @@
+import { model } from "@medusajs/framework/utils"
+
+const Ticket = model.define("ticket", {
+  id: model.id().primaryKey(),
+  order_id: model.text(),
+  customer_id: model.text().nullable(),
+  type: model.enum(["return", "exchange", "complaint", "inquiry"]),
+  status: model
+    .enum(["open", "in_progress", "resolved", "closed"])
+    .default("open"),
+  priority: model.enum(["low", "medium", "high", "urgent"]).default("medium"),
+  subject: model.text(),
+  description: model.text().nullable(),
+  metadata: model.json().nullable(),
+  resolved_at: model.dateTime().nullable(),
+  closed_at: model.dateTime().nullable(),
+})
+
+export default Ticket

--- a/src/modules/ticket/service.ts
+++ b/src/modules/ticket/service.ts
@@ -1,0 +1,7 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import Ticket from "./models/ticket"
+import TicketMessage from "./models/ticket-message"
+
+class TicketModuleService extends MedusaService({ Ticket, TicketMessage }) {}
+
+export default TicketModuleService

--- a/src/subscribers/return-status-events.ts
+++ b/src/subscribers/return-status-events.ts
@@ -1,0 +1,93 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+
+const relayWebhook = async (
+  eventName: string,
+  payload: Record<string, unknown>,
+  container: any
+) => {
+  const webhookUrl = process.env.WEBHOOK_RELAY_URL
+  if (!webhookUrl) {
+    return
+  }
+
+  const logger = container.resolve("logger") as {
+    info: (m: string) => void
+    error: (m: string) => void
+  }
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-NordHjem-Event": eventName,
+        ...(process.env.WEBHOOK_RELAY_SECRET
+          ? { "X-Webhook-Secret": process.env.WEBHOOK_RELAY_SECRET }
+          : {}),
+      },
+      body: JSON.stringify({
+        event: eventName,
+        data: payload,
+        timestamp: new Date().toISOString(),
+        source: "nordhjem-medusa",
+      }),
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) {
+      logger.error(`[return-status-events] Failed to relay ${eventName}: HTTP ${response.status}`)
+    } else {
+      logger.info(`[return-status-events] Relayed ${eventName} → ${response.status}`)
+    }
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : JSON.stringify(error)
+    logger.error(`[return-status-events] Error relaying ${eventName}: ${errMsg}`)
+  }
+}
+
+export default async function returnStatusEventsHandler({
+  event,
+  container,
+}: SubscriberArgs<Record<string, any>>) {
+  const name = (event as any).name
+
+  if (name === "return.requested") {
+    await relayWebhook(
+      name,
+      {
+        order_id: event.data.order_id,
+        return_id: event.data.return_id,
+        status: "return_requested",
+      },
+      container
+    )
+  }
+
+  if (name === "return.received") {
+    await relayWebhook(
+      name,
+      {
+        order_id: event.data.order_id,
+        return_id: event.data.return_id,
+        status: "received",
+      },
+      container
+    )
+  }
+
+  if (name === "refund.created") {
+    await relayWebhook(
+      name,
+      {
+        order_id: event.data.order_id,
+        return_id: event.data.return_id,
+        status: "refunded",
+      },
+      container
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: ["return.requested", "return.received", "refund.created"],
+}


### PR DESCRIPTION
### Motivation
- Medusa v2 does not include a built-in ticket/after-sales module, so a custom module and admin APIs are required to manage returns/exchanges/complaints and customer messaging.
- Admin workflows need a simple status machine for tickets with validated transitions and event emissions for downstream integrations.
- Return/refund lifecycle events must be relayed to an external webhook endpoint for integrations (webhook relay).

### Description
- Added a new `ticket` module under `src/modules/ticket` with `Ticket` and `TicketMessage` models, `TicketModuleService`, and a MikroORM migration (`Migration202603090001`) to create tables and indexes.
- Registered the ticket module in `medusa-config.ts` by adding `resolve: "./src/modules/ticket"`.
- Implemented admin APIs for tickets in `src/api/admin/tickets`:
  - `GET /admin/tickets` and `POST /admin/tickets` for listing (filters + pagination) and creating tickets, with order existence validation and `ticket.created` event emission.
  - `GET /admin/tickets/:id` and `PATCH /admin/tickets/:id` for ticket details and updates, enforcing allowed status transitions, auto-setting `resolved_at`/`closed_at`, and emitting `ticket.status_changed` on status changes.
  - `GET /admin/tickets/:id/messages` and `POST /admin/tickets/:id/messages` for message history and posting messages, validating message body and `sender_type`, and emitting `ticket.message_sent`.
- Added admin middleware entries in `src/api/middlewares.ts` to require `authenticate("user", ["bearer","session"])` for the new ticket endpoints.
- Added `src/subscribers/return-status-events.ts` which listens to `return.requested`, `return.received`, and `refund.created` and relays mapped payloads to `process.env.WEBHOOK_RELAY_URL` with appropriate headers and logging.

### Testing
- Ran `npm run build` (invokes `medusa build`) which failed in this environment because the `medusa` CLI binary is not available (`sh: 1: medusa: not found`).
- Ran `npx tsc --noEmit` which failed due to missing/unsatisfied project dependencies and type declarations in the execution environment (errors unrelated to these changes and affecting the whole repo).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af36f73abc8333be32dfa84a5529f1)