### PR TITLE
feat: payment methods, partial refunds, reconciliation, dead-letter queue & webhook retry

### DIFF
--- a/src/api/admin/payments/methods/route.ts
+++ b/src/api/admin/payments/methods/route.ts
@@ -1,0 +1,135 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+async function ensureMethodsTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS payment_methods_config (
+      id UUID PRIMARY KEY,
+      provider_id VARCHAR(64) UNIQUE NOT NULL,
+      display_name VARCHAR(128) NOT NULL,
+      is_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+      config_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+      priority INT NOT NULL DEFAULT 100,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`
+  )
+}
+
+async function seedDefaultMethod(pgConnection: any) {
+  const result = await pgConnection.raw(`SELECT COUNT(*)::int AS count FROM payment_methods_config`)
+  const count = Number(result?.rows?.[0]?.count || 0)
+  if (count > 0) {
+    return
+  }
+
+  await pgConnection.raw(
+    `INSERT INTO payment_methods_config
+      (id, provider_id, display_name, is_enabled, config_json, priority)
+     VALUES (?, ?, ?, ?, ?::jsonb, ?),
+            (?, ?, ?, ?, ?::jsonb, ?)`,
+    [
+      crypto.randomUUID(),
+      "stripe",
+      "Credit Card (Stripe)",
+      true,
+      JSON.stringify({}),
+      1,
+      crypto.randomUUID(),
+      "paypal",
+      "PayPal (Coming Soon)",
+      false,
+      JSON.stringify({ mode: "placeholder" }),
+      2,
+    ]
+  )
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  try {
+    await ensureMethodsTable(pgConnection)
+    await seedDefaultMethod(pgConnection)
+
+    const result = await pgConnection.raw(
+      `SELECT id, provider_id, display_name, is_enabled, config_json, priority, created_at, updated_at
+       FROM payment_methods_config
+       ORDER BY priority ASC, created_at ASC`
+    )
+
+    return res.status(200).json({ methods: result?.rows || [] })
+  } catch (err: any) {
+    logger.error(`[admin-payment-methods] GET error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to fetch payment methods" })
+  }
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  const body = (req.body || {}) as any
+  const providerId = String(body.provider_id || "").trim().toLowerCase()
+  const displayName = String(body.display_name || "").trim()
+  const isEnabled = Boolean(body.is_enabled)
+  const priority = Number.isFinite(Number(body.priority)) ? Number(body.priority) : 100
+  const config = body.config && typeof body.config === "object" ? body.config : {}
+
+  if (!providerId || !displayName) {
+    return res.status(400).json({ error: "provider_id and display_name are required" })
+  }
+
+  try {
+    await ensureMethodsTable(pgConnection)
+
+    const existing = await pgConnection.raw(
+      `SELECT id FROM payment_methods_config WHERE provider_id = ? LIMIT 1`,
+      [providerId]
+    )
+
+    if (existing?.rows?.length) {
+      await pgConnection.raw(
+        `UPDATE payment_methods_config
+         SET display_name = ?, is_enabled = ?, config_json = ?::jsonb, priority = ?, updated_at = NOW()
+         WHERE provider_id = ?`,
+        [displayName, isEnabled, JSON.stringify(config), priority, providerId]
+      )
+    } else {
+      await pgConnection.raw(
+        `INSERT INTO payment_methods_config
+          (id, provider_id, display_name, is_enabled, config_json, priority)
+         VALUES (?, ?, ?, ?, ?::jsonb, ?)`,
+        [crypto.randomUUID(), providerId, displayName, isEnabled, JSON.stringify(config), priority]
+      )
+    }
+
+    const result = await pgConnection.raw(
+      `SELECT id, provider_id, display_name, is_enabled, config_json, priority, created_at, updated_at
+       FROM payment_methods_config
+       WHERE provider_id = ?
+       LIMIT 1`,
+      [providerId]
+    )
+
+    const method = result?.rows?.[0] || null
+
+    await eventBus.emit("payment.method_updated", {
+      provider_id: providerId,
+      display_name: displayName,
+      is_enabled: isEnabled,
+      priority,
+      metadata: {
+        actor_id: (req as any).auth_context?.actor_id || null,
+        ip_address: req.ip || null,
+      },
+    })
+
+    return res.status(200).json({ method })
+  } catch (err: any) {
+    logger.error(`[admin-payment-methods] POST error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to upsert payment method" })
+  }
+}

--- a/src/api/admin/payments/reconciliation/route.ts
+++ b/src/api/admin/payments/reconciliation/route.ts
@@ -1,0 +1,95 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import Stripe from "stripe"
+
+function toMinorAmount(value: unknown) {
+  const amount = Number(value || 0)
+  return Number.isFinite(amount) ? Math.round(amount) : 0
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const query = req.query as any
+  const dateFrom = query.date_from ? String(query.date_from) : null
+  const dateTo = query.date_to ? String(query.date_to) : null
+
+  const stripeApiKey = process.env.STRIPE_API_KEY
+  if (!stripeApiKey) {
+    return res.status(500).json({ error: "STRIPE_API_KEY not configured" })
+  }
+
+  const stripe = new Stripe(stripeApiKey)
+
+  try {
+    const conditions = ["o.canceled_at IS NULL"]
+    const params: any[] = []
+
+    if (dateFrom) {
+      conditions.push("o.created_at >= ?::timestamptz")
+      params.push(dateFrom)
+    }
+
+    if (dateTo) {
+      conditions.push("o.created_at < (?::date + interval '1 day')")
+      params.push(dateTo)
+    }
+
+    const result = await pgConnection.raw(
+      `SELECT o.id AS order_id, o.payment_status, o.currency_code, o.total
+       FROM "order" o
+       WHERE ${conditions.join(" AND ")}
+       ORDER BY o.created_at DESC
+       LIMIT 100`,
+      params
+    )
+
+    const rows = result?.rows || []
+    const discrepancies: any[] = []
+    let matched = 0
+
+    for (const row of rows) {
+      const paymentResult = await pgConnection.raw(
+        `SELECT p.data
+         FROM payment p
+         WHERE p.payment_collection_id IN (
+           SELECT payment_collection_id FROM order_payment_collection WHERE order_id = ?
+         )
+         ORDER BY p.created_at DESC
+         LIMIT 1`,
+        [row.order_id]
+      )
+
+      const data = paymentResult?.rows?.[0]?.data || {}
+      const paymentIntentId = String(data.id || data.payment_intent || data.payment_intent_id || "")
+      if (!paymentIntentId) {
+        continue
+      }
+
+      const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId)
+      const localStatus = String(row.payment_status || "unknown")
+      const stripeStatus = String(paymentIntent.status || "unknown")
+
+      if (localStatus === stripeStatus) {
+        matched += 1
+      } else {
+        discrepancies.push({
+          order_id: row.order_id,
+          local_status: localStatus,
+          stripe_status: stripeStatus,
+          amount: toMinorAmount(row.total),
+        })
+      }
+    }
+
+    return res.status(200).json({
+      total_orders: rows.length,
+      matched,
+      discrepancies,
+    })
+  } catch (err: any) {
+    logger.error(`[admin-payment-reconciliation] GET error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to reconcile payments" })
+  }
+}

