### PR TITLE
feat(checkout): add shipping-split, gift-cards, reservations, idempotency & event tracking

### DIFF
--- a/src/api/admin/gift-cards/route.ts
+++ b/src/api/admin/gift-cards/route.ts
@@ -1,0 +1,110 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { randomBytes, randomUUID } from "crypto"
+
+const ensureTable = async (pgConnection: any) => {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS gift_cards (
+      id uuid PRIMARY KEY,
+      code varchar(16) UNIQUE NOT NULL,
+      value numeric NOT NULL,
+      balance numeric NOT NULL,
+      currency_code text NOT NULL DEFAULT 'usd',
+      is_active boolean NOT NULL DEFAULT true,
+      expires_at timestamptz,
+      metadata jsonb,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`
+  )
+}
+
+const generateCode = () => randomBytes(8).toString("hex").toUpperCase()
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.body || {}) as any
+  const value = Number(body.value)
+
+  if (!value || value <= 0) {
+    return res.status(400).json({ message: "value must be a positive number" })
+  }
+
+  const currencyCode = String(body.currency_code || "usd").toLowerCase()
+  const expiresAt = body.expires_at ? new Date(body.expires_at) : null
+
+  if (expiresAt && Number.isNaN(expiresAt.getTime())) {
+    return res.status(400).json({ message: "expires_at is invalid" })
+  }
+
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  await ensureTable(pgConnection)
+
+  let code = generateCode()
+  let inserted
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      inserted = await pgConnection.raw(
+        `INSERT INTO gift_cards (id, code, value, balance, currency_code, expires_at, metadata)
+         VALUES (?, ?, ?, ?, ?, ?, ?::jsonb)
+         RETURNING *`,
+        [
+          randomUUID(),
+          code,
+          value,
+          value,
+          currencyCode,
+          expiresAt ? expiresAt.toISOString() : null,
+          JSON.stringify(body.metadata || {}),
+        ]
+      )
+      break
+    } catch (error: any) {
+      if (error?.message?.includes("gift_cards_code_key")) {
+        code = generateCode()
+        continue
+      }
+      throw error
+    }
+  }
+
+  if (!inserted?.rows?.[0]) {
+    return res.status(500).json({ message: "failed to create gift card" })
+  }
+
+  const giftCard = inserted.rows[0]
+
+  await eventBus.emit({
+    name: "gift_card.created",
+    data: {
+      gift_card_id: giftCard.id,
+      code: giftCard.code,
+      value: giftCard.value,
+      currency_code: giftCard.currency_code,
+    },
+  })
+
+  return res.status(200).json({ gift_card: giftCard })
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const limit = Number(req.query.limit || 50)
+  const offset = Number(req.query.offset || 0)
+
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  await ensureTable(pgConnection)
+
+  const rowsResult = await pgConnection.raw(
+    `SELECT * FROM gift_cards ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+    [limit, offset]
+  )
+  const countResult = await pgConnection.raw(`SELECT COUNT(*)::int AS count FROM gift_cards`)
+
+  return res.status(200).json({
+    gift_cards: rowsResult.rows || [],
+    count: countResult.rows?.[0]?.count || 0,
+    limit,
+    offset,
+  })
+}

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -161,5 +161,46 @@ export default defineMiddlewares({
       method: ["GET", "POST"],
       middlewares: [authenticate("user", ["bearer", "session"])],
     },
+    {
+      matcher: "/store/checkout/shipping-addresses",
+      method: ["GET", "POST"],
+      middlewares: [
+        authenticate("customer", ["bearer", "session"], {
+          allowUnauthenticated: true,
+        }),
+      ],
+    },
+    {
+      matcher: "/admin/gift-cards",
+      method: ["GET", "POST"],
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/store/cart/gift-card",
+      method: ["GET", "POST"],
+      middlewares: [
+        authenticate("customer", ["bearer", "session"], {
+          allowUnauthenticated: true,
+        }),
+      ],
+    },
+    {
+      matcher: "/store/checkout/reserve",
+      method: ["POST", "DELETE"],
+      middlewares: [
+        authenticate("customer", ["bearer", "session"], {
+          allowUnauthenticated: true,
+        }),
+      ],
+    },
+    {
+      matcher: "/store/checkout/idempotency",
+      method: "POST",
+      middlewares: [
+        authenticate("customer", ["bearer", "session"], {
+          allowUnauthenticated: true,
+        }),
+      ],
+    },
   ],
 })

