### PR TITLE
fix: resolve Q-037 TypeScript typing issues in admin routes

### DIFF
--- a/src/api/admin/orders/[id]/exchange/route.ts
+++ b/src/api/admin/orders/[id]/exchange/route.ts
@@ -15,7 +15,7 @@ type SendItemInput = {
 
 async function emitEvent(scope: MedusaRequest["scope"], name: string, data: Record<string, unknown>) {
   try {
-    const eventBus = scope.resolve("event_bus") as { emit: (name: string, data: any) => Promise<void> }
+    const eventBus = scope.resolve("event_bus") as any
     await eventBus.emit(name, data)
   } catch {
     // noop

--- a/src/api/admin/orders/[id]/return-request/route.ts
+++ b/src/api/admin/orders/[id]/return-request/route.ts
@@ -11,7 +11,7 @@ type ReturnItemInput = {
 
 async function emitEvent(scope: MedusaRequest["scope"], name: string, data: Record<string, unknown>) {
   try {
-    const eventBus = scope.resolve("event_bus") as { emit: (name: string, data: any) => Promise<void> }
+    const eventBus = scope.resolve("event_bus") as any
     await eventBus.emit(name, data)
   } catch {
     // ignore event bus failures for API response

--- a/src/api/admin/orders/batch/route.ts
+++ b/src/api/admin/orders/batch/route.ts
@@ -6,7 +6,7 @@ type BatchAction = "update_status" | "create_fulfillment" | "export"
 
 async function emitEvent(scope: MedusaRequest["scope"], name: string, data: Record<string, unknown>) {
   try {
-    const eventBus = scope.resolve("event_bus") as { emit: (name: string, data: any) => Promise<void> }
+    const eventBus = scope.resolve("event_bus") as any
     await eventBus.emit(name, data)
   } catch {
     // optional

--- a/src/api/admin/tickets/[id]/route.ts
+++ b/src/api/admin/tickets/[id]/route.ts
@@ -39,13 +39,14 @@ export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
 
   try {
     const ticket = await ticketService.retrieveTicket(req.params.id)
-    const nextStatus = req.body?.status as string | undefined
+    const body = req.body as any
+    const nextStatus = body?.status as string | undefined
 
     const patch: Record<string, unknown> = {
-      ...(req.body?.priority ? { priority: req.body.priority } : {}),
-      ...(req.body?.subject ? { subject: req.body.subject } : {}),
-      ...(req.body?.description !== undefined ? { description: req.body.description } : {}),
-      ...(req.body?.metadata !== undefined ? { metadata: req.body.metadata } : {}),
+      ...(body?.priority ? { priority: body.priority } : {}),
+      ...(body?.subject ? { subject: body.subject } : {}),
+      ...(body?.description !== undefined ? { description: body.description } : {}),
+      ...(body?.metadata !== undefined ? { metadata: body.metadata } : {}),
       ...(nextStatus ? { status: nextStatus } : {}),
     }
 


### PR DESCRIPTION
### Motivation
- Fix TypeScript compile errors related to strict inline casts and optional `req.body` accesses in several admin API route handlers. 
- Avoid spreading tighter function/type signatures that cause type-check failures without changing runtime behavior.

### Description
- In `src/api/admin/tickets/[id]/route.ts` PATCH handler cast `req.body` once with `const body = req.body as any` and replace five `req.body?.*` occurrences (`status`, `priority`, `subject`, `description`, `metadata`) with `body?.*` to stabilize typing.
- In `src/api/admin/orders/[id]/exchange/route.ts`, `src/api/admin/orders/[id]/return-request/route.ts`, and `src/api/admin/orders/batch/route.ts` relax the `event_bus` resolution typing from `as { emit: (name: string, data: any) => Promise<void> }` to `as any` to avoid strict emit signature issues.
- No business logic changes were introduced; only type assertions/usage were adjusted.

### Testing
- Ran `npx tsc --noEmit`; the command failed in this environment due to missing project dependencies/type declarations (e.g. `@medusajs/*`, Node typings), so a full project type-check could not be validated here.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af3e90cef08333affc1967b64fa90f)