### PR TITLE
feat(store): enhanced customer account APIs — addresses, orders, preferences, login history

### DIFF
--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -1,6 +1,7 @@
 import { defineMiddlewares, authenticate, validateAndTransformBody } from "@medusajs/framework/http"
 import { securityAuditMiddleware } from "./middlewares/security-audit"
 import { stripeWebhookAuditMiddleware } from "./middlewares/stripe-webhook-audit"
+import { loginTrackerMiddleware } from "./middlewares/login-tracker"
 import { StoreCreateRestockSubscription } from "./store/restock-subscriptions/validators"
 
 export default defineMiddlewares({
@@ -201,6 +202,36 @@ export default defineMiddlewares({
           allowUnauthenticated: true,
         }),
       ],
+    },
+    {
+      matcher: "/store/me/addresses",
+      method: ["GET", "POST"],
+      middlewares: [authenticate("customer", ["bearer", "session"])],
+    },
+    {
+      matcher: "/store/me/addresses/:id",
+      method: ["PATCH", "DELETE"],
+      middlewares: [authenticate("customer", ["bearer", "session"])],
+    },
+    {
+      matcher: "/store/me/orders",
+      method: "GET",
+      middlewares: [authenticate("customer", ["bearer", "session"])],
+    },
+    {
+      matcher: "/store/me/preferences",
+      method: ["GET", "PATCH"],
+      middlewares: [authenticate("customer", ["bearer", "session"])],
+    },
+    {
+      matcher: "/store/me/login-history",
+      method: "GET",
+      middlewares: [authenticate("customer", ["bearer", "session"])],
+    },
+    {
+      matcher: "/auth/customer/emailpass",
+      method: "POST",
+      middlewares: [loginTrackerMiddleware],
     },
   ],
 })

