### PR TITLE
feat(security): add RBAC role management, audit logging, and AES field encryption

### DIFF
--- a/src/api/admin/security/audit-logs/route.ts
+++ b/src/api/admin/security/audit-logs/route.ts
@@ -1,0 +1,62 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: Record<string, unknown>[] }>
+  }
+
+  const query = req.query as Record<string, string | undefined>
+  const action = query.action
+  const actorId = query.actor_id
+  const date = query.date
+  const limit = Number.parseInt(query.limit || "50", 10) || 50
+  const offset = Number.parseInt(query.offset || "0", 10) || 0
+
+  try {
+    await pgConnection.raw(
+      `CREATE TABLE IF NOT EXISTS security_audit_log (
+        id BIGSERIAL PRIMARY KEY,
+        action VARCHAR(64) NOT NULL,
+        actor_id VARCHAR(128),
+        target_id VARCHAR(128),
+        resource VARCHAR(128),
+        metadata JSONB DEFAULT '{}'::jsonb,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )`
+    )
+
+    let sql = `SELECT * FROM security_audit_log WHERE 1=1`
+    const params: unknown[] = []
+
+    if (action) {
+      sql += ` AND action = ?`
+      params.push(action)
+    }
+
+    if (actorId) {
+      sql += ` AND actor_id = ?`
+      params.push(actorId)
+    }
+
+    if (date) {
+      sql += ` AND DATE(created_at) = ?`
+      params.push(date)
+    }
+
+    sql += ` ORDER BY created_at DESC LIMIT ? OFFSET ?`
+    params.push(limit, offset)
+
+    const result = await pgConnection.raw(sql, params)
+
+    return res.status(200).json({
+      logs: result?.rows || [],
+      limit,
+      offset,
+    })
+  } catch (err: any) {
+    logger.error(`[security-audit-logs] GET error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to fetch security audit logs" })
+  }
+}

--- a/src/api/admin/security/roles/[id]/route.ts
+++ b/src/api/admin/security/roles/[id]/route.ts
@@ -1,0 +1,98 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+const ALLOWED_ROLES = new Set(["admin", "manager", "staff"])
+
+async function ensureUserRoleTable(pgConnection: {
+  raw: (query: string, params?: unknown[]) => Promise<{ rows?: Record<string, unknown>[] }>
+}) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS user_role (
+      id BIGSERIAL PRIMARY KEY,
+      role VARCHAR(32) NOT NULL UNIQUE,
+      permissions JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`
+  )
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: Record<string, unknown>[] }>
+  }
+
+  try {
+    await ensureUserRoleTable(pgConnection)
+    const result = await pgConnection.raw(`SELECT * FROM user_role WHERE id = ?`, [req.params.id])
+
+    if (!result?.rows?.[0]) {
+      return res.status(404).json({ error: "Role not found" })
+    }
+
+    return res.status(200).json({ role: result.rows[0] })
+  } catch (err: any) {
+    logger.error(`[security-roles:id] GET error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to fetch role" })
+  }
+}
+
+export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: Record<string, unknown>[] }>
+  }
+
+  const body = (req.body as any) || {}
+  const role = body.role
+  const permissions = body.permissions
+
+  if (typeof role === "string" && !ALLOWED_ROLES.has(role)) {
+    return res.status(400).json({ error: "Invalid role. Allowed values: admin, manager, staff" })
+  }
+
+  try {
+    await ensureUserRoleTable(pgConnection)
+
+    const result = await pgConnection.raw(
+      `UPDATE user_role
+       SET role = COALESCE(?, role),
+           permissions = COALESCE(?::jsonb, permissions),
+           updated_at = NOW()
+       WHERE id = ?
+       RETURNING *`,
+      [role ?? null, permissions ? JSON.stringify(permissions) : null, req.params.id]
+    )
+
+    if (!result?.rows?.[0]) {
+      return res.status(404).json({ error: "Role not found" })
+    }
+
+    return res.status(200).json({ role: result.rows[0] })
+  } catch (err: any) {
+    logger.error(`[security-roles:id] PATCH error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to update role" })
+  }
+}
+
+export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: Record<string, unknown>[] }>
+  }
+
+  try {
+    await ensureUserRoleTable(pgConnection)
+    const result = await pgConnection.raw(`DELETE FROM user_role WHERE id = ? RETURNING id`, [req.params.id])
+
+    if (!result?.rows?.[0]) {
+      return res.status(404).json({ error: "Role not found" })
+    }
+
+    return res.status(200).json({ id: result.rows[0].id, deleted: true })
+  } catch (err: any) {
+    logger.error(`[security-roles:id] DELETE error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to delete role" })
+  }
+}

--- a/src/api/admin/security/roles/route.ts
+++ b/src/api/admin/security/roles/route.ts
@@ -1,0 +1,75 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+const ALLOWED_ROLES = new Set(["admin", "manager", "staff"])
+
+const DEFAULT_PERMISSIONS = {
+  products: { read: true, write: false, delete: false },
+  orders: { read: true, write: false, delete: false },
+  customers: { read: true, write: false, delete: false },
+}
+
+async function ensureUserRoleTable(pgConnection: {
+  raw: (query: string, params?: unknown[]) => Promise<{ rows?: Record<string, unknown>[] }>
+}) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS user_role (
+      id BIGSERIAL PRIMARY KEY,
+      role VARCHAR(32) NOT NULL UNIQUE,
+      permissions JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`
+  )
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: Record<string, unknown>[] }>
+  }
+
+  try {
+    await ensureUserRoleTable(pgConnection)
+    const result = await pgConnection.raw(`SELECT * FROM user_role ORDER BY created_at ASC`)
+    return res.status(200).json({ roles: result?.rows || [] })
+  } catch (err: any) {
+    logger.error(`[security-roles] GET error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to fetch roles" })
+  }
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: Record<string, unknown>[] }>
+  }
+
+  const body = (req.body as any) || {}
+  const role = typeof body.role === "string" ? body.role : ""
+  const permissions = body.permissions ?? DEFAULT_PERMISSIONS
+
+  if (!ALLOWED_ROLES.has(role)) {
+    return res.status(400).json({
+      error: "Invalid role. Allowed values: admin, manager, staff",
+    })
+  }
+
+  try {
+    await ensureUserRoleTable(pgConnection)
+
+    const result = await pgConnection.raw(
+      `INSERT INTO user_role (role, permissions)
+       VALUES (?, ?::jsonb)
+       ON CONFLICT (role)
+       DO UPDATE SET permissions = EXCLUDED.permissions, updated_at = NOW()
+       RETURNING *`,
+      [role, JSON.stringify(permissions)]
+    )
+
+    return res.status(200).json({ role: result?.rows?.[0] || null })
+  } catch (err: any) {
+    logger.error(`[security-roles] POST error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to create role" })
+  }
+}

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -1,4 +1,5 @@
 import { defineMiddlewares, authenticate, validateAndTransformBody } from "@medusajs/framework/http"