--- a/src/api/store/cart/gift-card/route.ts
+++ b/src/api/store/cart/gift-card/route.ts
@@ -1,0 +1,130 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { randomUUID } from "crypto"
+
+const ensureTables = async (pgConnection: any) => {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS gift_card_transactions (
+      id uuid PRIMARY KEY,
+      gift_card_id uuid NOT NULL,
+      cart_id text NOT NULL,
+      amount numeric NOT NULL,
+      status text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`
+  )
+
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS gift_cards (
+      id uuid PRIMARY KEY,
+      code varchar(16) UNIQUE NOT NULL,
+      value numeric NOT NULL,
+      balance numeric NOT NULL,
+      currency_code text NOT NULL DEFAULT 'usd',
+      is_active boolean NOT NULL DEFAULT true,
+      expires_at timestamptz,
+      metadata jsonb,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`
+  )
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.body || {}) as any
+  const cartId = body.cart_id
+  const giftCardCode = String(body.gift_card_code || "").toUpperCase()
+
+  if (!cartId || !giftCardCode) {
+    return res.status(400).json({ message: "cart_id and gift_card_code are required" })
+  }
+
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  await ensureTables(pgConnection)
+
+  const cardResult = await pgConnection.raw(`SELECT * FROM gift_cards WHERE code = ? LIMIT 1`, [giftCardCode])
+  const giftCard = cardResult.rows?.[0]
+
+  if (!giftCard) {
+    return res.status(404).json({ message: "gift card not found" })
+  }
+
+  if (!giftCard.is_active) {
+    return res.status(400).json({ message: "gift card is inactive" })
+  }
+
+  if (giftCard.expires_at && new Date(giftCard.expires_at).getTime() < Date.now()) {
+    return res.status(400).json({ message: "gift card has expired" })
+  }
+
+  const balance = Number(giftCard.balance || 0)
+  if (balance <= 0) {
+    return res.status(400).json({ message: "gift card balance is zero" })
+  }
+
+  const cartResult = await pgConnection.raw(`SELECT id, total, metadata FROM cart WHERE id = ? LIMIT 1`, [cartId])
+  const cart = cartResult.rows?.[0]
+  if (!cart) {
+    return res.status(404).json({ message: "cart not found" })
+  }
+
+  const cartTotal = Math.max(Number(cart.total || 0), 0)
+  const appliedAmount = cartTotal > 0 ? Math.min(balance, cartTotal) : balance
+
+  await pgConnection.raw(
+    `INSERT INTO gift_card_transactions (id, gift_card_id, cart_id, amount, status)
+     VALUES (?, ?, ?, ?, ?)`,
+    [randomUUID(), giftCard.id, cartId, appliedAmount, "pending"]
+  )
+
+  await pgConnection.raw(
+    `UPDATE cart
+     SET metadata = COALESCE(metadata, '{}'::jsonb) || ?::jsonb
+     WHERE id = ?`,
+    [JSON.stringify({ gift_card: { code: giftCardCode, applied_amount: appliedAmount } }), cartId]
+  )
+
+  await eventBus.emit({
+    name: "gift_card.applied",
+    data: {
+      gift_card_id: giftCard.id,
+      cart_id: cartId,
+      code: giftCardCode,
+      applied_amount: appliedAmount,
+    },
+  })
+
+  return res.status(200).json({
+    applied: true,
+    gift_card_code: giftCardCode,
+    balance_remaining: balance,
+    applied_amount: appliedAmount,
+  })
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const cartId = (req.query.cart_id as string) || ""
+  if (!cartId) {
+    return res.status(400).json({ message: "cart_id is required" })
+  }
+
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  await ensureTables(pgConnection)
+
+  const cartResult = await pgConnection.raw(`SELECT metadata FROM cart WHERE id = ? LIMIT 1`, [cartId])
+  const txResult = await pgConnection.raw(
+    `SELECT gct.*, gc.code
+     FROM gift_card_transactions gct
+     JOIN gift_cards gc ON gc.id = gct.gift_card_id
+     WHERE gct.cart_id = ?
+     ORDER BY gct.created_at DESC`,
+    [cartId]
+  )
+
+  return res.status(200).json({
+    cart_id: cartId,
+    gift_card: cartResult.rows?.[0]?.metadata?.gift_card || null,
+    transactions: txResult.rows || [],
+  })
+}