--- a/src/api/middlewares/login-tracker.ts
+++ b/src/api/middlewares/login-tracker.ts
@@ -1,0 +1,82 @@
+import type {
+  MedusaNextFunction,
+  MedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+async function ensureLoginHistoryTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS customer_login_history (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      customer_id TEXT,
+      ip_address TEXT,
+      user_agent TEXT,
+      login_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      status TEXT NOT NULL
+    )`
+  )
+}
+
+function getIp(req: MedusaRequest) {
+  const forwarded = req.headers["x-forwarded-for"]
+  if (Array.isArray(forwarded)) {
+    return forwarded[0]?.split(",")[0]?.trim() || req.ip || null
+  }
+
+  if (typeof forwarded === "string") {
+    return forwarded.split(",")[0]?.trim() || req.ip || null
+  }
+
+  return req.ip || null
+}
+
+export async function loginTrackerMiddleware(
+  req: MedusaRequest,
+  res: MedusaResponse,
+  next: MedusaNextFunction
+) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  await ensureLoginHistoryTable(pgConnection)
+
+  let responseBody: any = null
+  const originalJson = res.json.bind(res)
+  ;(res as any).json = (body: any) => {
+    responseBody = body
+    return originalJson(body)
+  }
+
+  res.on("finish", async () => {
+    const status = res.statusCode === 200 ? "success" : "failed"
+
+    let customerId: string | null = null
+    if (status === "success") {
+      customerId =
+        responseBody?.customer?.id ||
+        responseBody?.customer_id ||
+        responseBody?.actor_id ||
+        (res as any).locals?.auth_context?.actor_id ||
+        null
+    }
+
+    if (!customerId) {
+      const body = (req.body || {}) as any
+      if (body.email) {
+        const result = await pgConnection.raw(
+          `SELECT id FROM customer WHERE email = ? LIMIT 1`,
+          [body.email]
+        )
+        customerId = result.rows?.[0]?.id || null
+      }
+    }
+
+    await pgConnection.raw(
+      `INSERT INTO customer_login_history (customer_id, ip_address, user_agent, login_at, status)
+       VALUES (?, ?, ?, NOW(), ?)`,
+      [customerId, getIp(req), req.headers["user-agent"] || null, status]
+    )
+  })
+
+  next()
+}

--- a/src/api/store/me/addresses/[id]/route.ts
+++ b/src/api/store/me/addresses/[id]/route.ts
@@ -1,0 +1,172 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+async function ensureMetadataTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS customer_address_metadata (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      customer_id TEXT NOT NULL,
+      address_id TEXT NOT NULL,
+      label TEXT,
+      is_default BOOLEAN NOT NULL DEFAULT false,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (customer_id, address_id)
+    )`
+  )
+}
+
+export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
+  const customerService = req.scope.resolve(Modules.CUSTOMER) as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const addressId = (req.params as any)?.id
+  const body = (req.body || {}) as any
+
+  await ensureMetadataTable(pgConnection)
+
+  const updatePayload: Record<string, any> = {}
+  const updatableFields = [
+    "address_1",
+    "address_2",
+    "city",
+    "country_code",
+    "postal_code",
+    "first_name",
+    "last_name",
+    "phone",
+    "province",
+    "company",
+  ]
+
+  for (const field of updatableFields) {
+    if (body[field] !== undefined) {
+      updatePayload[field] = body[field]
+    }
+  }
+
+  if (Object.keys(updatePayload).length > 0) {
+    const updateMethods = [
+      () => customerService.updateAddresses(addressId, updatePayload),
+      () => customerService.updateCustomerAddresses(addressId, updatePayload),
+    ]
+
+    let updated = false
+    for (const fn of updateMethods) {
+      try {
+        await fn()
+        updated = true
+        break
+      } catch {
+        // fallback
+      }
+    }
+
+    if (!updated) {
+      return res.status(500).json({ error: "Failed to update address" })
+    }
+  }
+
+  if (body.is_default === true) {
+    await pgConnection.raw(
+      `UPDATE customer_address_metadata
+       SET is_default = false, updated_at = NOW()
+       WHERE customer_id = ?`,
+      [customerId]
+    )
+  }
+
+  if (body.label !== undefined || body.is_default !== undefined) {
+    await pgConnection.raw(
+      `INSERT INTO customer_address_metadata (customer_id, address_id, label, is_default, created_at, updated_at)
+       VALUES (?, ?, ?, ?, NOW(), NOW())
+       ON CONFLICT (customer_id, address_id)
+       DO UPDATE SET
+         label = COALESCE(EXCLUDED.label, customer_address_metadata.label),
+         is_default = EXCLUDED.is_default,
+         updated_at = NOW()`,
+      [
+        customerId,
+        addressId,
+        body.label !== undefined ? body.label : null,
+        body.is_default === true,
+      ]
+    )
+  }
+
+  const customer = await customerService.retrieveCustomer(customerId, {
+    relations: ["addresses"],
+  })
+  const address = (customer?.addresses || []).find((item: any) => item.id === addressId)
+
+  const metadataResult = await pgConnection.raw(
+    `SELECT label, is_default FROM customer_address_metadata WHERE customer_id = ? AND address_id = ?`,
+    [customerId, addressId]
+  )
+  const metadata = metadataResult.rows?.[0]
+
+  return res.status(200).json({
+    address: {
+      ...address,
+      label: metadata?.label || null,
+      is_default: Boolean(metadata?.is_default),
+    },
+  })
+}
+
+export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
+  const customerService = req.scope.resolve(Modules.CUSTOMER) as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const addressId = (req.params as any)?.id
+
+  await ensureMetadataTable(pgConnection)
+
+  const metadataResult = await pgConnection.raw(
+    `SELECT is_default FROM customer_address_metadata WHERE customer_id = ? AND address_id = ?`,
+    [customerId, addressId]
+  )
+
+  if (metadataResult.rows?.[0]?.is_default) {
+    return res
+      .status(400)
+      .json({ error: "Cannot delete default address. Set another address as default first." })
+  }
+
+  const deleteMethods = [
+    () => customerService.deleteAddresses(addressId),
+    () => customerService.deleteCustomerAddresses(addressId),
+  ]
+
+  let deleted = false
+  for (const fn of deleteMethods) {
+    try {
+      await fn()
+      deleted = true
+      break
+    } catch {
+      // fallback
+    }
+  }
+
+  if (!deleted) {
+    return res.status(500).json({ error: "Failed to delete address" })
+  }
+
+  await pgConnection.raw(
+    `DELETE FROM customer_address_metadata WHERE customer_id = ? AND address_id = ?`,
+    [customerId, addressId]
+  )
+
+  return res.status(200).json({ id: addressId, object: "address", deleted: true })
+}