--- a/src/api/admin/refunds/route.ts
+++ b/src/api/admin/refunds/route.ts
@@ -1,0 +1,183 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import Stripe from "stripe"
+
+function toMinorUnit(amount: number) {
+  return Math.round(amount * 100)
+}
+
+async function ensureRefundTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS refund_records (
+      id UUID PRIMARY KEY,
+      order_id VARCHAR(64) NOT NULL,
+      payment_intent_id VARCHAR(128) NOT NULL,
+      stripe_refund_id VARCHAR(128),
+      amount INT NOT NULL,
+      currency_code VARCHAR(16) NOT NULL,
+      reason TEXT NOT NULL,
+      note TEXT,
+      status VARCHAR(32) NOT NULL,
+      ticket_id VARCHAR(64),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`
+  )
+}
+
+async function resolvePaymentIntentId(pgConnection: any, orderId: string) {
+  const result = await pgConnection.raw(
+    `SELECT p.data
+     FROM payment p
+     WHERE p.payment_collection_id IN (
+       SELECT opc.payment_collection_id
+       FROM order_payment_collection opc
+       WHERE opc.order_id = ?
+     )
+     ORDER BY p.created_at DESC
+     LIMIT 1`,
+    [orderId]
+  )
+
+  const data = result?.rows?.[0]?.data || {}
+  return String(data.id || data.payment_intent || data.payment_intent_id || "")
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const orderService = req.scope.resolve(Modules.ORDER) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  const body = (req.body || {}) as any
+  const orderId = String(body.order_id || "").trim()
+  const amountMajor = Number(body.amount || 0)
+  const reason = String(body.reason || "").trim()
+  const note = body.note ? String(body.note) : null
+  const ticketId = body.ticket_id ? String(body.ticket_id) : null
+
+  if (!orderId || !reason || !Number.isFinite(amountMajor) || amountMajor <= 0) {
+    return res.status(400).json({ error: "order_id, amount, reason are required" })
+  }
+
+  try {
+    await ensureRefundTable(pgConnection)
+
+    const order = await orderService.retrieveOrder(orderId)
+    if (!order) {
+      return res.status(404).json({ error: "Order not found" })
+    }
+
+    const paymentIntentId = await resolvePaymentIntentId(pgConnection, orderId)
+    if (!paymentIntentId) {
+      return res.status(400).json({ error: "No Stripe Payment Intent found for order" })
+    }
+
+    const stripeApiKey = process.env.STRIPE_API_KEY
+    if (!stripeApiKey) {
+      return res.status(500).json({ error: "STRIPE_API_KEY not configured" })
+    }
+
+    const stripe = new Stripe(stripeApiKey)
+    const refundResult = await stripe.refunds.create({
+      payment_intent: paymentIntentId,
+      amount: toMinorUnit(amountMajor),
+      reason: "requested_by_customer",
+      metadata: {
+        order_id: orderId,
+        note: note || "",
+      },
+    })
+
+    const id = crypto.randomUUID()
+    const currencyCode = String(refundResult.currency || order.currency_code || "usd")
+    const status = String(refundResult.status || "pending")
+
+    await pgConnection.raw(
+      `INSERT INTO refund_records
+        (id, order_id, payment_intent_id, stripe_refund_id, amount, currency_code, reason, note, status, ticket_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        orderId,
+        paymentIntentId,
+        refundResult.id,
+        toMinorUnit(amountMajor),
+        currencyCode,
+        reason,
+        note,
+        status,
+        ticketId,
+      ]
+    )
+
+    await eventBus.emit("refund.created", {
+      id,
+      order_id: orderId,
+      amount: toMinorUnit(amountMajor),
+      currency_code: currencyCode,
+      stripe_refund_id: refundResult.id,
+      status,
+      metadata: {
+        actor_id: (req as any).auth_context?.actor_id || null,
+        ip_address: req.ip || null,
+      },
+    })
+
+    return res.status(200).json({
+      refund: {
+        id,
+        order_id: orderId,
+        amount: toMinorUnit(amountMajor),
+        status,
+        stripe_refund_id: refundResult.id,
+      },
+    })
+  } catch (err: any) {
+    logger.error(`[admin-refunds] POST error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to create refund" })
+  }
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const query = req.query as any
+  const orderId = query.order_id ? String(query.order_id) : null
+  const limit = Math.min(200, Number.parseInt(String(query.limit || "50"), 10) || 50)
+  const offset = Number.parseInt(String(query.offset || "0"), 10) || 0
+
+  try {
+    await ensureRefundTable(pgConnection)
+
+    let sql = `SELECT * FROM refund_records WHERE 1=1`
+    const params: any[] = []
+
+    if (orderId) {
+      sql += ` AND order_id = ?`
+      params.push(orderId)
+    }
+
+    sql += ` ORDER BY created_at DESC LIMIT ? OFFSET ?`
+    params.push(limit, offset)
+
+    const result = await pgConnection.raw(sql, params)
+
+    let countSql = `SELECT COUNT(*)::int AS count FROM refund_records WHERE 1=1`
+    const countParams: any[] = []
+    if (orderId) {
+      countSql += ` AND order_id = ?`
+      countParams.push(orderId)
+    }
+
+    const countResult = await pgConnection.raw(countSql, countParams)
+
+    return res.status(200).json({
+      refunds: result?.rows || [],
+      count: Number(countResult?.rows?.[0]?.count || 0),
+    })
+  } catch (err: any) {
+    logger.error(`[admin-refunds] GET error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to query refunds" })
+  }
+}