--- a/src/api/store/checkout/idempotency/route.ts
+++ b/src/api/store/checkout/idempotency/route.ts
@@ -1,0 +1,67 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { randomUUID } from "crypto"
+
+const ensureTable = async (pgConnection: any) => {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS checkout_idempotency (
+      id uuid PRIMARY KEY,
+      cart_id text NOT NULL,
+      idempotency_key text UNIQUE NOT NULL,
+      status text NOT NULL,
+      result_json jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )`
+  )
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.body || {}) as any
+  const cartId = body.cart_id
+  const idempotencyKey = body.idempotency_key
+
+  if (!cartId || !idempotencyKey) {
+    return res.status(400).json({ message: "cart_id and idempotency_key are required" })
+  }
+
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  await ensureTable(pgConnection)
+
+  const existingResult = await pgConnection.raw(
+    `SELECT * FROM checkout_idempotency WHERE idempotency_key = ? LIMIT 1`,
+    [idempotencyKey]
+  )
+  const existing = existingResult.rows?.[0]
+
+  if (existing?.status === "completed") {
+    return res.status(200).json({
+      is_duplicate: true,
+      previous_result: existing.result_json || {},
+    })
+  }
+
+  if (existing?.status === "processing") {
+    return res.status(409).json({
+      message: "request with this idempotency_key is processing",
+      is_duplicate: true,
+    })
+  }
+
+  if (existing?.status === "failed") {
+    await pgConnection.raw(
+      `UPDATE checkout_idempotency
+       SET cart_id = ?, status = 'processing', result_json = NULL, updated_at = now()
+       WHERE idempotency_key = ?`,
+      [cartId, idempotencyKey]
+    )
+  } else {
+    await pgConnection.raw(
+      `INSERT INTO checkout_idempotency (id, cart_id, idempotency_key, status)
+       VALUES (?, ?, ?, 'processing')`,
+      [randomUUID(), cartId, idempotencyKey]
+    )
+  }
+
+  return res.status(200).json({ is_duplicate: false })
+}

--- a/src/api/store/checkout/reserve/route.ts
+++ b/src/api/store/checkout/reserve/route.ts
@@ -1,0 +1,90 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { randomUUID } from "crypto"
+
+const ensureTable = async (pgConnection: any) => {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS stock_reservations (
+      id uuid PRIMARY KEY,
+      cart_id text NOT NULL,
+      variant_id text NOT NULL,
+      quantity integer NOT NULL,
+      expires_at timestamptz NOT NULL,
+      status text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`
+  )
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.body || {}) as any
+  const cartId = body.cart_id
+
+  if (!cartId) {
+    return res.status(400).json({ message: "cart_id is required" })
+  }
+
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  await ensureTable(pgConnection)
+
+  const lineItemsResult = await pgConnection.raw(
+    `SELECT variant_id, quantity
+     FROM cart_line_item
+     WHERE cart_id = ?`,
+    [cartId]
+  )
+  const lineItems = (lineItemsResult.rows || []).filter((item: any) => item.variant_id && Number(item.quantity) > 0)
+
+  if (!lineItems.length) {
+    return res.status(404).json({ message: "no reservable line items found" })
+  }
+
+  const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString()
+  const reservationId = randomUUID()
+
+  for (const item of lineItems) {
+    await pgConnection.raw(
+      `INSERT INTO stock_reservations (id, cart_id, variant_id, quantity, expires_at, status)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [randomUUID(), cartId, item.variant_id, Number(item.quantity), expiresAt, "active"]
+    )
+  }
+
+  await eventBus.emit({
+    name: "checkout.stock_reserved",
+    data: {
+      reservation_id: reservationId,
+      cart_id: cartId,
+      items_reserved: lineItems.length,
+      expires_at: expiresAt,
+    },
+  })
+
+  return res.status(200).json({
+    reservation_id: reservationId,
+    items_reserved: lineItems.length,
+    expires_at: expiresAt,
+  })
+}
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const cartId = (req.query.cart_id as string) || ""
+
+  if (!cartId) {
+    return res.status(400).json({ message: "cart_id is required" })
+  }
+
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  await ensureTable(pgConnection)
+
+  await pgConnection.raw(
+    `UPDATE stock_reservations
+     SET status = 'expired'
+     WHERE cart_id = ? AND status = 'active'`,
+    [cartId]
+  )
+
+  return res.status(200).json({ released: true })
+}

--- a/src/api/store/checkout/shipping-addresses/route.ts
+++ b/src/api/store/checkout/shipping-addresses/route.ts
@@ -1,0 +1,100 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { randomUUID } from "crypto"
+
+const ensureTable = async (pgConnection: any) => {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS checkout_shipping_addresses (
+      id uuid PRIMARY KEY,
+      cart_id text NOT NULL,
+      line_item_id text NOT NULL,
+      address_json jsonb NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`
+  )
+}
+
+const toAddressGroups = (rows: any[]) => {
+  const grouped = new Map<string, { address: any; line_item_ids: string[]; estimated_items_count: number }>()
+
+  for (const row of rows) {
+    const address = row.address_json
+    const key = JSON.stringify(address)
+    const existing = grouped.get(key)
+
+    if (existing) {
+      existing.line_item_ids.push(row.line_item_id)
+      existing.estimated_items_count += 1
+      continue
+    }
+
+    grouped.set(key, {
+      address,
+      line_item_ids: [row.line_item_id],
+      estimated_items_count: 1,
+    })
+  }
+
+  return Array.from(grouped.values())
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.body || {}) as any
+  const cartId = body.cart_id
+  const items = Array.isArray(body.items) ? body.items : []
+
+  if (!cartId || !items.length) {
+    return res.status(400).json({ message: "cart_id and items are required" })
+  }
+
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  await ensureTable(pgConnection)
+  await pgConnection.raw(`DELETE FROM checkout_shipping_addresses WHERE cart_id = ?`, [cartId])
+
+  for (const item of items) {
+    if (!item?.line_item_id || !item?.address) {
+      continue
+    }
+
+    await pgConnection.raw(
+      `INSERT INTO checkout_shipping_addresses (id, cart_id, line_item_id, address_json)
+       VALUES (?, ?, ?, ?::jsonb)`,
+      [randomUUID(), cartId, item.line_item_id, JSON.stringify(item.address)]
+    )
+  }
+
+  const result = await pgConnection.raw(
+    `SELECT line_item_id, address_json
+     FROM checkout_shipping_addresses
+     WHERE cart_id = ?
+     ORDER BY created_at ASC`,
+    [cartId]
+  )
+
+  return res.status(200).json({
+    address_groups: toAddressGroups(result.rows || []),
+  })
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const cartId = (req.query.cart_id as string) || ""
+  if (!cartId) {
+    return res.status(400).json({ message: "cart_id is required" })
+  }
+
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  await ensureTable(pgConnection)
+
+  const result = await pgConnection.raw(
+    `SELECT line_item_id, address_json
+     FROM checkout_shipping_addresses
+     WHERE cart_id = ?
+     ORDER BY created_at ASC`,
+    [cartId]
+  )
+
+  return res.status(200).json({
+    address_groups: toAddressGroups(result.rows || []),
+  })
+}

