### PR TITLE
feat(admin/analytics): add reports, events, funnel and CSV export endpoints

### DIFF
--- a/src/api/admin/analytics/events/route.ts
+++ b/src/api/admin/analytics/events/route.ts
@@ -1,0 +1,117 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+const ensureTableSql = `
+  CREATE TABLE IF NOT EXISTS analytics_event (
+    id BIGSERIAL PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    event_name TEXT NOT NULL,
+    properties JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )
+`
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(
+    ContainerRegistrationKeys.PG_CONNECTION
+  ) as any
+  const logger = req.scope.resolve("logger") as any
+  const body = req.body as any
+
+  const sessionId = body?.session_id
+  const eventName = body?.event_name
+  const properties = body?.properties ?? {}
+
+  if (!sessionId || !eventName) {
+    return res.status(400).json({
+      error: "session_id and event_name are required",
+    })
+  }
+
+  try {
+    await pgConnection.raw(ensureTableSql)
+    await pgConnection.raw(
+      `
+        INSERT INTO analytics_event (session_id, event_name, properties)
+        VALUES (?, ?, ?::jsonb)
+      `,
+      [sessionId, eventName, JSON.stringify(properties)]
+    )
+
+    return res.status(200).json({ ok: true })
+  } catch (err: any) {
+    logger.error(`[analytics-events:POST] ${err.message}`)
+    return res.status(500).json({ error: "Failed to record analytics event" })
+  }
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(
+    ContainerRegistrationKeys.PG_CONNECTION
+  ) as any
+  const logger = req.scope.resolve("logger") as any
+  const { date_from, date_to, session_id } = req.query as Record<string, string>
+
+  try {
+    await pgConnection.raw(ensureTableSql)
+
+    const conditions: string[] = []
+    const params: any[] = []
+
+    if (date_from) {
+      conditions.push("created_at >= ?::timestamptz")
+      params.push(date_from)
+    }
+
+    if (date_to) {
+      conditions.push("created_at < (?::date + interval '1 day')")
+      params.push(date_to)
+    }
+
+    if (session_id) {
+      conditions.push("session_id = ?")
+      params.push(session_id)
+    }
+
+    const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""
+
+    const summaryResult = await pgConnection.raw(
+      `
+      SELECT
+        COUNT(*)::int AS total_events,
+        COUNT(DISTINCT session_id)::int AS unique_sessions
+      FROM analytics_event
+      ${whereClause}
+      `,
+      params
+    )
+
+    const breakdownResult = await pgConnection.raw(
+      `
+      SELECT
+        event_name,
+        COUNT(*)::int AS count
+      FROM analytics_event
+      ${whereClause}
+      GROUP BY event_name
+      ORDER BY count DESC, event_name ASC
+      `,
+      params
+    )
+
+    return res.status(200).json({
+      total_events: parseInt(summaryResult?.rows?.[0]?.total_events || "0", 10),
+      unique_sessions: parseInt(
+        summaryResult?.rows?.[0]?.unique_sessions || "0",
+        10
+      ),
+      breakdown: breakdownResult?.rows || [],
+      date_from: date_from || null,
+      date_to: date_to || null,
+      session_id: session_id || null,
+    })
+  } catch (err: any) {
+    logger.error(`[analytics-events:GET] ${err.message}`)
+    return res.status(500).json({ error: "Failed to query analytics events" })
+  }
+}