--- a/src/api/admin/webhooks/dead-letter/route.ts
+++ b/src/api/admin/webhooks/dead-letter/route.ts
@@ -1,0 +1,107 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+async function ensureDeadLetterTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS webhook_dead_letter (
+      id UUID PRIMARY KEY,
+      provider VARCHAR(32) NOT NULL,
+      event_type VARCHAR(128) NOT NULL,
+      event_id VARCHAR(128) NOT NULL UNIQUE,
+      payload_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+      error_message TEXT,
+      retry_count INT NOT NULL DEFAULT 0,
+      last_retry_at TIMESTAMPTZ,
+      status VARCHAR(32) NOT NULL DEFAULT 'pending',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`
+  )
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const query = req.query as any
+  const status = query.status ? String(query.status) : null
+  const limit = Math.min(200, Number.parseInt(String(query.limit || "50"), 10) || 50)
+  const offset = Number.parseInt(String(query.offset || "0"), 10) || 0
+
+  try {
+    await ensureDeadLetterTable(pgConnection)
+
+    let sql = `SELECT * FROM webhook_dead_letter WHERE 1=1`
+    const params: any[] = []
+
+    if (status) {
+      sql += ` AND status = ?`
+      params.push(status)
+    }
+
+    sql += ` ORDER BY created_at DESC LIMIT ? OFFSET ?`
+    params.push(limit, offset)
+
+    const result = await pgConnection.raw(sql, params)
+
+    let countSql = `SELECT COUNT(*)::int AS count FROM webhook_dead_letter WHERE 1=1`
+    const countParams: any[] = []
+    if (status) {
+      countSql += ` AND status = ?`
+      countParams.push(status)
+    }
+
+    const countResult = await pgConnection.raw(countSql, countParams)
+
+    return res.status(200).json({
+      events: result?.rows || [],
+      count: Number(countResult?.rows?.[0]?.count || 0),
+    })
+  } catch (err: any) {
+    logger.error(`[admin-webhook-dead-letter] GET error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to fetch dead-letter events" })
+  }
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  const body = (req.body || {}) as any
+  const eventId = String(body.event_id || "").trim()
+
+  if (!eventId) {
+    return res.status(400).json({ error: "event_id is required" })
+  }
+
+  try {
+    await ensureDeadLetterTable(pgConnection)
+
+    const existing = await pgConnection.raw(
+      `SELECT * FROM webhook_dead_letter WHERE event_id = ? LIMIT 1`,
+      [eventId]
+    )
+
+    const eventRow = existing?.rows?.[0]
+    if (!eventRow) {
+      return res.status(404).json({ error: "Dead-letter event not found" })
+    }
+
+    const newRetryCount = Number(eventRow.retry_count || 0) + 1
+    const newStatus = newRetryCount >= 5 ? "exhausted" : "retrying"
+
+    await eventBus.emit(String(eventRow.event_type), eventRow.payload_json || {})
+
+    await pgConnection.raw(
+      `UPDATE webhook_dead_letter
+       SET retry_count = ?, last_retry_at = NOW(), status = ?
+       WHERE event_id = ?`,
+      [newRetryCount, newStatus, eventId]
+    )
+
+    return res.status(200).json({ retried: true, new_status: newStatus })
+  } catch (err: any) {
+    logger.error(`[admin-webhook-dead-letter] POST error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to retry dead-letter event" })
+  }
+}

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -233,5 +233,34 @@ export default defineMiddlewares({
       method: "POST",
       middlewares: [loginTrackerMiddleware],
     },
+    {
+      matcher: "/admin/payments/methods",
+      method: ["GET", "POST"],
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/store/payment-methods",
+      method: "GET",
+      middlewares: [
+        authenticate("customer", ["bearer", "session"], {
+          allowUnauthenticated: true,
+        }),
+      ],
+    },
+    {
+      matcher: "/admin/refunds",
+      method: ["GET", "POST"],
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/payments/reconciliation",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/webhooks/dead-letter",
+      method: ["GET", "POST"],
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
   ],
 })

--- a/src/api/store/payment-methods/route.ts
+++ b/src/api/store/payment-methods/route.ts
@@ -1,0 +1,38 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+async function ensureMethodsTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS payment_methods_config (
+      id UUID PRIMARY KEY,
+      provider_id VARCHAR(64) UNIQUE NOT NULL,
+      display_name VARCHAR(128) NOT NULL,
+      is_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+      config_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+      priority INT NOT NULL DEFAULT 100,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`
+  )
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as any
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  try {
+    await ensureMethodsTable(pgConnection)
+
+    const result = await pgConnection.raw(
+      `SELECT provider_id, display_name
+       FROM payment_methods_config
+       WHERE is_enabled = TRUE
+       ORDER BY priority ASC, created_at ASC`
+    )
+
+    return res.status(200).json({ payment_methods: result?.rows || [] })
+  } catch (err: any) {
+    logger.error(`[store-payment-methods] GET error: ${err.message}`)
+    return res.status(500).json({ error: "Failed to fetch payment methods" })
+  }
+}