--- a/src/jobs/expire-reservations.ts
+++ b/src/jobs/expire-reservations.ts
@@ -1,0 +1,54 @@
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+export default async function expireReservationsJob(container: MedusaContainer) {
+  const pgConnection = container.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = container.resolve(Modules.EVENT_BUS) as any
+
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS stock_reservations (
+      id uuid PRIMARY KEY,
+      cart_id text NOT NULL,
+      variant_id text NOT NULL,
+      quantity integer NOT NULL,
+      expires_at timestamptz NOT NULL,
+      status text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`
+  )
+
+  const expiredResult = await pgConnection.raw(
+    `SELECT id, cart_id, variant_id, quantity
+     FROM stock_reservations
+     WHERE status = 'active' AND expires_at < now()`
+  )
+
+  const expiredRows = expiredResult.rows || []
+
+  if (!expiredRows.length) {
+    return
+  }
+
+  await pgConnection.raw(
+    `UPDATE stock_reservations
+     SET status = 'expired'
+     WHERE status = 'active' AND expires_at < now()`
+  )
+
+  for (const row of expiredRows) {
+    await eventBus.emit({
+      name: "checkout.reservation_expired",
+      data: {
+        reservation_id: row.id,
+        cart_id: row.cart_id,
+        variant_id: row.variant_id,
+        quantity: row.quantity,
+      },
+    })
+  }
+}
+
+export const config = {
+  name: "expire-reservations",
+  schedule: "*/5 * * * *",
+}

--- a/src/subscribers/checkout-events.ts
+++ b/src/subscribers/checkout-events.ts
@@ -1,0 +1,69 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { randomUUID } from "crypto"
+
+export default async function checkoutEventsHandler({ event, container }: SubscriberArgs<Record<string, any>>) {
+  const pgConnection = container.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const logger = container.resolve("logger") as any
+
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS checkout_events (
+      id uuid PRIMARY KEY,
+      cart_id text,
+      order_id text,
+      event_name text NOT NULL,
+      event_data jsonb,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`
+  )
+
+  const eventName = event.name
+  const mappedName =
+    eventName === "cart.created"
+      ? "checkout.started"
+      : eventName === "order.placed"
+        ? "checkout.completed"
+        : eventName
+
+  const eventData = (event.data || {}) as any
+
+  await pgConnection.raw(
+    `INSERT INTO checkout_events (id, cart_id, order_id, event_name, event_data)
+     VALUES (?, ?, ?, ?, ?::jsonb)`,
+    [
+      randomUUID(),
+      eventData.cart_id || eventData.id || null,
+      eventData.order_id || eventData.id || null,
+      mappedName,
+      JSON.stringify(eventData),
+    ]
+  )
+
+  const webhookUrl = process.env.WEBHOOK_RELAY_URL
+  if (!webhookUrl) {
+    return
+  }
+
+  try {
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-NordHjem-Event": mappedName,
+      },
+      body: JSON.stringify({
+        event: mappedName,
+        source_event: eventName,
+        data: eventData,
+        timestamp: new Date().toISOString(),
+      }),
+      signal: AbortSignal.timeout(10000),
+    })
+  } catch (error: any) {
+    logger.error(`[checkout-events] webhook relay failed: ${error?.message || String(error)}`)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: ["cart.created", "cart.updated", "order.placed"],
+}