--- a/src/api/store/me/addresses/route.ts
+++ b/src/api/store/me/addresses/route.ts
@@ -1,0 +1,136 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+async function ensureMetadataTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS customer_address_metadata (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      customer_id TEXT NOT NULL,
+      address_id TEXT NOT NULL,
+      label TEXT,
+      is_default BOOLEAN NOT NULL DEFAULT false,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (customer_id, address_id)
+    )`
+  )
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const customerService = req.scope.resolve(Modules.CUSTOMER) as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  await ensureMetadataTable(pgConnection)
+
+  const customer = await customerService.retrieveCustomer(customerId, {
+    relations: ["addresses"],
+  })
+
+  const addresses = customer?.addresses || []
+  const metadataResult = await pgConnection.raw(
+    `SELECT address_id, label, is_default FROM customer_address_metadata WHERE customer_id = ?`,
+    [customerId]
+  )
+  const metadataRows = metadataResult.rows || []
+  const metadataMap = new Map(metadataRows.map((row: any) => [row.address_id, row]))
+
+  return res.status(200).json({
+    addresses: addresses.map((address: any) => {
+      const metadata = metadataMap.get(address.id)
+      return {
+        ...address,
+        label: metadata?.label || null,
+        is_default: Boolean(metadata?.is_default),
+      }
+    }),
+  })
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const customerService = req.scope.resolve(Modules.CUSTOMER) as any
+  const eventBus = req.scope.resolve(ContainerRegistrationKeys.EVENT_BUS) as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const body = (req.body || {}) as any
+
+  await ensureMetadataTable(pgConnection)
+
+  const customer = await customerService.retrieveCustomer(customerId, {
+    relations: ["addresses"],
+  })
+
+  if ((customer?.addresses || []).length >= 10) {
+    return res.status(400).json({ error: "Address limit reached (max 10)" })
+  }
+
+  const addressPayload = {
+    first_name: body.first_name,
+    last_name: body.last_name,
+    address_1: body.address_1,
+    city: body.city,
+    country_code: body.country_code,
+    postal_code: body.postal_code,
+    phone: body.phone,
+  }
+
+  const createMethods = [
+    () => customerService.addAddresses(customerId, [addressPayload]),
+    () => customerService.createAddresses(customerId, [addressPayload]),
+    () => customerService.createCustomerAddresses(customerId, [addressPayload]),
+  ]
+
+  let created: any = null
+  for (const fn of createMethods) {
+    try {
+      const result = await fn()
+      created = Array.isArray(result) ? result[0] : result?.[0] || result
+      if (created) {
+        break
+      }
+    } catch {
+      // fallback to next supported method
+    }
+  }
+
+  if (!created?.id) {
+    return res.status(500).json({ error: "Failed to create address" })
+  }
+
+  if (body.is_default === true) {
+    await pgConnection.raw(
+      `UPDATE customer_address_metadata SET is_default = false, updated_at = NOW() WHERE customer_id = ?`,
+      [customerId]
+    )
+  }
+
+  await pgConnection.raw(
+    `INSERT INTO customer_address_metadata (customer_id, address_id, label, is_default, created_at, updated_at)
+     VALUES (?, ?, ?, ?, NOW(), NOW())
+     ON CONFLICT (customer_id, address_id)
+     DO UPDATE SET label = EXCLUDED.label, is_default = EXCLUDED.is_default, updated_at = NOW()`,
+    [customerId, created.id, body.label || null, body.is_default === true]
+  )
+
+  await eventBus.emit({
+    name: "customer.address_created",
+    data: { customer_id: customerId, address_id: created.id },
+  })
+
+  return res.status(200).json({
+    address: {
+      ...created,
+      label: body.label || null,
+      is_default: body.is_default === true,
+    },
+  })
+}

--- a/src/api/store/me/login-history/route.ts
+++ b/src/api/store/me/login-history/route.ts
@@ -1,0 +1,49 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+async function ensureLoginHistoryTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS customer_login_history (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      customer_id TEXT NOT NULL,
+      ip_address TEXT,
+      user_agent TEXT,
+      login_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      status TEXT NOT NULL
+    )`
+  )
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const query = (req.query || {}) as any
+  const limit = Math.min(Number(query.limit) || 20, 100)
+  const offset = Math.max(Number(query.offset) || 0, 0)
+
+  await ensureLoginHistoryTable(pgConnection)
+
+  const listResult = await pgConnection.raw(
+    `SELECT id, customer_id, ip_address, user_agent, login_at, status
+     FROM customer_login_history
+     WHERE customer_id = ?
+     ORDER BY login_at DESC
+     LIMIT ? OFFSET ?`,
+    [customerId, limit, offset]
+  )
+
+  const countResult = await pgConnection.raw(
+    `SELECT COUNT(*)::int AS count FROM customer_login_history WHERE customer_id = ?`,
+    [customerId]
+  )
+
+  return res.status(200).json({
+    login_history: listResult.rows || [],
+    count: countResult.rows?.[0]?.count || 0,
+  })
+}

