### PR TITLE
fix: 同步 Q-039 的 TS 类型修复

### DIFF
--- a/src/api/store/me/addresses/route.ts
+++ b/src/api/store/me/addresses/route.ts
@@ -41,7 +41,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
 
   return res.status(200).json({
     addresses: addresses.map((address: any) => {
-      const metadata = metadataMap.get(address.id)
+      const metadata = metadataMap.get(address.id) as any
       return {
         ...address,
         label: metadata?.label || null,
@@ -53,7 +53,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
 
 export async function POST(req: MedusaRequest, res: MedusaResponse) {
   const customerService = req.scope.resolve(Modules.CUSTOMER) as any
-  const eventBus = req.scope.resolve(ContainerRegistrationKeys.EVENT_BUS) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
   const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
 
   const customerId = (req as any).auth_context?.actor_id

--- a/src/api/store/me/preferences/route.ts
+++ b/src/api/store/me/preferences/route.ts
@@ -1,5 +1,5 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 
 const defaultPreferences = {
   language: "en",
@@ -58,7 +58,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
 
 export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
   const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
-  const eventBus = req.scope.resolve(ContainerRegistrationKeys.EVENT_BUS) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
 
   const customerId = (req as any).auth_context?.actor_id
   if (!customerId) {

--- a/src/jobs/low-stock-alert.ts
+++ b/src/jobs/low-stock-alert.ts
@@ -44,9 +44,7 @@ export default async function lowStockAlertJob(container: MedusaContainer) {
   const notificationService = container.resolve(Modules.NOTIFICATION) as unknown as {
     createNotifications: (data: Record<string, unknown>) => Promise<unknown>
   }
-  const eventBus = container.resolve(Modules.EVENT_BUS) as {
-    emit: (name: string, data: Record<string, unknown>) => Promise<void>
-  }
+  const eventBus = container.resolve(Modules.EVENT_BUS) as any
 
   logger.info("[low-stock-alert] Starting low stock check...")
 


### PR DESCRIPTION
### Motivation
- 同步已在 VPS 上为 Q-039 部署时手动修复的 3 处 TypeScript 类型问题到仓库以消除编译错误并保持代码一致性。 

### Description
- `src/jobs/low-stock-alert.ts`: 将 `eventBus` 的显式 `emit` 签名类型断言替换为更宽松的 `as any`。 
- `src/api/store/me/addresses/route.ts`: 将 `metadataMap.get(address.id)` 断言为 `as any`，并将 `eventBus` 的解析 key 从 `ContainerRegistrationKeys.EVENT_BUS` 改为 `Modules.EVENT_BUS`。 
- `src/api/store/me/preferences/route.ts`: 在 `utils` 导入中加入 `Modules`，并将 `eventBus` 的解析 key 从 `ContainerRegistrationKeys.EVENT_BUS` 改为 `Modules.EVENT_BUS`。 

### Testing
- 未在仓库中运行自动测试（按要求无需运行测试）。
- 已在 VPS 上通过 `docker build` 验证这些类型修复可以解决部署时的 TypeScript 编译错误并成功完成镜像构建。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af844b8470833382295944490b97ee)