### PR DESCRIPTION
### Motivation
- Implement M3 checkout backend enhancements to support multi-address shipping, gift cards, checkout idempotency, temporary stock reservations, and end-to-end checkout event tracking. 
- Provide admin and store APIs plus a scheduled job and subscriber so these features can operate without adding Medusa modules or DB migrations.

### Description
- Added Store APIs: `POST/GET /store/checkout/shipping-addresses`, `POST/DELETE /store/checkout/reserve`, `POST /store/checkout/idempotency`, and `POST/GET /store/cart/gift-card` to persist shipping per line item, create/release 15-minute stock reservations, handle idempotency keys, and apply gift cards respectively (new files under `src/api/store/*`).
- Added Admin API `POST/GET /admin/gift-cards` to create and list gift cards and emit `gift_card.created` (new file `src/api/admin/gift-cards/route.ts`).
- Added checkout event subscriber `src/subscribers/checkout-events.ts` to record mapped checkout events to `checkout_events` and relay to `WEBHOOK_RELAY_URL`, and a scheduled job `src/jobs/expire-reservations.ts` to expire reservations and emit `checkout.reservation_expired` every 5 minutes.
- Appended authentication middleware entries to the end of `src/api/middlewares.ts` for the new routes and adhered to technical constraints: DB queries use `?` placeholders, `container/req.scope` resolves use `as any`, `req.body` is read via `const body = (req.body || {}) as any`, and `CREATE TABLE IF NOT EXISTS` is used for schema creation in handlers.

### Testing
- Attempted to run `npm run build` which invokes `medusa build`, but the build failed in this environment with `sh: 1: medusa: not found` so TypeScript/production build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af75ecc2f4833393dd0f0124fd10b1)