### PR TITLE
feat(orders): add advanced filters, stats summary, and order notes for Q-041 M4

### DIFF
--- a/src/api/admin/orders/[id]/notes/route.ts
+++ b/src/api/admin/orders/[id]/notes/route.ts
@@ -1,0 +1,64 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules, ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+const CREATE_TABLE_SQL = `
+  CREATE TABLE IF NOT EXISTS order_note (
+    id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    order_id TEXT NOT NULL,
+    content TEXT NOT NULL,
+    author TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    metadata JSONB DEFAULT '{}'
+  )
+`
+
+async function ensureOrderNoteTable(pgConnection: any) {
+  await pgConnection.raw(CREATE_TABLE_SQL)
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const orderId = req.params.id
+
+  await ensureOrderNoteTable(pgConnection)
+
+  const result = await pgConnection.raw(
+    `SELECT id, order_id, content, author, created_at, metadata
+     FROM order_note
+     WHERE order_id = ?
+     ORDER BY created_at DESC`,
+    [orderId]
+  )
+
+  return res.status(200).json({ notes: result?.rows || [] })
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+  const orderId = req.params.id
+
+  const { content, author, metadata = {} } = (req.body || {}) as Record<string, any>
+
+  if (!content || !author) {
+    return res.status(400).json({ error: "content and author are required" })
+  }
+
+  await ensureOrderNoteTable(pgConnection)
+
+  const insertResult = await pgConnection.raw(
+    `INSERT INTO order_note (order_id, content, author, metadata)
+     VALUES (?, ?, ?, ?::jsonb)
+     RETURNING id, order_id, content, author, created_at, metadata`,
+    [orderId, content, author, JSON.stringify(metadata || {})]
+  )
+
+  const note = insertResult?.rows?.[0]
+
+  await eventBus.emit("order.note.created", {
+    order_id: orderId,
+    note,
+  })
+
+  return res.status(201).json({ note })
+}

--- a/src/api/admin/orders/route.ts
+++ b/src/api/admin/orders/route.ts
@@ -1,0 +1,84 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const query = (req.query || {}) as Record<string, any>
+  const limit = Math.min(Number(query.limit) || 20, 100)
+  const offset = Math.max(Number(query.offset) || 0, 0)
+
+  const sortBy = query.sort_by === "total" ? "total" : "created_at"
+  const sortOrder = String(query.sort_order || "desc").toLowerCase() === "asc" ? "ASC" : "DESC"
+
+  const statusAllowList = ["pending", "completed", "canceled", "archived", "requires_action"]
+
+  const conditions: string[] = []
+  const params: any[] = []
+
+  if (query.date_from) {
+    conditions.push("o.created_at >= ?::timestamptz")
+    params.push(query.date_from)
+  }
+
+  if (query.date_to) {
+    conditions.push("o.created_at < (?::date + interval '1 day')")
+    params.push(query.date_to)
+  }
+
+  if (query.status && statusAllowList.includes(String(query.status))) {
+    conditions.push("o.status = ?")
+    params.push(query.status)
+  }
+
+  const minAmount = query.amount_min ?? query.min_amount
+  if (minAmount !== undefined && minAmount !== "") {
+    conditions.push("COALESCE((o.raw_total->>'value')::numeric, o.total, 0) >= ?")
+    params.push(Number(minAmount))
+  }
+
+  const maxAmount = query.amount_max ?? query.max_amount
+  if (maxAmount !== undefined && maxAmount !== "") {
+    conditions.push("COALESCE((o.raw_total->>'value')::numeric, o.total, 0) <= ?")
+    params.push(Number(maxAmount))
+  }
+
+  if (query.customer_id) {
+    conditions.push("o.customer_id = ?")
+    params.push(String(query.customer_id))
+  }
+
+  if (query.product_id) {
+    conditions.push(
+      `EXISTS (
+        SELECT 1
+        FROM order_line_item oli
+        WHERE oli.order_id = o.id
+          AND oli.product_id = ?
+      )`
+    )
+    params.push(String(query.product_id))
+  }
+
+  const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""
+
+  const countResult = await pgConnection.raw(
+    `SELECT COUNT(*)::int AS count FROM "order" o ${whereClause}`,
+    params
+  )
+
+  const listResult = await pgConnection.raw(
+    `SELECT o.* FROM "order" o
+     ${whereClause}
+     ORDER BY o.${sortBy === "total" ? "total" : "created_at"} ${sortOrder}
+     LIMIT ? OFFSET ?`,
+    [...params, limit, offset]
+  )
+
+  return res.status(200).json({
+    orders: listResult.rows || [],
+    count: countResult.rows?.[0]?.count || 0,
+    limit,
+    offset,
+  })
+}