+import { securityAuditMiddleware } from "./middlewares/security-audit"
 import { stripeWebhookAuditMiddleware } from "./middlewares/stripe-webhook-audit"
 import { StoreCreateRestockSubscription } from "./store/restock-subscriptions/validators"
 
@@ -41,12 +42,39 @@ export default defineMiddlewares({
     {
       matcher: "/store/customers/me/data-export",
       method: "GET",
-      middlewares: [authenticate("customer", ["bearer", "session"])],
+      middlewares: [
+        authenticate("customer", ["bearer", "session"]),
+        securityAuditMiddleware,
+      ],
     },
     {
       matcher: "/store/customers/me/data-erasure",
       method: "DELETE",
-      middlewares: [authenticate("customer", ["bearer", "session"])],
+      middlewares: [
+        authenticate("customer", ["bearer", "session"]),
+        securityAuditMiddleware,
+      ],
+    },
+    {
+      matcher: "/admin/security/audit-logs",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/security/roles",
+      method: ["GET", "POST"],
+      middlewares: [
+        authenticate("user", ["bearer", "session"]),
+        securityAuditMiddleware,
+      ],
+    },
+    {
+      matcher: "/admin/security/roles/:id",
+      method: ["GET", "PATCH", "DELETE"],
+      middlewares: [
+        authenticate("user", ["bearer", "session"]),
+        securityAuditMiddleware,
+      ],
     },
     {
       matcher: "/admin/analytics/*",

--- a/src/api/middlewares/field-encryption.ts
+++ b/src/api/middlewares/field-encryption.ts
@@ -1,0 +1,63 @@
+import crypto from "crypto"
+
+const ALGORITHM = "aes-256-gcm"
+const IV_LENGTH = 12
+
+function getKey(): Buffer {
+  const rawKey = process.env.FIELD_ENCRYPTION_KEY
+
+  if (!rawKey) {
+    throw new Error("FIELD_ENCRYPTION_KEY is required")
+  }
+
+  const normalized = rawKey.length === 64 ? Buffer.from(rawKey, "hex") : Buffer.from(rawKey, "utf8")
+
+  if (normalized.length === 32) {
+    return normalized
+  }
+
+  return crypto.createHash("sha256").update(rawKey).digest()
+}
+
+export function isEncrypted(value: unknown): boolean {
+  return typeof value === "string" && value.startsWith("enc::")
+}
+
+export function encryptField(value: string): string {
+  if (isEncrypted(value)) {
+    return value
+  }
+
+  const key = getKey()
+  const iv = crypto.randomBytes(IV_LENGTH)
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv)
+
+  const encrypted = Buffer.concat([cipher.update(value, "utf8"), cipher.final()])
+  const tag = cipher.getAuthTag()
+
+  return `enc::${iv.toString("base64")}:${tag.toString("base64")}:${encrypted.toString("base64")}`
+}
+
+export function decryptField(value: string): string {
+  if (!isEncrypted(value)) {
+    return value
+  }
+
+  const payload = value.replace("enc::", "")
+  const [ivBase64, tagBase64, encryptedBase64] = payload.split(":")
+
+  if (!ivBase64 || !tagBase64 || !encryptedBase64) {
+    throw new Error("Invalid encrypted field format")
+  }
+
+  const key = getKey()
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, Buffer.from(ivBase64, "base64"))
+  decipher.setAuthTag(Buffer.from(tagBase64, "base64"))
+
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(encryptedBase64, "base64")),
+    decipher.final(),
+  ])
+
+  return decrypted.toString("utf8")
+}

