### PR TITLE
feat: add /store/health endpoint and ENV.md documentation

### DIFF
--- a/ENV.md
+++ b/ENV.md
@@ -1,0 +1,23 @@
+# Environment Variables
+
+Below are the environment variables used by this backend for infrastructure and integrations.
+
+| Variable | Required | Default | Example |
+| --- | --- | --- | --- |
+| `DATABASE_URL` | Yes | None | `postgres://USER:PASSWORD@HOST:5432/DB_NAME` |
+| `REDIS_URL` | No | None (`/store/health` reports Redis as `skipped`) | `redis://:PASSWORD@HOST:6379` |
+| `STORE_CORS` | Yes | None | `http://localhost:8000,https://store.example.com` |
+| `ADMIN_CORS` | Yes | None | `http://localhost:9000` |
+| `AUTH_CORS` | Yes | None | `http://localhost:8000,https://store.example.com` |
+| `STRIPE_API_KEY` | Yes (if using Stripe payments) | None | `sk_test_xxx` |
+| `STRIPE_WEBHOOK_SECRET` | Yes (if using Stripe webhooks) | None | `whsec_xxx` |
+| `RESEND_API_KEY` | Yes (if using Resend email) | None | `re_xxx` |
+| `RESEND_FROM_EMAIL` | Yes (if using Resend email) | None | `NordHjem <noreply@example.com>` |
+| `WEBHOOK_RELAY_URL` | No | None | `https://n8n.example.com/webhook/order-events` |
+| `WEBHOOK_RELAY_SECRET` | No | None | `relay_secret_123` |
+| `DISABLE_MEDUSA_ADMIN` | No | `false` | `true` |
+
+## Notes
+- `DATABASE_URL` is mandatory for server startup.
+- `REDIS_URL` is optional; when unset, Redis-dependent checks and features should degrade gracefully.
+- `DISABLE_MEDUSA_ADMIN=true` disables Admin UI build output for backend-only deployments.

--- a/src/api/store/health/route.ts
+++ b/src/api/store/health/route.ts
@@ -1,0 +1,74 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+type HealthStatus = "ok" | "error"
+type RedisStatus = HealthStatus | "skipped"
+
+type RedisClient = {
+  ping: () => Promise<unknown>
+}
+
+type PgConnection = {
+  raw: (query: string) => Promise<unknown>
+}
+
+const APP_VERSION = "0.0.1"
+
+const resolveRedisClient = (req: MedusaRequest): RedisClient | null => {
+  const candidateKeys = ["redis", "redisClient", ContainerRegistrationKeys.CACHE]
+
+  for (const key of candidateKeys) {
+    try {
+      const candidate = req.scope.resolve(key) as Partial<RedisClient>
+      if (candidate && typeof candidate.ping === "function") {
+        return candidate as RedisClient
+      }
+    } catch {
+      continue
+    }
+  }
+
+  return null
+}
+
+const checkDatabase = async (req: MedusaRequest): Promise<HealthStatus> => {
+  try {
+    const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as PgConnection
+    await pgConnection.raw("SELECT 1")
+    return "ok"
+  } catch {
+    return "error"
+  }
+}
+
+const checkRedis = async (req: MedusaRequest): Promise<RedisStatus> => {
+  if (!process.env.REDIS_URL) {
+    return "skipped"
+  }
+
+  try {
+    const redisClient = resolveRedisClient(req)
+    if (!redisClient) {
+      return "error"
+    }
+
+    await redisClient.ping()
+    return "ok"
+  } catch {
+    return "error"
+  }
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const [database, redis] = await Promise.all([checkDatabase(req), checkRedis(req)])
+
+  return res.status(200).json({
+    status: "ok",
+    version: APP_VERSION,
+    timestamp: new Date().toISOString(),
+    checks: {
+      database,
+      redis,
+    },
+  })
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight health check endpoint for monitoring that reports app status, version, timestamp, and dependency checks.
- Surface database and optional Redis health so orchestrators or load balancers can make informed decisions.
- Consolidate environment variable documentation into a single `ENV.md` for onboarding and deployments.

### Description
- Added a new TypeScript route `GET /store/health` at `src/api/store/health/route.ts` which returns `status`, `version` (`0.0.1`), ISO8601 `timestamp`, and `checks` object containing `database` and `redis` statuses.
- Implemented `database` check by resolving the Medusa Postgres connection from the request scope and executing a lightweight query (`SELECT 1`).
- Implemented `redis` check which returns `skipped` when `REDIS_URL` is not set, otherwise attempts to resolve a Redis client from scope (keys: `redis`, `redisClient`, `ContainerRegistrationKeys.CACHE`) and calls `ping()` to return `ok` or `error`.
- Added `ENV.md` at the repository root documenting required and optional environment variables (`DATABASE_URL`, `REDIS_URL`, `STORE_CORS`, `ADMIN_CORS`, `AUTH_CORS`, `STRIPE_*`, `RESEND_*`, `WEBHOOK_RELAY_*`, `DISABLE_MEDUSA_ADMIN`) with requiredness, defaults, and examples.

### Testing
- Ran `npm run build` which failed in this environment because the `medusa` CLI binary is not available (observed `medusa: not found`).
- Ran `npx tsc --noEmit` which failed due to missing project dependencies/type declarations in the environment (multiple `Cannot find module` / missing `@types/node` errors).
- No automated unit tests were added in this PR; the changes are small and focused on a new HTTP route and documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0211115348333a10f9ba3ee4b2d33)