--- a/src/api/admin/analytics/export/route.ts
+++ b/src/api/admin/analytics/export/route.ts
@@ -1,0 +1,84 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+const ensureTableSql = `
+  CREATE TABLE IF NOT EXISTS analytics_event (
+    id BIGSERIAL PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    event_name TEXT NOT NULL,
+    properties JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )
+`
+
+const escapeCsv = (value: unknown): string => {
+  const raw = value == null ? "" : String(value)
+  const escaped = raw.replace(/"/g, '""')
+  return `"${escaped}"`
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(
+    ContainerRegistrationKeys.PG_CONNECTION
+  ) as any
+  const logger = req.scope.resolve("logger") as any
+  const { date_from, date_to, event_name } = req.query as Record<string, string>
+
+  try {
+    await pgConnection.raw(ensureTableSql)
+
+    const conditions: string[] = []
+    const params: any[] = []
+
+    if (date_from) {
+      conditions.push("created_at >= ?::timestamptz")
+      params.push(date_from)
+    }
+
+    if (date_to) {
+      conditions.push("created_at < (?::date + interval '1 day')")
+      params.push(date_to)
+    }
+
+    if (event_name) {
+      conditions.push("event_name = ?")
+      params.push(event_name)
+    }
+
+    const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""
+
+    const result = await pgConnection.raw(
+      `
+      SELECT
+        id,
+        session_id,
+        event_name,
+        properties,
+        created_at
+      FROM analytics_event
+      ${whereClause}
+      ORDER BY created_at DESC
+      `,
+      params
+    )
+
+    const headers = ["id", "session_id", "event_name", "properties", "created_at"]
+    const rows = (result?.rows || []).map((row: any) => [
+      row.id,
+      row.session_id,
+      row.event_name,
+      JSON.stringify(row.properties || {}),
+      row.created_at,
+    ])
+
+    const csv = [headers.map(escapeCsv).join(","), ...rows.map((r: any[]) => r.map(escapeCsv).join(","))].join("\n")
+
+    res.setHeader("Content-Type", "text/csv; charset=utf-8")
+    res.setHeader("Content-Disposition", 'attachment; filename="analytics-events.csv"')
+
+    return res.status(200).send(csv)
+  } catch (err: any) {
+    logger.error(`[analytics-export] ${err.message}`)
+    return res.status(500).json({ error: "Failed to export analytics CSV" })
+  }
+}

--- a/src/api/admin/analytics/funnel/route.ts
+++ b/src/api/admin/analytics/funnel/route.ts
@@ -1,0 +1,122 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+const ensureTableSql = `
+  CREATE TABLE IF NOT EXISTS analytics_event (
+    id BIGSERIAL PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    event_name TEXT NOT NULL,
+    properties JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )
+`
+
+const defaultSteps = ["page_view", "add_to_cart", "checkout_started", "purchase"]
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(
+    ContainerRegistrationKeys.PG_CONNECTION
+  ) as any
+  const logger = req.scope.resolve("logger") as any
+  const { date_from, date_to, steps } = req.query as Record<string, string>
+
+  const funnelSteps = (steps || defaultSteps.join(","))
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  if (funnelSteps.length < 2) {
+    return res.status(400).json({ error: "At least 2 funnel steps are required" })
+  }
+
+  try {
+    await pgConnection.raw(ensureTableSql)
+
+    const timeConditions: string[] = []
+    const params: any[] = [funnelSteps]
+
+    if (date_from) {
+      timeConditions.push("created_at >= ?::timestamptz")
+      params.push(date_from)
+    }
+
+    if (date_to) {
+      timeConditions.push("created_at < (?::date + interval '1 day')")
+      params.push(date_to)
+    }
+
+    const timeWhere = timeConditions.length
+      ? `AND ${timeConditions.join(" AND ")}`
+      : ""
+
+    const result = await pgConnection.raw(
+      `
+      WITH step_events AS (
+        SELECT
+          session_id,
+          event_name,
+          MIN(created_at) AS first_seen
+        FROM analytics_event
+        WHERE event_name = ANY(?::text[])
+          ${timeWhere}
+        GROUP BY session_id, event_name
+      ),
+      ordered AS (
+        SELECT
+          session_id,
+          ARRAY_AGG(event_name ORDER BY first_seen) AS reached_steps
+        FROM step_events
+        GROUP BY session_id
+      )
+      SELECT reached_steps FROM ordered
+      `,
+      params
+    )
+
+    const sessions: string[][] = (result?.rows || []).map(
+      (row: any) => row.reached_steps || []
+    )
+
+    const counts = funnelSteps.map((step, index) => {
+      const reached = sessions.filter((seq) => {
+        let lastPos = -1
+
+        for (let i = 0; i <= index; i++) {
+          const pos = seq.indexOf(funnelSteps[i])
+          if (pos === -1 || pos < lastPos) {
+            return false
+          }
+          lastPos = pos
+        }
+
+        return true
+      }).length
+
+      return { step, reached }
+    })
+
+    const firstStepCount = counts[0].reached
+    const stepsWithRates = counts.map((item, index) => {
+      const prev = index === 0 ? item.reached : counts[index - 1].reached
+      const conversionRate = prev > 0 ? Math.round((item.reached / prev) * 10000) / 100 : 0
+      const dropOffRate = prev > 0 ? Math.round(((prev - item.reached) / prev) * 10000) / 100 : 0
+
+      return {
+        step: item.step,
+        sessions: item.reached,
+        conversion_rate: conversionRate,
+        drop_off_rate: dropOffRate,
+      }
+    })
+
+    return res.status(200).json({
+      total_sessions: firstStepCount,
+      steps: stepsWithRates,
+      date_from: date_from || null,
+      date_to: date_to || null,
+    })
+  } catch (err: any) {
+    logger.error(`[analytics-funnel] ${err.message}`)
+    return res.status(500).json({ error: "Failed to query funnel analytics" })
+  }
+}

