### PR TITLE
feat(C-037c): M4 order management — return/exchange requests, batch operations, order export

### DIFF
--- a/src/api/admin/orders/[id]/exchange/route.ts
+++ b/src/api/admin/orders/[id]/exchange/route.ts
@@ -1,0 +1,135 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { randomUUID } from "node:crypto"
+
+type ReturnItemInput = {
+  item_id: string
+  quantity: number
+  reason_id?: string
+}
+
+type SendItemInput = {
+  variant_id: string
+  quantity: number
+}
+
+async function emitEvent(scope: MedusaRequest["scope"], name: string, data: Record<string, unknown>) {
+  try {
+    const eventBus = scope.resolve("event_bus") as { emit: (name: string, data: any) => Promise<void> }
+    await eventBus.emit(name, data)
+  } catch {
+    // noop
+  }
+}
+
+async function tryCreateTicket(scope: MedusaRequest["scope"], payload: Record<string, unknown>) {
+  try {
+    const ticketService = scope.resolve("ticket") as any
+    if (typeof ticketService?.createTickets === "function") {
+      await ticketService.createTickets([payload])
+    } else if (typeof ticketService?.create === "function") {
+      await ticketService.create(payload)
+    }
+  } catch {
+    // optional integration
+  }
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const orderService = req.scope.resolve(Modules.ORDER) as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const orderId = req.params.id
+  const body = (req.body ?? {}) as {
+    return_items?: ReturnItemInput[]
+    send_items?: SendItemInput[]
+    return_shipping_option_id?: string
+    note?: string
+    metadata?: Record<string, unknown>
+  }
+
+  if (!Array.isArray(body.return_items) || body.return_items.length === 0) {
+    return res.status(400).json({ error: "return_items is required" })
+  }
+
+  if (!Array.isArray(body.send_items) || body.send_items.length === 0) {
+    return res.status(400).json({ error: "send_items is required" })
+  }
+
+  let order: any
+  try {
+    order = await orderService.retrieveOrder(orderId, { relations: ["items"] })
+  } catch {
+    return res.status(404).json({ error: "Order not found" })
+  }
+
+  if (!order || order.canceled_at) {
+    return res.status(400).json({ error: "Order is canceled or unavailable" })
+  }
+
+  for (const item of body.return_items) {
+    const orderItem = (order.items || []).find((oi: any) => oi.id === item.item_id)
+    if (!orderItem) {
+      return res.status(400).json({ error: `Order item not found: ${item.item_id}` })
+    }
+
+    if (!Number.isFinite(item.quantity) || item.quantity <= 0 || item.quantity > Number(orderItem.quantity || 0)) {
+      return res.status(400).json({ error: `Invalid return quantity for item ${item.item_id}` })
+    }
+  }
+
+  const variantIds = body.send_items.map((item) => item.variant_id)
+  const variantQuery = await pgConnection.raw(
+    `SELECT id FROM product_variant WHERE id IN (${variantIds.map(() => "?").join(",")})`,
+    variantIds
+  )
+  const foundVariants = new Set((variantQuery?.rows || []).map((row: any) => row.id))
+  for (const sendItem of body.send_items) {
+    if (!foundVariants.has(sendItem.variant_id)) {
+      return res.status(400).json({ error: `Variant not found: ${sendItem.variant_id}` })
+    }
+
+    if (!Number.isFinite(sendItem.quantity) || sendItem.quantity <= 0) {
+      return res.status(400).json({ error: `Invalid send quantity for variant ${sendItem.variant_id}` })
+    }
+  }
+
+  const exchangeId = `exch_${randomUUID().replace(/-/g, "")}`
+  await pgConnection.raw(
+    `INSERT INTO order_exchange (id, order_id, status, shipping_option_id, note, metadata, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?::jsonb, NOW(), NOW())`,
+    [
+      exchangeId,
+      orderId,
+      "requested",
+      body.return_shipping_option_id || null,
+      body.note || null,
+      body.metadata ? JSON.stringify(body.metadata) : null,
+    ]
+  )
+
+  await emitEvent(req.scope, "order.exchange_created", {
+    order_id: orderId,
+    exchange_id: exchangeId,
+    return_items: body.return_items,
+    send_items: body.send_items,
+  })
+
+  await tryCreateTicket(req.scope, {
+    type: "exchange",
+    order_id: orderId,
+    reference_id: exchangeId,
+    note: body.note || null,
+    metadata: body.metadata || {},
+  })
+
+  return res.status(200).json({
+    exchange: {
+      id: exchangeId,
+      order_id: orderId,
+      status: "requested",
+      return_items: body.return_items,
+      send_items: body.send_items,
+    },
+  })
+}