--- a/src/api/admin/orders/stats/route.ts
+++ b/src/api/admin/orders/stats/route.ts
@@ -1,0 +1,40 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules, ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+async function getRangeStats(pgConnection: any, range: string) {
+  const result = await pgConnection.raw(
+    `SELECT
+      COUNT(*)::int AS count,
+      COALESCE(SUM(COALESCE((o.raw_total->>'value')::numeric, o.total, 0)), 0) AS gmv,
+      COALESCE(AVG(COALESCE((o.raw_total->>'value')::numeric, o.total, 0)), 0) AS avg_order_value
+     FROM "order" o
+     WHERE o.created_at >= ${range}
+       AND o.created_at <= now()`
+  )
+
+  const row = result?.rows?.[0] || {}
+  return {
+    count: Number(row.count || 0),
+    gmv: Number(row.gmv || 0),
+    avg_order_value: Number(row.avg_order_value || 0),
+  }
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  const today = await getRangeStats(pgConnection, "date_trunc('day', now())")
+  const thisWeek = await getRangeStats(pgConnection, "date_trunc('week', now())")
+  const thisMonth = await getRangeStats(pgConnection, "date_trunc('month', now())")
+
+  const payload = {
+    today,
+    this_week: thisWeek,
+    this_month: thisMonth,
+  }
+
+  await eventBus.emit("order.stats.generated", payload)
+
+  return res.status(200).json(payload)
+}

--- a/src/subscribers/order-notes-events.ts
+++ b/src/subscribers/order-notes-events.ts
@@ -1,0 +1,51 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+
+export default async function orderNotesEventsHandler({
+  event,
+  container,
+}: SubscriberArgs<Record<string, unknown>>) {
+  const webhookUrl = process.env.WEBHOOK_RELAY_URL
+  if (!webhookUrl) {
+    return
+  }
+
+  const logger = container.resolve("logger") as {
+    info: (m: string) => void
+    error: (m: string) => void
+  }
+
+  const eventName = (event as any).name || "unknown"
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-NordHjem-Event": eventName,
+        ...(process.env.WEBHOOK_RELAY_SECRET
+          ? { "X-Webhook-Secret": process.env.WEBHOOK_RELAY_SECRET }
+          : {}),
+      },
+      body: JSON.stringify({
+        event: eventName,
+        data: event.data,
+        timestamp: new Date().toISOString(),
+        source: "nordhjem-medusa",
+      }),
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) {
+      logger.error(`[order-notes-events] Failed to relay ${eventName}: HTTP ${response.status}`)
+    } else {
+      logger.info(`[order-notes-events] Relayed ${eventName} → ${response.status}`)
+    }
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : JSON.stringify(error)
+    logger.error(`[order-notes-events] Error relaying ${eventName}: ${errMsg}`)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: ["order.note.created", "order.stats.generated"],
+}


### PR DESCRIPTION
### Motivation
- Provide richer admin order tooling by adding advanced list filters, a lightweight stats summary, and per-order notes to support Q-041 M4 requirements.
- Emit order-related events for downstream integrations and relay them to an external webhook via the existing webhook relay pattern.
- Use direct `pgConnection.raw()` SQL for aggregation and a simple `order_note` table to keep the implementation small and DB-centric.

### Description
- Added `GET /admin/orders` at `src/api/admin/orders/route.ts` with dynamic `WHERE` clause composition and new filters `amount_min`/`amount_max` (with `raw_total` fallback), `product_id`, and `customer_id`, while preserving pagination, sort, date range and status behavior.
- Added `GET /admin/orders/stats` at `src/api/admin/orders/stats/route.ts` which aggregates `count`, `gmv`, and `avg_order_value` for `today`, `this_week`, and `this_month` using `pgConnection.raw()` and emits the `order.stats.generated` event.
- Added `GET`/`POST /admin/orders/:id/notes` at `src/api/admin/orders/[id]/notes/route.ts` which ensures an `order_note` table exists (SQL creation included), stores notes `{ content, author, metadata }`, returns notes ordered by `created_at DESC`, and emits `order.note.created` on creation.
- Added a subscriber `src/subscribers/order-notes-events.ts` that listens for `order.note.created` and `order.stats.generated` and relays events to `process.env.WEBHOOK_RELAY_URL` following the repository's webhook relay pattern.

### Testing
- Ran TypeScript compile check via `npx tsc --noEmit`, which failed in this environment due to missing project dependencies/type declarations not introduced by these changes.
- No other repository-level automated tests were executed in this environment; files were added and committed (`feat/q041-m4-orders-final`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0c46eb1a48333b38ea6d322f743b8)