--- a/src/api/admin/analytics/reports/route.ts
+++ b/src/api/admin/analytics/reports/route.ts
@@ -1,0 +1,101 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+const ensureTableSql = `
+  CREATE TABLE IF NOT EXISTS analytics_event (
+    id BIGSERIAL PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    event_name TEXT NOT NULL,
+    properties JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )
+`
+
+const DIMENSION_WHITELIST: Record<string, string> = {
+  event_name: "event_name",
+  session_id: "session_id",
+  event_date: "DATE(created_at)",
+  event_hour: "DATE_TRUNC('hour', created_at)",
+}
+
+const METRIC_WHITELIST: Record<string, string> = {
+  event_count: "COUNT(*)::int",
+  unique_sessions: "COUNT(DISTINCT session_id)::int",
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(
+    ContainerRegistrationKeys.PG_CONNECTION
+  ) as any
+  const logger = req.scope.resolve("logger") as any
+  const body = req.body as any
+
+  const dimensionsInput = Array.isArray(body?.dimensions) ? body.dimensions : []
+  const metricsInput = Array.isArray(body?.metrics) ? body.metrics : ["event_count"]
+
+  const dimensions = dimensionsInput.filter((d: string) => DIMENSION_WHITELIST[d])
+  const metrics = metricsInput.filter((m: string) => METRIC_WHITELIST[m])
+
+  if (metrics.length === 0) {
+    return res.status(400).json({ error: "At least one valid metric is required" })
+  }
+
+  try {
+    await pgConnection.raw(ensureTableSql)
+
+    const selectParts: string[] = []
+    const groupByParts: string[] = []
+
+    dimensions.forEach((dimension) => {
+      selectParts.push(`${DIMENSION_WHITELIST[dimension]} AS ${dimension}`)
+      groupByParts.push(DIMENSION_WHITELIST[dimension])
+    })
+
+    metrics.forEach((metric) => {
+      selectParts.push(`${METRIC_WHITELIST[metric]} AS ${metric}`)
+    })
+
+    const conditions: string[] = []
+    const params: any[] = []
+
+    if (body?.date_from) {
+      conditions.push("created_at >= ?::timestamptz")
+      params.push(body.date_from)
+    }
+
+    if (body?.date_to) {
+      conditions.push("created_at < (?::date + interval '1 day')")
+      params.push(body.date_to)
+    }
+
+    if (body?.event_name) {
+      conditions.push("event_name = ?")
+      params.push(body.event_name)
+    }
+
+    const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""
+    const groupByClause = groupByParts.length
+      ? `GROUP BY ${groupByParts.join(", ")}`
+      : ""
+    const orderByClause = dimensions.length ? `ORDER BY ${dimensions.join(", ")}` : ""
+
+    const query = `
+      SELECT ${selectParts.join(", ")}
+      FROM analytics_event
+      ${whereClause}
+      ${groupByClause}
+      ${orderByClause}
+    `
+
+    const result = await pgConnection.raw(query, params)
+
+    return res.status(200).json({
+      dimensions,
+      metrics,
+      rows: result?.rows || [],
+    })
+  } catch (err: any) {
+    logger.error(`[analytics-reports] ${err.message}`)
+    return res.status(500).json({ error: "Failed to generate analytics report" })
+  }
+}

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -54,6 +54,26 @@ export default defineMiddlewares({
       middlewares: [authenticate("user", ["bearer", "session"])],
     },
     {
+      matcher: "/admin/analytics/reports",
+      method: "POST",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/analytics/events",
+      method: ["GET", "POST"],
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/analytics/funnel",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/analytics/export",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
       matcher: "/admin/finance/tax-rates",
       method: ["GET", "POST"],
       middlewares: [authenticate("user", ["bearer", "session"])],


### PR DESCRIPTION
### Motivation
- Provide a simple analytics subsystem to record behavioral events, run ad-hoc reports, compute conversion funnels and export event data as CSV for admin use. 
- Ensure endpoints are protected by admin auth and can operate without requiring prior DB migration by creating the `analytics_event` table on demand.

### Description
- Add `POST /admin/analytics/reports` in `src/api/admin/analytics/reports/route.ts` which accepts `dimensions` and `metrics`, applies whitelist mapping, builds dynamic SQL for `SELECT/GROUP BY/ORDER BY` and executes queries using `?` placeholders.
- Add `POST` and `GET /admin/analytics/events` in `src/api/admin/analytics/events/route.ts` which runs `CREATE TABLE IF NOT EXISTS analytics_event`, inserts events, and returns aggregated statistics (total events, unique sessions, breakdown by event name).
- Add `GET /admin/analytics/funnel` in `src/api/admin/analytics/funnel/route.ts` which computes funnel step reach per `session_id`, and returns per-step `conversion_rate` and `drop_off_rate` using the first-seen timestamp ordering.
- Add `GET /admin/analytics/export` in `src/api/admin/analytics/export/route.ts` which queries events and returns a CSV payload with `Content-Disposition: attachment; filename="analytics-events.csv"` and proper CSV escaping.
- Update `src/api/middlewares.ts` to add auth matchers for `/admin/analytics/reports` (POST), `/admin/analytics/events` (GET, POST), `/admin/analytics/funnel` (GET) and `/admin/analytics/export` (GET).
- Followed constraints: all Knex/raw SQL bindings use `?` placeholders and POST handlers cast `req.body` via `const body = req.body as any`.

### Testing
- Ran `npx tsc --noEmit` to typecheck; it failed with missing module/type errors because project dependencies were not installed in this environment. (Typecheck could not complete to `0 errors`.)
- Attempted `npm install` to install deps, but `npm` failed with a `403` fetching `resend` from the registry which prevented installing dependencies and completing the typecheck.
- Basic local verification: created branch `feat/analytics-reports-funnel-events`, added and committed the new files and middleware changes; no further automated tests succeeded due to the above install/typecheck failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af490ce35c8333bb0c4d305554fe02)