--- a/src/api/middlewares/security-audit.ts
+++ b/src/api/middlewares/security-audit.ts
@@ -1,0 +1,84 @@
+import type {
+  MedusaNextFunction,
+  MedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+type AuditAction = "role_change" | "data_export" | "data_deletion"
+
+function getAction(req: MedusaRequest): AuditAction | null {
+  const path = req.path || ""
+  const method = req.method.toUpperCase()
+
+  if (path.startsWith("/admin/security/roles") && ["POST", "PATCH", "DELETE"].includes(method)) {
+    return "role_change"
+  }
+
+  if (path === "/store/customers/me/data-export" && method === "GET") {
+    return "data_export"
+  }
+
+  if (path === "/store/customers/me/data-erasure" && method === "DELETE") {
+    return "data_deletion"
+  }
+
+  return null
+}
+
+export async function securityAuditMiddleware(
+  req: MedusaRequest,
+  res: MedusaResponse,
+  next: MedusaNextFunction
+) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: Record<string, unknown>[] }>
+  }
+
+  const action = getAction(req)
+  if (!action) {
+    next()
+    return
+  }
+
+  const actorId = (req as any).auth_context?.actor_id ?? null
+
+  res.on("finish", async () => {
+    if (res.statusCode >= 400) {
+      return
+    }
+
+    const targetId = (req.params as any)?.id ?? null
+
+    try {
+      await pgConnection.raw(
+        `CREATE TABLE IF NOT EXISTS security_audit_log (
+          id BIGSERIAL PRIMARY KEY,
+          action VARCHAR(64) NOT NULL,
+          actor_id VARCHAR(128),
+          target_id VARCHAR(128),
+          resource VARCHAR(128),
+          metadata JSONB DEFAULT '{}'::jsonb,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )`
+      )
+
+      await pgConnection.raw(
+        `INSERT INTO security_audit_log (action, actor_id, target_id, resource, metadata)
+         VALUES (?, ?, ?, ?, ?::jsonb)`,
+        [
+          action,
+          actorId,
+          targetId,
+          req.path,
+          JSON.stringify({ method: req.method, query: req.query ?? {} }),
+        ]
+      )
+    } catch (err: any) {
+      logger.error(`[security-audit] write error: ${err.message}`)
+    }
+  })
+
+  next()
+}


### PR DESCRIPTION
### Motivation
- Introduce server-side role management and audit logging to record sensitive operations for compliance and investigation.
- Provide field-level encryption utilities so sensitive values can be stored encrypted using a single configurable key.
- Wire the audit middleware into sensitive API routes so exports, deletions and role changes are automatically recorded.

### Description
- Added `GET /admin/security/audit-logs` in `src/api/admin/security/audit-logs/route.ts` which bootstraps `security_audit_log` with `CREATE TABLE IF NOT EXISTS` and supports `action`, `actor_id`, `date`, `limit` and `offset` filters using `?` SQL placeholders.
- Implemented role management endpoints in `src/api/admin/security/roles/route.ts` and `src/api/admin/security/roles/[id]/route.ts` backed by `user_role` table (auto-created); roles are validated against the whitelist `admin/manager/staff` and `permissions` are stored as `JSONB` per-module (`read/write/delete`).
- Added `securityAuditMiddleware` in `src/api/middlewares/security-audit.ts` that detects `role_change`, `data_export`, and `data_deletion` actions and inserts audit rows into `security_audit_log`; the actor ID is read from `(req as any).auth_context?.actor_id`.
- Added AES-256-GCM helpers in `src/api/middlewares/field-encryption.ts` with `encryptField`, `decryptField`, and `isEncrypted`, using `FIELD_ENCRYPTION_KEY` to derive a 32-byte key.
- Updated `src/api/middlewares.ts` to import `securityAuditMiddleware` and register matchers for `/admin/security/audit-logs`, `/admin/security/roles`, `/admin/security/roles/:id` and to attach the audit middleware on sensitive endpoints.

### Testing
- Ran `npx tsc --noEmit`, which failed to complete in this environment due to missing project type dependencies and unresolved private/external modules (errors include missing `@medusajs/*` types and Node type definitions). Failure is environmental and unrelated to the new code shape.
- Attempted `npm install` to restore dependencies, but the run was blocked by an npm registry `403` for a private/package (`resend`) which prevented installing dev types and completing type-checking.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af4926f4108333aeed2c3b2dab6a30)