--- a/src/api/admin/orders/[id]/return-request/route.ts
+++ b/src/api/admin/orders/[id]/return-request/route.ts
@@ -1,0 +1,143 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { randomUUID } from "node:crypto"
+
+type ReturnItemInput = {
+  item_id: string
+  quantity: number
+  reason_id?: string
+  note?: string
+}
+
+async function emitEvent(scope: MedusaRequest["scope"], name: string, data: Record<string, unknown>) {
+  try {
+    const eventBus = scope.resolve("event_bus") as { emit: (name: string, data: any) => Promise<void> }
+    await eventBus.emit(name, data)
+  } catch {
+    // ignore event bus failures for API response
+  }
+}
+
+async function tryCreateTicket(
+  scope: MedusaRequest["scope"],
+  payload: Record<string, unknown>
+) {
+  try {
+    const ticketService = scope.resolve("ticket") as {
+      createTickets?: (data: Record<string, unknown>[]) => Promise<unknown>
+      create?: (data: Record<string, unknown>) => Promise<unknown>
+    }
+
+    if (typeof ticketService.createTickets === "function") {
+      await ticketService.createTickets([payload])
+      return
+    }
+
+    if (typeof ticketService.create === "function") {
+      await ticketService.create(payload)
+    }
+  } catch {
+    // optional integration: skip when ticket module is unavailable
+  }
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const orderService = req.scope.resolve(Modules.ORDER) as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: any[]) => Promise<{ rows?: any[] }>
+  }
+
+  const orderId = req.params.id
+  const body = (req.body ?? {}) as {
+    items?: ReturnItemInput[]
+    return_shipping_option_id?: string
+    note?: string
+    metadata?: Record<string, unknown>
+  }
+
+  if (!Array.isArray(body.items) || body.items.length === 0) {
+    return res.status(400).json({ error: "items is required" })
+  }
+
+  let order: any
+  try {
+    order = await orderService.retrieveOrder(orderId, { relations: ["items"] })
+  } catch {
+    return res.status(404).json({ error: "Order not found" })
+  }
+
+  if (!order || order.canceled_at) {
+    return res.status(400).json({ error: "Order is canceled or unavailable" })
+  }
+
+  const orderItems = order.items || []
+  let returnRow: { rows?: any[] } = { rows: [] }
+  try {
+    returnRow = await pgConnection.raw(
+      `SELECT item_id, COALESCE(SUM(quantity), 0) AS returned_qty FROM return_item WHERE item_id IN (${body.items
+        .map(() => "?")
+        .join(",")}) GROUP BY item_id`,
+      body.items.map((i) => i.item_id)
+    )
+  } catch {
+    // allow environments where return_item table is unavailable
+  }
+
+  const returnedMap = new Map<string, number>()
+  for (const row of returnRow?.rows || []) {
+    returnedMap.set(row.item_id, Number(row.returned_qty || 0))
+  }
+
+  for (const item of body.items) {
+    if (!item.item_id || !Number.isFinite(item.quantity) || item.quantity <= 0) {
+      return res.status(400).json({ error: "Invalid return items payload" })
+    }
+
+    const orderItem = orderItems.find((oi: any) => oi.id === item.item_id)
+    if (!orderItem) {
+      return res.status(400).json({ error: `Order item not found: ${item.item_id}` })
+    }
+
+    const alreadyReturned = returnedMap.get(item.item_id) || 0
+    const availableToReturn = Number(orderItem.quantity || 0) - alreadyReturned
+    if (item.quantity > availableToReturn) {
+      return res.status(400).json({ error: `Return quantity exceeds available for item ${item.item_id}` })
+    }
+  }
+
+  const returnId = `ret_${randomUUID().replace(/-/g, "")}`
+  const metadata = body.metadata ? JSON.stringify(body.metadata) : null
+
+  await pgConnection.raw(
+    `INSERT INTO "return" (id, order_id, status, no_notification, shipping_option_id, metadata, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?::jsonb, NOW(), NOW())`,
+    [returnId, orderId, "requested", false, body.return_shipping_option_id || null, metadata]
+  )
+
+  for (const item of body.items) {
+    await pgConnection.raw(
+      `INSERT INTO return_item (id, return_id, item_id, quantity, reason_id, note, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())`,
+      [`ri_${randomUUID().replace(/-/g, "")}`, returnId, item.item_id, item.quantity, item.reason_id || null, item.note || null]
+    )
+  }
+
+  await emitEvent(req.scope, "order.return_requested", {
+    order_id: orderId,
+    return_id: returnId,
+    note: body.note || null,
+    metadata: body.metadata || {},
+  })
+
+  await tryCreateTicket(req.scope, {
+    type: "return",
+    order_id: orderId,
+    reference_id: returnId,
+    note: body.note || null,
+    metadata: body.metadata || {},
+  })
+
+  const created = await pgConnection.raw(`SELECT * FROM "return" WHERE id = ? LIMIT 1`, [returnId])
+
+  return res.status(200).json({ return: created?.rows?.[0] || { id: returnId, order_id: orderId } })
+}

