### PR TITLE
C-040: optimize Docker build by skipping Admin dashboard compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,28 +2,32 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# 构建依赖
+# Build dependencies
 RUN apk add --no-cache python3 make g++ curl
 
-# 先复制依赖清单，利用 Docker 缓存层
+# Layer 1: dependencies (cached when package*.json unchanged)
 COPY package*.json ./
 
-# 安装依赖（优先 npm ci，失败则回退）
 RUN if [ -f package-lock.json ]; then \
       npm ci --legacy-peer-deps || npm install --legacy-peer-deps; \
     else \
       npm install --legacy-peer-deps; \
     fi
 
-# 复制源码
+# Layer 2: source code
 COPY . .
 
-# 编译 TypeScript → JavaScript (medusa build)
+# Layer 3: build backend only (skip Admin Vite compilation ~3-5 min)
+# medusa-config.ts reads DISABLE_MEDUSA_ADMIN to set admin.disable
+ENV DISABLE_MEDUSA_ADMIN=true
 RUN npx medusa build
 
-# 创建 admin 静态文件链接
+# Reset so admin is enabled at runtime
+ENV DISABLE_MEDUSA_ADMIN=false
+
+# Admin static files link (no-op if admin wasn't built, harmless)
 RUN mkdir -p /app/public && \
-    ln -sfn /app/.medusa/server/public/admin /app/public/admin
+    ln -sfn /app/.medusa/server/public/admin /app/public/admin 2>/dev/null || true
 
 EXPOSE 9000
 

--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -17,6 +17,9 @@ module.exports = defineConfig({
       cookieSecret: process.env.COOKIE_SECRET || "supersecret",
     },
   },
+  admin: {
+    disable: process.env.DISABLE_MEDUSA_ADMIN === "true",
+  },
   modules: [
     {
       resolve: "./src/modules/restock",


### PR DESCRIPTION
### Motivation
- Reduce Docker image build time on low-resource VPS by skipping compilation of the default Medusa Admin dashboard during image build, while keeping runtime/admin recovery options available.

### Description
- Add an `admin` config block to `medusa-config.ts` with `disable: process.env.DISABLE_MEDUSA_ADMIN === "true"` placed between `projectConfig` and `modules`, without changing existing configuration logic.
- Replace `Dockerfile` to install build dependencies, cache dependency installation, copy source, set `DISABLE_MEDUSA_ADMIN=true` for `npx medusa build`, then reset `DISABLE_MEDUSA_ADMIN=false` for runtime and create a safe admin static-files symlink that is a no-op if assets are absent.
- Do not change `.env`, `package.json`, `package-lock.json`, or `.dockerignore`.
- Documented recovery approach: rebuild admin once inside a running container with `docker exec <container> sh -c "npx medusa build --admin-only"`.

### Testing
- Ran `git diff --check` and it reported no whitespace or diff errors.
- Inspected the resulting diffs and file contents with `git show --stat` and `nl -ba` to verify the `admin` insertion in `medusa-config.ts` and the new `Dockerfile` content, and both matched the intended changes.
- No runtime builds were executed as part of these automated checks to avoid long local compilations, and validation is limited to static verification of the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af7d8c6f1c833390cca39c2919315f)