### PR TITLE
feat(inventory): add batch operations, inventory_log endpoints, and webhook relay

### DIFF
--- a/src/api/admin/inventory/[id]/logs/route.ts
+++ b/src/api/admin/inventory/[id]/logs/route.ts
@@ -1,0 +1,47 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+async function ensureInventoryLogTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS inventory_log (
+      id TEXT PRIMARY KEY,
+      inventory_item_id TEXT NOT NULL,
+      location_id TEXT,
+      quantity_before INTEGER,
+      quantity_after INTEGER,
+      adjustment INTEGER,
+      reason TEXT,
+      actor_id TEXT,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )`
+  )
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const limit = Number((req.query.limit as string) || 50)
+  const offset = Number((req.query.offset as string) || 0)
+
+  await ensureInventoryLogTable(pgConnection)
+
+  const result = await pgConnection.raw(
+    `SELECT id, inventory_item_id, location_id, quantity_before, quantity_after, adjustment, reason, actor_id, created_at
+     FROM inventory_log
+     WHERE inventory_item_id = ?
+     ORDER BY created_at DESC
+     LIMIT ? OFFSET ?`,
+    [req.params.id, limit, offset]
+  )
+
+  const countResult = await pgConnection.raw(
+    `SELECT COUNT(*)::int AS count FROM inventory_log WHERE inventory_item_id = ?`,
+    [req.params.id]
+  )
+
+  return res.status(200).json({
+    logs: result?.rows || [],
+    count: Number(countResult?.rows?.[0]?.count || 0),
+    limit,
+    offset,
+  })
+}

--- a/src/api/admin/inventory/batch/route.ts
+++ b/src/api/admin/inventory/batch/route.ts
@@ -1,0 +1,153 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+type BatchInventoryAction = "adjust_quantity" | "set_threshold" | "csv_import"
+
+type BatchInventoryItem = {
+  inventory_item_id: string
+  location_id: string
+  quantity?: number
+  threshold?: number
+  reason?: string
+}
+
+async function ensureInventoryLogTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS inventory_log (
+      id TEXT PRIMARY KEY,
+      inventory_item_id TEXT NOT NULL,
+      location_id TEXT,
+      quantity_before INTEGER,
+      quantity_after INTEGER,
+      adjustment INTEGER,
+      reason TEXT,
+      actor_id TEXT,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )`
+  )
+}
+
+function getActorId(req: MedusaRequest) {
+  const authContext = (req as any).auth_context || {}
+  return authContext.actor_id || authContext.user_id || null
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  const body = (req.body || {}) as any
+  const action = body.action as BatchInventoryAction | undefined
+  const items = Array.isArray(body.items) ? (body.items as BatchInventoryItem[]) : []
+
+  if (!action || !["adjust_quantity", "set_threshold", "csv_import"].includes(action)) {
+    return res.status(400).json({ error: "Invalid action" })
+  }
+
+  if (items.length === 0) {
+    return res.status(400).json({ error: "items is required" })
+  }
+
+  await ensureInventoryLogTable(pgConnection)
+
+  const results: Array<Record<string, unknown>> = []
+  const actorId = getActorId(req)
+
+  for (const item of items) {
+    try {
+      if (!item.inventory_item_id) {
+        throw new Error("inventory_item_id is required")
+      }
+
+      const levelResult = await pgConnection.raw(
+        `SELECT stocked_quantity FROM inventory_level WHERE inventory_item_id = ? AND location_id = ? LIMIT 1`,
+        [item.inventory_item_id, item.location_id]
+      )
+
+      const row = levelResult?.rows?.[0]
+      if (!row) {
+        throw new Error("Inventory level not found")
+      }
+
+      const quantityBefore = Number(row.stocked_quantity || 0)
+      let quantityAfter = quantityBefore
+      let adjustment = 0
+
+      if (action === "adjust_quantity" || action === "csv_import") {
+        const delta = Number(item.quantity || 0)
+        quantityAfter = quantityBefore + delta
+        adjustment = delta
+
+        await pgConnection.raw(
+          `UPDATE inventory_level SET stocked_quantity = ?, updated_at = NOW() WHERE inventory_item_id = ? AND location_id = ?`,
+          [quantityAfter, item.inventory_item_id, item.location_id]
+        )
+      }
+
+      if (action === "set_threshold") {
+        const threshold = Number(item.threshold)
+        if (!Number.isFinite(threshold)) {
+          throw new Error("threshold is required")
+        }
+
+        await pgConnection.raw(
+          `UPDATE inventory_level SET metadata = COALESCE(metadata, '{}'::jsonb) || ?::jsonb, updated_at = NOW() WHERE inventory_item_id = ? AND location_id = ?`,
+          [JSON.stringify({ low_stock_threshold: threshold }), item.inventory_item_id, item.location_id]
+        )
+      }
+
+      const reason = item.reason || `${action}`
+
+      await pgConnection.raw(
+        `INSERT INTO inventory_log (id, inventory_item_id, location_id, quantity_before, quantity_after, adjustment, reason, actor_id, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW())`,
+        [
+          `ilog_${Math.random().toString(36).slice(2)}`,
+          item.inventory_item_id,
+          item.location_id,
+          quantityBefore,
+          quantityAfter,
+          adjustment,
+          reason,
+          actorId,
+        ]
+      )
+
+      results.push({
+        inventory_item_id: item.inventory_item_id,
+        location_id: item.location_id,
+        success: true,
+        quantity_before: quantityBefore,
+        quantity_after: quantityAfter,
+        adjustment,
+      })
+    } catch (e: any) {
+      results.push({
+        inventory_item_id: item.inventory_item_id,
+        location_id: item.location_id,
+        success: false,
+        error: e?.message || "Unknown error",
+      })
+    }
+  }
+
+  try {
+    await eventBus.emit("inventory.batch_updated", {
+      action,
+      processed: results.length,
+      succeeded: results.filter((r) => r.success).length,
+      failed: results.filter((r) => !r.success).length,
+      results,
+    })
+  } catch {
+    // optional
+  }
+
+  return res.status(200).json({
+    action,
+    processed: results.length,
+    succeeded: results.filter((r) => r.success).length,
+    failed: results.filter((r) => !r.success).length,
+    results,
+  })
+}

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -99,6 +99,16 @@ export default defineMiddlewares({
       middlewares: [authenticate("user", ["bearer", "session"])],
     },
     {
+      matcher: "/admin/inventory/batch",
+      method: "POST",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/inventory/:id/logs",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
       matcher: "/admin/orders/export",
       method: "GET",
       middlewares: [authenticate("user", ["bearer", "session"])],

--- a/src/jobs/low-stock-alert.ts
+++ b/src/jobs/low-stock-alert.ts
@@ -44,6 +44,9 @@ export default async function lowStockAlertJob(container: MedusaContainer) {
   const notificationService = container.resolve(Modules.NOTIFICATION) as unknown as {
     createNotifications: (data: Record<string, unknown>) => Promise<unknown>
   }
+  const eventBus = container.resolve(Modules.EVENT_BUS) as {
+    emit: (name: string, data: Record<string, unknown>) => Promise<void>
+  }
 
   logger.info("[low-stock-alert] Starting low stock check...")
 
@@ -91,6 +94,16 @@ export default async function lowStockAlertJob(container: MedusaContainer) {
     }
 
     logger.info(`[low-stock-alert] Found ${lowStockItems.length} low stock items.`)
+
+    try {
+      await eventBus.emit("inventory.low_stock", {
+        threshold: LOW_STOCK_THRESHOLD,
+        count: lowStockItems.length,
+        items: lowStockItems,
+      })
+    } catch (eventError) {
+      logger.error(`[low-stock-alert] Failed to emit inventory.low_stock: ${eventError}`)
+    }
 
     const tableRows = lowStockItems
       .map(

--- a/src/subscribers/inventory-webhook-relay.ts
+++ b/src/subscribers/inventory-webhook-relay.ts
@@ -1,0 +1,53 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+
+export default async function inventoryWebhookRelayHandler({
+  event,
+  container,
+}: SubscriberArgs<Record<string, unknown>>) {
+  const webhookUrl = process.env.WEBHOOK_RELAY_URL
+  if (!webhookUrl) {
+    return
+  }
+
+  const logger = container.resolve("logger") as {
+    info: (m: string) => void
+    error: (m: string) => void
+  }
+
+  const eventName = (event as any).name || "unknown"
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-NordHjem-Event": eventName,
+        ...(process.env.WEBHOOK_RELAY_SECRET
+          ? { "X-Webhook-Secret": process.env.WEBHOOK_RELAY_SECRET }
+          : {}),
+      },
+      body: JSON.stringify({
+        event: eventName,
+        data: event.data,
+        timestamp: new Date().toISOString(),
+        source: "nordhjem-medusa",
+      }),
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) {
+      logger.error(
+        `[inventory-webhook-relay] Failed to relay ${eventName}: HTTP ${response.status}`
+      )
+    } else {
+      logger.info(`[inventory-webhook-relay] Relayed ${eventName} → ${response.status}`)
+    }
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : JSON.stringify(error)
+    logger.error(`[inventory-webhook-relay] Error relaying ${eventName}: ${errMsg}`)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: ["inventory.low_stock", "inventory.batch_updated"],
+}


### PR DESCRIPTION
### Motivation

- Provide an admin API to perform bulk inventory operations and persist an audit trail for each adjustment in `inventory_log` for traceability. 
- Relay inventory events to an external system and notify other internal parts of the system when low-stock is detected.

### Description

- Add `POST /admin/inventory/batch` implementation in `src/api/admin/inventory/batch/route.ts` to support `adjust_quantity`, `set_threshold`, and `csv_import`, update `inventory_level`, write a row into `inventory_log` per item, and emit an `inventory.batch_updated` event. 
- Add `GET /admin/inventory/:id/logs` in `src/api/admin/inventory/[id]/logs/route.ts` which ensures `inventory_log` exists (`CREATE TABLE IF NOT EXISTS`) and returns paginated logs for an `inventory_item_id`. 
- Add subscriber `src/subscribers/inventory-webhook-relay.ts` to listen for `inventory.low_stock` and `inventory.batch_updated` and POST event payloads to `WEBHOOK_RELAY_URL` with optional secret header. 
- Update `src/jobs/low-stock-alert.ts` to emit `inventory.low_stock` (payload includes threshold, count, and items) when low-stock items are found. 
- Update `src/api/middlewares.ts` to add route matchers for `/admin/inventory/batch` (POST) and `/admin/inventory/:id/logs` (GET) using admin authentication.

### Testing

- Ran `npx tsc --noEmit` in this environment and it failed due to missing external type definitions (`@medusajs/*`, Node types, etc.), which are unrelated to these changes; no repository-local automated tests were executed successfully here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af491cea9c83338049e69de1ee234d)