--- a/src/api/admin/orders/batch/route.ts
+++ b/src/api/admin/orders/batch/route.ts
@@ -1,0 +1,109 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { randomUUID } from "node:crypto"
+
+type BatchAction = "update_status" | "create_fulfillment" | "export"
+
+async function emitEvent(scope: MedusaRequest["scope"], name: string, data: Record<string, unknown>) {
+  try {
+    const eventBus = scope.resolve("event_bus") as { emit: (name: string, data: any) => Promise<void> }
+    await eventBus.emit(name, data)
+  } catch {
+    // optional
+  }
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const orderService = req.scope.resolve(Modules.ORDER) as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const body = (req.body ?? {}) as {
+    action?: BatchAction
+    order_ids?: string[]
+    data?: {
+      status?: string
+      fulfillment_data?: Record<string, unknown>
+    }
+  }
+
+  if (!Array.isArray(body.order_ids) || body.order_ids.length === 0) {
+    return res.status(400).json({ error: "order_ids cannot be empty" })
+  }
+
+  if (body.order_ids.length > 100) {
+    return res.status(400).json({ error: "Max 100 orders per batch" })
+  }
+
+  if (!body.action) {
+    return res.status(400).json({ error: "action is required" })
+  }
+
+  if (body.action === "export") {
+    const jobId = `job_${randomUUID().replace(/-/g, "")}`
+    return res.status(200).json({
+      processed: body.order_ids.length,
+      succeeded: body.order_ids.length,
+      failed: 0,
+      job_id: jobId,
+      note: "Use /admin/orders/export for CSV output",
+      results: body.order_ids.map((order_id) => ({ order_id, success: true })),
+    })
+  }
+
+  const results: Array<{ order_id: string; success: boolean; error?: string }> = []
+
+  for (const orderId of body.order_ids) {
+    try {
+      const order = await orderService.retrieveOrder(orderId, { relations: ["fulfillments"] })
+
+      if (!order || order.canceled_at) {
+        throw new Error("Order is canceled")
+      }
+
+      if (body.action === "update_status") {
+        if (!body.data?.status) {
+          throw new Error("data.status is required")
+        }
+
+        await pgConnection.raw(`UPDATE "order" SET status = ?, updated_at = NOW() WHERE id = ?`, [
+          body.data.status,
+          orderId,
+        ])
+
+        await emitEvent(req.scope, "order.status_updated", {
+          order_id: orderId,
+          status: body.data.status,
+        })
+      }
+
+      if (body.action === "create_fulfillment") {
+        if (typeof orderService.createFulfillment === "function") {
+          await orderService.createFulfillment({
+            order_id: orderId,
+            ...body.data?.fulfillment_data,
+          })
+        } else {
+          throw new Error("Fulfillment API unavailable")
+        }
+
+        await emitEvent(req.scope, "order.fulfillment_created", {
+          order_id: orderId,
+          fulfillment_data: body.data?.fulfillment_data || {},
+        })
+      }
+
+      results.push({ order_id: orderId, success: true })
+    } catch (err: any) {
+      results.push({ order_id: orderId, success: false, error: err.message || "Unknown error" })
+    }
+  }
+
+  const succeeded = results.filter((r) => r.success).length
+
+  return res.status(200).json({
+    processed: results.length,
+    succeeded,
+    failed: results.length - succeeded,
+    results,
+  })
+}