--- a/src/jobs/payment-reconciliation.ts
+++ b/src/jobs/payment-reconciliation.ts
@@ -1,0 +1,95 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import Stripe from "stripe"
+
+async function ensureLogTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS payment_reconciliation_log (
+      id UUID PRIMARY KEY,
+      order_id VARCHAR(64) NOT NULL,
+      expected_status VARCHAR(64) NOT NULL,
+      actual_status VARCHAR(64) NOT NULL,
+      amount INT NOT NULL,
+      checked_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`
+  )
+}
+
+export default async function paymentReconciliationJob(container: MedusaContainer) {
+  const logger = container.resolve("logger") as any
+  const pgConnection = container.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = container.resolve(Modules.EVENT_BUS) as any
+
+  const stripeApiKey = process.env.STRIPE_API_KEY
+  if (!stripeApiKey) {
+    logger.error("[payment-reconciliation-job] STRIPE_API_KEY not configured")
+    return
+  }
+
+  const stripe = new Stripe(stripeApiKey)
+
+  try {
+    await ensureLogTable(pgConnection)
+
+    const ordersResult = await pgConnection.raw(
+      `SELECT o.id AS order_id, o.payment_status, o.total
+       FROM "order" o
+       WHERE o.canceled_at IS NULL
+         AND o.created_at >= NOW() - interval '24 hours'
+         AND o.status = 'completed'
+       ORDER BY o.created_at DESC
+       LIMIT 50`
+    )
+
+    const orders = ordersResult?.rows || []
+
+    for (const row of orders) {
+      const paymentResult = await pgConnection.raw(
+        `SELECT p.data
+         FROM payment p
+         WHERE p.payment_collection_id IN (
+           SELECT payment_collection_id FROM order_payment_collection WHERE order_id = ?
+         )
+         ORDER BY p.created_at DESC
+         LIMIT 1`,
+        [row.order_id]
+      )
+
+      const data = paymentResult?.rows?.[0]?.data || {}
+      const paymentIntentId = String(data.id || data.payment_intent || data.payment_intent_id || "")
+      if (!paymentIntentId) {
+        continue
+      }
+
+      const pi = await stripe.paymentIntents.retrieve(paymentIntentId)
+      const expectedStatus = String(row.payment_status || "unknown")
+      const actualStatus = String(pi.status || "unknown")
+
+      if (expectedStatus !== actualStatus) {
+        const logId = crypto.randomUUID()
+
+        await pgConnection.raw(
+          `INSERT INTO payment_reconciliation_log
+            (id, order_id, expected_status, actual_status, amount)
+           VALUES (?, ?, ?, ?, ?)`,
+          [logId, row.order_id, expectedStatus, actualStatus, Number(row.total || 0)]
+        )
+
+        await eventBus.emit("payment.reconciliation_alert", {
+          id: logId,
+          order_id: row.order_id,
+          expected_status: expectedStatus,
+          actual_status: actualStatus,
+          amount: Number(row.total || 0),
+        })
+      }
+    }
+  } catch (err: any) {
+    logger.error(`[payment-reconciliation-job] Error: ${err.message}`)
+  }
+}
+
+export const config = {
+  name: "payment-reconciliation",
+  schedule: "0 3 * * *",
+}

--- a/src/subscribers/payment-security-audit.ts
+++ b/src/subscribers/payment-security-audit.ts
@@ -1,0 +1,62 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+async function ensureAuditColumns(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS security_audit_log (
+      id BIGSERIAL PRIMARY KEY,
+      action VARCHAR(64) NOT NULL,
+      actor_id VARCHAR(128),
+      target_id VARCHAR(128),
+      resource VARCHAR(128),
+      metadata JSONB DEFAULT '{}'::jsonb,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`
+  )
+
+  await pgConnection.raw(`ALTER TABLE security_audit_log ADD COLUMN IF NOT EXISTS resource_type VARCHAR(128)`)
+  await pgConnection.raw(`ALTER TABLE security_audit_log ADD COLUMN IF NOT EXISTS resource_id VARCHAR(128)`)
+  await pgConnection.raw(`ALTER TABLE security_audit_log ADD COLUMN IF NOT EXISTS details_json JSONB DEFAULT '{}'::jsonb`)
+  await pgConnection.raw(`ALTER TABLE security_audit_log ADD COLUMN IF NOT EXISTS ip_address VARCHAR(128)`)
+}
+
+export default async function paymentSecurityAuditHandler({
+  event,
+  container,
+}: SubscriberArgs<Record<string, unknown>>) {
+  const logger = container.resolve("logger") as any
+  const pgConnection = container.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const eventName = String((event as any).name || "unknown")
+  const payload = (event.data || {}) as any
+  const metadata = (payload.metadata || {}) as any
+
+  try {
+    await ensureAuditColumns(pgConnection)
+
+    await pgConnection.raw(
+      `INSERT INTO security_audit_log
+        (action, actor_id, resource_type, resource_id, details_json, ip_address)
+       VALUES (?, ?, ?, ?, ?::jsonb, ?)`,
+      [
+        eventName,
+        metadata.actor_id || null,
+        "payment",
+        payload.id || payload.order_id || payload.provider_id || null,
+        JSON.stringify(payload),
+        metadata.ip_address || null,
+      ]
+    )
+  } catch (err: any) {
+    logger.error(`[payment-security-audit] Error writing audit log: ${err.message}`)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: [
+    "payment.captured",
+    "payment.refunded",
+    "refund.created",
+    "payment.method_updated",
+  ],
+}

--- a/src/subscribers/webhook-retry.ts
+++ b/src/subscribers/webhook-retry.ts
@@ -1,0 +1,106 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+const MAX_AUTO_RETRY = 3
+
+async function ensureDeadLetterTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS webhook_dead_letter (
+      id UUID PRIMARY KEY,
+      provider VARCHAR(32) NOT NULL,
+      event_type VARCHAR(128) NOT NULL,
+      event_id VARCHAR(128) NOT NULL UNIQUE,
+      payload_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+      error_message TEXT,
+      retry_count INT NOT NULL DEFAULT 0,
+      last_retry_at TIMESTAMPTZ,
+      status VARCHAR(32) NOT NULL DEFAULT 'pending',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`
+  )
+}
+
+export default async function webhookRetryHandler({
+  event,
+  container,
+}: SubscriberArgs<Record<string, unknown>>) {
+  const logger = container.resolve("logger") as any
+  const pgConnection = container.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = container.resolve(Modules.EVENT_BUS) as any
+
+  const payload = (event.data || {}) as any
+  const eventId = String(payload.event_id || payload.id || crypto.randomUUID())
+  const eventType = String(payload.event_type || "stripe.webhook.unknown")
+  const provider = String(payload.provider || "stripe")
+  const errorMessage = String(payload.error_message || "Webhook processing failed")
+  const retryCount = Number(payload.retry_count || 0)
+
+  try {
+    await ensureDeadLetterTable(pgConnection)
+
+    await pgConnection.raw(
+      `INSERT INTO webhook_dead_letter
+        (id, provider, event_type, event_id, payload_json, error_message, retry_count, status)
+       VALUES (?, ?, ?, ?, ?::jsonb, ?, ?, ?)
+       ON CONFLICT (event_id)
+       DO UPDATE SET
+         error_message = EXCLUDED.error_message,
+         payload_json = EXCLUDED.payload_json,
+         retry_count = webhook_dead_letter.retry_count + 1,
+         status = CASE
+           WHEN webhook_dead_letter.retry_count + 1 >= 5 THEN 'exhausted'
+           ELSE 'retrying'
+         END,
+         last_retry_at = NOW()`,
+      [
+        crypto.randomUUID(),
+        provider,
+        eventType,
+        eventId,
+        JSON.stringify(payload.payload || payload),
+        errorMessage,
+        retryCount,
+        retryCount >= 5 ? "exhausted" : "pending",
+      ]
+    )
+
+    if (retryCount < MAX_AUTO_RETRY) {
+      const delayMs = Math.pow(2, retryCount) * 1000
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+
+      await eventBus.emit(eventType, {
+        ...(payload.payload || payload),
+        retry_count: retryCount + 1,
+      })
+    }
+
+    const relayUrl = process.env.N8N_WEBHOOK_RELAY_URL || process.env.WEBHOOK_RELAY_URL
+    if (relayUrl) {
+      await fetch(relayUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(process.env.WEBHOOK_RELAY_SECRET
+            ? { "X-Webhook-Secret": process.env.WEBHOOK_RELAY_SECRET }
+            : {}),
+        },
+        body: JSON.stringify({
+          alert_type: "stripe_webhook_failed",
+          event_id: eventId,
+          event_type: eventType,
+          provider,
+          retry_count: retryCount,
+          error_message: errorMessage,
+          timestamp: new Date().toISOString(),
+        }),
+        signal: AbortSignal.timeout(10000),
+      })
+    }
+  } catch (err: any) {
+    logger.error(`[webhook-retry] Error handling failed webhook ${eventId}: ${err.message}`)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "stripe.webhook.failed",
+}


### PR DESCRIPTION
### Motivation
- Provide a central payment-methods API so admins can manage enabled providers and store can list available options for the frontend. 
- Add partial refund support and durable refund records so admins can issue refunds via Stripe and track them. 
- Improve webhook robustness with a dead-letter queue, automatic retry subscriber and manual retry endpoint to avoid lost Stripe events. 
- Add reconciliation and security-audit tooling to detect and log mismatches and record payment-related security events for investigation.

### Description
- Added admin payment methods endpoints at `src/api/admin/payments/methods/route.ts` with `payment_methods_config` table bootstrap, default seeds for Stripe + PayPal placeholder, and `payment.method_updated` event emission. 
- Added store-facing payment list endpoint at `src/api/store/payment-methods/route.ts` that returns enabled methods (no config payload) ordered by `priority`. 
- Implemented admin partial-refund endpoints at `src/api/admin/refunds/route.ts` that resolve Stripe PaymentIntent via DB, call `stripe.refunds.create`, persist to `refund_records`, and emit `refund.created`. 
- Implemented admin reconciliation endpoint at `src/api/admin/payments/reconciliation/route.ts` that compares local order payment status with Stripe PaymentIntent status (max 100 orders per request). 
- Implemented webhook dead-letter admin endpoints at `src/api/admin/webhooks/dead-letter/route.ts` and `src/subscribers/webhook-retry.ts` subscriber which persists failed webhooks into `webhook_dead_letter`, performs exponential backoff auto-retries, and relays alerts to n8n/Webhook relay. 
- Added `src/subscribers/payment-security-audit.ts` to write payment-related events into the `security_audit_log` (adds columns if missing). 
- Added scheduled reconciliation job `src/jobs/payment-reconciliation.ts` (cron `0 3 * * *`) to check past 24h completed orders (limit 50), write `payment_reconciliation_log`, and emit `payment.reconciliation_alert`. 
- Registered all new routes at the end of `src/api/middlewares.ts` using the requested authentication strategies. 
- Implementation follows constraints: `as any` for `container.resolve()` / `req.scope.resolve()` results, uses `?` for SQL placeholders in `pgConnection.raw()`, guards `req.body` as `const body = (req.body || {}) as any`, and uses `CREATE TABLE IF NOT EXISTS` for schema bootstrapping. 

### Testing
- Ran TypeScript type-check with `npx tsc --noEmit` which failed in this environment due to unresolved external `@medusajs/*` types and missing Node type definitions. 
- Ran `npm run build` which failed because the `medusa` CLI binary is not available in the execution environment; both failures are environmental and not related to the added code logic itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af760605a48333b21218255e967cd4)