--- a/src/api/store/me/orders/route.ts
+++ b/src/api/store/me/orders/route.ts
@@ -1,0 +1,70 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const query = (req.query || {}) as any
+  const limit = Math.min(Number(query.limit) || 20, 100)
+  const offset = Math.max(Number(query.offset) || 0, 0)
+
+  const sortBy = query.sort_by === "total" ? "total" : "created_at"
+  const sortOrder = String(query.sort_order || "desc").toLowerCase() === "asc" ? "ASC" : "DESC"
+
+  const statusAllowList = ["pending", "completed", "canceled", "archived"]
+
+  const conditions: string[] = [`customer_id = ?`]
+  const params: any[] = [customerId]
+
+  if (query.date_from) {
+    conditions.push("created_at >= ?")
+    params.push(new Date(query.date_from))
+  }
+
+  if (query.date_to) {
+    conditions.push("created_at <= ?")
+    params.push(new Date(query.date_to))
+  }
+
+  if (query.status && statusAllowList.includes(query.status)) {
+    conditions.push("status = ?")
+    params.push(query.status)
+  }
+
+  if (query.min_amount !== undefined) {
+    conditions.push("total >= ?")
+    params.push(Number(query.min_amount))
+  }
+
+  if (query.max_amount !== undefined) {
+    conditions.push("total <= ?")
+    params.push(Number(query.max_amount))
+  }
+
+  const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""
+
+  const countResult = await pgConnection.raw(
+    `SELECT COUNT(*)::int AS count FROM "order" ${whereClause}`,
+    params
+  )
+
+  const listResult = await pgConnection.raw(
+    `SELECT * FROM "order"
+     ${whereClause}
+     ORDER BY ${sortBy === "total" ? "total" : "created_at"} ${sortOrder}
+     LIMIT ? OFFSET ?`,
+    [...params, limit, offset]
+  )
+
+  return res.status(200).json({
+    orders: listResult.rows || [],
+    count: countResult.rows?.[0]?.count || 0,
+    limit,
+    offset,
+  })
+}