--- a/src/api/admin/orders/export/route.ts
+++ b/src/api/admin/orders/export/route.ts
@@ -1,0 +1,143 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+const CSV_HEADERS = [
+  "order_id",
+  "display_id",
+  "date",
+  "customer_email",
+  "items",
+  "subtotal",
+  "shipping",
+  "tax",
+  "discount",
+  "total",
+  "payment_status",
+  "fulfillment_status",
+  "refund_amount",
+  "currency_code",
+]
+
+function escCsv(val: unknown): string {
+  if (val === null || val === undefined) return ""
+  const str = String(val)
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return '"' + str.replace(/"/g, '""') + '"'
+  }
+  return str
+}
+
+function amount(raw: unknown, plain: unknown): number {
+  if (raw && typeof raw === "object" && "value" in (raw as Record<string, unknown>)) {
+    return Number((raw as { value: unknown }).value || 0)
+  }
+  return Number(plain || 0)
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: any[]) => Promise<{ rows?: any[] }>
+  }
+
+  const {
+    format = "csv",
+    date_from,
+    date_to,
+    status,
+    currency_code = "usd",
+  } = req.query as Record<string, string>
+
+  if (format.toLowerCase() === "xlsx") {
+    return res.status(400).json({ note: "XLSX export requires xlsx dependency, use CSV" })
+  }
+
+  if (format.toLowerCase() !== "csv") {
+    return res.status(400).json({ error: "format must be csv or xlsx" })
+  }
+
+  const conditions = ["o.currency_code = ?"]
+  const params: any[] = [currency_code.toLowerCase()]
+
+  if (date_from) {
+    conditions.push("o.created_at >= ?::timestamptz")
+    params.push(date_from)
+  }
+
+  if (date_to) {
+    conditions.push("o.created_at < (?::date + interval '1 day')")
+    params.push(date_to)
+  }
+
+  if (status) {
+    conditions.push("o.status = ?")
+    params.push(status)
+  }
+
+  const query = `
+    SELECT
+      o.id AS order_id,
+      o.display_id,
+      o.created_at AS date,
+      o.email AS customer_email,
+      o.raw_subtotal,
+      o.subtotal,
+      o.raw_shipping_total,
+      o.shipping_total,
+      o.raw_tax_total,
+      o.tax_total,
+      o.raw_discount_total,
+      o.discount_total,
+      o.raw_total,
+      o.total,
+      o.raw_refunded_total,
+      o.refunded_total,
+      o.payment_status,
+      o.fulfillment_status,
+      o.currency_code,
+      (
+        SELECT STRING_AGG(CONCAT(li.title, ' (x', li.quantity, ')'), '; ')
+        FROM order_line_item li
+        WHERE li.order_id = o.id
+      ) AS items
+    FROM "order" o
+    WHERE ${conditions.join(" AND ")}
+    ORDER BY o.created_at DESC
+  `
+
+  let rows: any[] = []
+  try {
+    const result = await pgConnection.raw(query, params)
+    rows = result?.rows || []
+  } catch (err: any) {
+    if (!err.message?.includes("does not exist")) {
+      return res.status(500).json({ error: "Failed to export orders" })
+    }
+  }
+
+  const lines = [CSV_HEADERS.join(",")]
+  for (const row of rows) {
+    lines.push(
+      [
+        escCsv(row.order_id),
+        escCsv(row.display_id),
+        escCsv(row.date ? new Date(row.date).toISOString() : ""),
+        escCsv(row.customer_email),
+        escCsv(row.items || ""),
+        escCsv(amount(row.raw_subtotal, row.subtotal)),
+        escCsv(amount(row.raw_shipping_total, row.shipping_total)),
+        escCsv(amount(row.raw_tax_total, row.tax_total)),
+        escCsv(amount(row.raw_discount_total, row.discount_total)),
+        escCsv(amount(row.raw_total, row.total)),
+        escCsv(row.payment_status),
+        escCsv(row.fulfillment_status),
+        escCsv(amount(row.raw_refunded_total, row.refunded_total)),
+        escCsv(row.currency_code),
+      ].join(",")
+    )
+  }
+
+  const today = new Date().toISOString().split("T")[0]
+  res.setHeader("Content-Type", "text/csv; charset=utf-8")
+  res.setHeader("Content-Disposition", `attachment; filename="nordhjem-orders-export-${today}.csv"`)
+  return res.status(200).send(lines.join("\n") + "\n")
+}

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -64,6 +64,26 @@ export default defineMiddlewares({
       middlewares: [authenticate("user", ["bearer", "session"])],
     },
     {
+      matcher: "/admin/orders/:id/return-request",
+      method: "POST",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/orders/:id/exchange",
+      method: "POST",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/orders/batch",
+      method: "POST",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/orders/export",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
       matcher: "/admin/finance/*",
       method: "GET",
       middlewares: [authenticate("user", ["bearer", "session"])],

--- a/src/subscribers/order-webhook-relay.ts
+++ b/src/subscribers/order-webhook-relay.ts
@@ -57,6 +57,9 @@ export const config: SubscriberConfig = {
     "order.claim_created",
     "order.exchange_created",
     "order.return_requested",
+    "order.status_updated",
     "order.refund_created",
+    "ticket.created",
+    "ticket.status_changed",
   ],
 }


### PR DESCRIPTION
### Motivation
- Add admin endpoints to support returns, exchanges, bulk order operations and enhanced order export for the order management workflow (M4), with fallback behavior when optional modules are not available. 
- Use direct DB writes via `pgConnection.raw()` where the native Medusa flow is not relied on, and ensure PostgreSQL-style placeholders like `?` are used for all raw SQL.

### Description
- Added new admin routes: `POST /admin/orders/:id/return-request`, `POST /admin/orders/:id/exchange`, `POST /admin/orders/batch`, and `GET /admin/orders/export` implemented at `src/api/admin/orders/.../route.ts` files, with validation and DB persistence using `pgConnection.raw()` and `?` placeholders. 
- Implemented return/exchange flows: validate order existence and cancellation state, validate item/variant presence and quantities, insert rows into `"return"`, `return_item`, and `order_exchange` tables, emit events (`order.return_requested`, `order.exchange_created`) and attempt optional ticket creation (silently skip if ticket module unavailable). 
- Implemented batch actions (`update_status`, `create_fulfillment`, `export`) with per-order success/failure reporting and event emission (`order.status_updated`, `order.fulfillment_created`), and `export` returns a `job_id` placeholder advising use of the CSV export endpoint. 
- Added enhanced CSV export with filters `format|date_from|date_to|status|currency_code`, CSV column set matching spec, `xlsx` requests return `400` with guidance, and proper `Content-Disposition` header; export uses `pgConnection.raw()` queries. 
- Updated `src/api/middlewares.ts` to protect the new admin routes with `authenticate("user", ["bearer", "session"])`, and extended `src/subscribers/order-webhook-relay.ts` event list to include `order.status_updated`, `ticket.created`, and `ticket.status_changed`.

### Testing
- Attempted to build with `npm run build` which failed in the current environment because the `medusa` CLI binary is not available (`medusa: not found`).
- Ran TypeScript check with `npx tsc --noEmit` which failed due to missing installed dependencies and type packages in the execution environment (module/type resolution errors), so full type-check/build could not complete here.
- Basic smoke verification: created and linted route files in the repository layout and ran a local `git` status to confirm file changes were persisted; runtime integration and automated tests should be executed in CI or a dev environment with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af37096f3483339eeca34020ed969b)