--- a/src/api/store/me/preferences/route.ts
+++ b/src/api/store/me/preferences/route.ts
@@ -1,0 +1,114 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+const defaultPreferences = {
+  language: "en",
+  currency_code: "usd",
+  notification_email: true,
+  notification_sms: false,
+  marketing_opt_in: false,
+}
+
+async function ensurePreferencesTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS customer_preferences (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      customer_id TEXT UNIQUE NOT NULL,
+      language TEXT,
+      currency_code TEXT,
+      notification_email BOOLEAN NOT NULL DEFAULT true,
+      notification_sms BOOLEAN NOT NULL DEFAULT false,
+      marketing_opt_in BOOLEAN NOT NULL DEFAULT false,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`
+  )
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  await ensurePreferencesTable(pgConnection)
+
+  const result = await pgConnection.raw(
+    `SELECT language, currency_code, notification_email, notification_sms, marketing_opt_in
+     FROM customer_preferences
+     WHERE customer_id = ?`,
+    [customerId]
+  )
+
+  const row = result.rows?.[0]
+
+  return res.status(200).json({
+    preferences: row
+      ? {
+          language: row.language || defaultPreferences.language,
+          currency_code: row.currency_code || defaultPreferences.currency_code,
+          notification_email: row.notification_email,
+          notification_sms: row.notification_sms,
+          marketing_opt_in: row.marketing_opt_in,
+        }
+      : defaultPreferences,
+  })
+}
+
+export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = req.scope.resolve(ContainerRegistrationKeys.EVENT_BUS) as any
+
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const body = (req.body || {}) as any
+
+  await ensurePreferencesTable(pgConnection)
+
+  await pgConnection.raw(
+    `INSERT INTO customer_preferences (
+      customer_id,
+      language,
+      currency_code,
+      notification_email,
+      notification_sms,
+      marketing_opt_in,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, NOW())
+    ON CONFLICT (customer_id)
+    DO UPDATE SET
+      language = COALESCE(EXCLUDED.language, customer_preferences.language),
+      currency_code = COALESCE(EXCLUDED.currency_code, customer_preferences.currency_code),
+      notification_email = COALESCE(EXCLUDED.notification_email, customer_preferences.notification_email),
+      notification_sms = COALESCE(EXCLUDED.notification_sms, customer_preferences.notification_sms),
+      marketing_opt_in = COALESCE(EXCLUDED.marketing_opt_in, customer_preferences.marketing_opt_in),
+      updated_at = NOW()`,
+    [
+      customerId,
+      body.language ?? null,
+      body.currency_code ?? null,
+      body.notification_email ?? null,
+      body.notification_sms ?? null,
+      body.marketing_opt_in ?? null,
+    ]
+  )
+
+  const result = await pgConnection.raw(
+    `SELECT language, currency_code, notification_email, notification_sms, marketing_opt_in
+     FROM customer_preferences
+     WHERE customer_id = ?`,
+    [customerId]
+  )
+  const preferences = result.rows?.[0] || defaultPreferences
+
+  await eventBus.emit({
+    name: "customer.preferences_updated",
+    data: { customer_id: customerId, preferences },
+  })
+
+  return res.status(200).json({ preferences })
+}

--- a/src/subscribers/login-tracker.ts
+++ b/src/subscribers/login-tracker.ts
@@ -1,0 +1,35 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+export default async function loginTrackerSubscriber({
+  event,
+  container,
+}: SubscriberArgs<any>) {
+  const pgConnection = container.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS customer_login_history (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      customer_id TEXT,
+      ip_address TEXT,
+      user_agent TEXT,
+      login_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      status TEXT NOT NULL
+    )`
+  )
+
+  const customerId = event.data?.customer_id || event.data?.actor_id || event.data?.id || null
+  if (!customerId) {
+    return
+  }
+
+  await pgConnection.raw(
+    `INSERT INTO customer_login_history (customer_id, ip_address, user_agent, login_at, status)
+     VALUES (?, ?, ?, NOW(), ?)`,
+    [customerId, null, null, "success"]
+  )
+}
+
+export const config: SubscriberConfig = {
+  event: "auth.authenticated",
+}


### PR DESCRIPTION
### Motivation
- Provide richer customer account features on top of Medusa v2 native store APIs by adding address book metadata (labels + default), advanced order history filtering, persistent user preferences, and login history tracking. 
- Maintain project conventions: use `as any` for `container.resolve()` / `req.scope.resolve()` results, use `?` placeholders in `pgConnection.raw()`, and create tables with `CREATE TABLE IF NOT EXISTS`.

### Description
- Added enhanced address book endpoints at `/store/me/addresses` (GET/POST) and `/store/me/addresses/:id` (PATCH/DELETE) including `customer_address_metadata` bootstrap, label + `is_default` handling, max 10 address limit, and `customer.address_created` emission; new files: `src/api/store/me/addresses/route.ts` and `src/api/store/me/addresses/[id]/route.ts`.
- Added orders listing endpoint `/store/me/orders` (GET) with date/status/amount filtering, pagination and sorting implemented via parameterized SQL against the `"order"` table in `src/api/store/me/orders/route.ts`.
- Added preferences endpoints `/store/me/preferences` (GET/PATCH) with default values, table UPSERT behavior, and `customer.preferences_updated` event emission in `src/api/store/me/preferences/route.ts`.
- Added login history API `/store/me/login-history` (GET), a `loginTrackerMiddleware` for `/auth/customer/emailpass`, and a subscriber fallback for `auth.authenticated`, with table bootstrapping to persist IP/UA/status in `customer_login_history`; new files: `src/api/middlewares/login-tracker.ts` and `src/subscribers/login-tracker.ts` and `src/api/store/me/login-history/route.ts`.
- Registered all new routes by appending entries to the end of the `routes` array in `src/api/middlewares.ts` and imported `loginTrackerMiddleware` at the top of that file, while following the project's required access patterns (`const body = (req.body || {}) as any`).

### Testing
- Ran `npm run build` which failed because the `medusa` CLI is not available in the environment (`sh: 1: medusa: not found`).
- Ran `npx medusa build` which failed due to registry/network restrictions producing `403 Forbidden` when fetching Medusa packages from npm. 
- Ran `npx tsc --noEmit` which surfaced type-resolution errors for missing framework and Node type declarations in the container, indicating the environment lacks project dependencies so full type-check/build cannot complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af75f7991883338a73e1db2e814be0)