### PR TITLE
feat(inventory): add turnover rate and inventory report APIs for Q-041 M13a

### DIFF
--- a/src/api/admin/inventory/report/route.ts
+++ b/src/api/admin/inventory/report/route.ts
@@ -1,0 +1,103 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+function toNum(value: unknown, fallback = 0): number {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: any[]) => Promise<{ rows?: any[] }>
+  }
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as {
+    emit: (eventName: string, data: Record<string, unknown>) => Promise<void>
+  }
+
+  const query = `
+    WITH inventory_by_item AS (
+      SELECT
+        il.inventory_item_id,
+        SUM(COALESCE(il.stocked_quantity, 0))::numeric AS total_stock,
+        MAX(COALESCE((il.metadata->>'low_stock_threshold')::numeric, 10)) AS threshold
+      FROM inventory_level il
+      GROUP BY il.inventory_item_id
+    ),
+    sku_stats AS (
+      SELECT
+        COUNT(*)::numeric AS total_items,
+        SUM(CASE WHEN COALESCE(ibi.total_stock, 0) = 0 THEN 1 ELSE 0 END)::numeric AS stockout_items,
+        SUM(CASE WHEN COALESCE(ibi.total_stock, 0) < COALESCE(ibi.threshold, 10) THEN 1 ELSE 0 END)::numeric AS below_threshold_items
+      FROM inventory_by_item ibi
+    ),
+    sales_by_product AS (
+      SELECT
+        li.product_id,
+        SUM(COALESCE(li.quantity, 0))::numeric AS sold_quantity
+      FROM order_line_item li
+      JOIN "order" o ON o.id = li.order_id
+      WHERE o.canceled_at IS NULL
+      GROUP BY li.product_id
+    ),
+    inventory_by_product AS (
+      SELECT
+        pv.product_id,
+        AVG(COALESCE(il.stocked_quantity, 0))::numeric AS avg_inventory
+      FROM product_variant_inventory_item pvii
+      JOIN product_variant pv ON pv.id = pvii.variant_id
+      JOIN inventory_level il ON il.inventory_item_id = pvii.inventory_item_id
+      GROUP BY pv.product_id
+    ),
+    turnover AS (
+      SELECT
+        COALESCE(SUM(
+          CASE WHEN COALESCE(ibp.avg_inventory, 0) = 0 THEN 0
+               ELSE COALESCE(sbp.sold_quantity, 0) / NULLIF(ibp.avg_inventory, 0)
+          END
+        ) / NULLIF(COUNT(*), 0), 0)::numeric AS avg_turnover_rate
+      FROM inventory_by_product ibp
+      LEFT JOIN sales_by_product sbp ON sbp.product_id = ibp.product_id
+    )
+    SELECT
+      COALESCE(SUM(ibi.total_stock * COALESCE(ii.unit_cost, 0)), 0)::numeric AS total_inventory_value,
+      COALESCE(ss.stockout_items / NULLIF(ss.total_items, 0), 0)::numeric AS stockout_rate,
+      CASE
+        WHEN COALESCE(t.avg_turnover_rate, 0) = 0 THEN 0
+        ELSE ROUND(365 / t.avg_turnover_rate, 2)
+      END AS avg_turnover_days,
+      COALESCE(ss.below_threshold_items, 0)::int AS items_below_threshold,
+      COALESCE(ss.total_items, 0)::int AS total_items
+    FROM inventory_by_item ibi
+    LEFT JOIN inventory_item ii ON ii.id = ibi.inventory_item_id
+    CROSS JOIN sku_stats ss
+    CROSS JOIN turnover t
+  `
+
+  let row: any
+  try {
+    const result = await pgConnection.raw(query)
+    row = result?.rows?.[0] || {}
+  } catch (err: any) {
+    return res.status(500).json({ error: "Failed to generate inventory report", message: err?.message })
+  }
+
+  const report = {
+    total_inventory_value: toNum(row.total_inventory_value),
+    stockout_rate: toNum(row.stockout_rate),
+    avg_turnover_days: toNum(row.avg_turnover_days),
+    items_below_threshold: toNum(row.items_below_threshold),
+    total_items: toNum(row.total_items),
+    metadata: {},
+  }
+
+  try {
+    await eventBus.emit("inventory.report.generated", {
+      ...report,
+      generated_at: new Date().toISOString(),
+    })
+  } catch {
+    // optional event
+  }
+
+  return res.status(200).json(report)
+}

--- a/src/api/admin/inventory/turnover/route.ts
+++ b/src/api/admin/inventory/turnover/route.ts
@@ -1,0 +1,131 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+type TurnoverRow = {
+  product_id: string
+  product_title: string
+  sold_quantity: number
+  avg_inventory: number
+  turnover_rate: number
+}
+
+function toNum(value: unknown, fallback = 0): number {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: any[]) => Promise<{ rows?: any[] }>
+  }
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as {
+    emit: (eventName: string, data: Record<string, unknown>) => Promise<void>
+  }
+
+  const {
+    start_date,
+    end_date,
+    product_id,
+    category_id,
+  } = req.query as Record<string, string | undefined>
+
+  const periodStart = start_date || new Date(new Date().setDate(new Date().getDate() - 30)).toISOString()
+  const periodEnd = end_date || new Date().toISOString()
+
+  const conditions = [
+    "o.canceled_at IS NULL",
+    "o.created_at >= ?::timestamptz",
+    "o.created_at <= ?::timestamptz",
+  ]
+  const params: any[] = [periodStart, periodEnd]
+
+  if (product_id) {
+    conditions.push("li.product_id = ?")
+    params.push(product_id)
+  }
+
+  if (category_id) {
+    conditions.push(
+      "EXISTS (SELECT 1 FROM product_category_product pcp WHERE pcp.product_id = li.product_id AND pcp.product_category_id = ?)"
+    )
+    params.push(category_id)
+  }
+
+  const query = `
+    WITH sold AS (
+      SELECT
+        li.product_id,
+        MAX(li.title) AS product_title,
+        SUM(COALESCE(li.quantity, 0))::numeric AS sold_quantity
+      FROM order_line_item li
+      JOIN "order" o ON o.id = li.order_id
+      WHERE ${conditions.join(" AND ")}
+      GROUP BY li.product_id
+    ),
+    inventory AS (
+      SELECT
+        pv.product_id,
+        AVG(COALESCE(il.stocked_quantity, 0))::numeric AS avg_inventory
+      FROM product_variant_inventory_item pvii
+      JOIN product_variant pv ON pv.id = pvii.variant_id
+      JOIN inventory_level il ON il.inventory_item_id = pvii.inventory_item_id
+      GROUP BY pv.product_id
+    )
+    SELECT
+      COALESCE(s.product_id, i.product_id) AS product_id,
+      COALESCE(s.product_title, p.title, '') AS product_title,
+      COALESCE(s.sold_quantity, 0) AS sold_quantity,
+      COALESCE(i.avg_inventory, 0) AS avg_inventory,
+      CASE
+        WHEN COALESCE(i.avg_inventory, 0) = 0 THEN 0
+        ELSE ROUND(COALESCE(s.sold_quantity, 0) / NULLIF(i.avg_inventory, 0), 4)
+      END AS turnover_rate
+    FROM sold s
+    FULL OUTER JOIN inventory i ON s.product_id = i.product_id
+    LEFT JOIN product p ON p.id = COALESCE(s.product_id, i.product_id)
+    ${product_id ? "WHERE COALESCE(s.product_id, i.product_id) = ?" : ""}
+    ORDER BY turnover_rate DESC, sold_quantity DESC
+  `
+
+  const queryParams = product_id ? [...params, product_id] : params
+
+  try {
+    const result = await pgConnection.raw(query, queryParams)
+    const items: TurnoverRow[] = (result?.rows || []).map((row) => ({
+      product_id: String(row.product_id || ""),
+      product_title: String(row.product_title || ""),
+      sold_quantity: toNum(row.sold_quantity),
+      avg_inventory: toNum(row.avg_inventory),
+      turnover_rate: toNum(row.turnover_rate),
+    }))
+
+    try {
+      await eventBus.emit("inventory.turnover.calculated", {
+        period_start: periodStart,
+        period_end: periodEnd,
+        product_id: product_id || null,
+        category_id: category_id || null,
+        count: items.length,
+      })
+    } catch {
+      // optional event
+    }
+
+    return res.status(200).json({
+      items,
+      period_start: periodStart,
+      period_end: periodEnd,
+    })
+  } catch (err: any) {
+    if (err?.message?.includes("order_line_item") && err?.message?.includes("does not exist")) {
+      return res.status(200).json({
+        items: [],
+        period_start: periodStart,
+        period_end: periodEnd,
+        note: "order_line_item table not found",
+      })
+    }
+
+    return res.status(500).json({ error: "Failed to calculate inventory turnover" })
+  }
+}

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -153,6 +153,16 @@ export default defineMiddlewares({
       middlewares: [authenticate("user", ["bearer", "session"])],
     },
     {
+      matcher: "/admin/inventory/turnover",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/inventory/report",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
       matcher: "/admin/orders/export",
       method: "GET",
       middlewares: [authenticate("user", ["bearer", "session"])],

--- a/src/subscribers/inventory-report-events.ts
+++ b/src/subscribers/inventory-report-events.ts
@@ -1,0 +1,54 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+
+export default async function inventoryReportEventsSubscriber({
+  event,
+  container,
+}: SubscriberArgs<Record<string, unknown>>) {
+  const relayUrl = process.env.WEBHOOK_RELAY_URL
+  if (!relayUrl) {
+    return
+  }
+
+  const logger = container.resolve("logger") as {
+    info: (msg: string) => void
+    error: (msg: string) => void
+  }
+
+  const eventName = (event as any)?.name || "unknown"
+
+  try {
+    const response = await fetch(relayUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-NordHjem-Event": eventName,
+        ...(process.env.WEBHOOK_RELAY_SECRET
+          ? { "X-Webhook-Secret": process.env.WEBHOOK_RELAY_SECRET }
+          : {}),
+      },
+      body: JSON.stringify({
+        event: eventName,
+        data: (event as any)?.data || {},
+        source: "nordhjem-medusa",
+        timestamp: new Date().toISOString(),
+      }),
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) {
+      logger.error(
+        `[inventory-report-events] Failed to relay ${eventName}: HTTP ${response.status}`
+      )
+      return
+    }
+
+    logger.info(`[inventory-report-events] Relayed ${eventName}: HTTP ${response.status}`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : JSON.stringify(error)
+    logger.error(`[inventory-report-events] Error relaying ${eventName}: ${message}`)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: ["inventory.turnover.calculated", "inventory.report.generated"],
+}


### PR DESCRIPTION
### Motivation
- Provide admin APIs to measure inventory performance (turnover) and a high-level inventory report to support analytics and operational monitoring.
- Allow filtering turnover calculations by period, product, and category to support targeted analysis and reporting needs.
- Emit analytic events so external systems can react to generated reports and turnover calculations via an existing webhook relay.

### Description
- Added `GET /admin/inventory/turnover` handler at `src/api/admin/inventory/turnover/route.ts` which aggregates orders and inventory via `pgConnection.raw()` to compute `sold_quantity`, `avg_inventory`, and `turnover_rate`, and returns `{ items, period_start, period_end }` while emitting `inventory.turnover.calculated`.
- Added `GET /admin/inventory/report` handler at `src/api/admin/inventory/report/route.ts` which aggregates inventory and sales to return `{ total_inventory_value, stockout_rate, avg_turnover_days, items_below_threshold, total_items, metadata }` and emits `inventory.report.generated`.
- Added subscriber `src/subscribers/inventory-report-events.ts` to forward both `inventory.turnover.calculated` and `inventory.report.generated` events to `process.env.WEBHOOK_RELAY_URL` with optional secret header support.
- Registered admin auth middleware entries for the new endpoints by updating `src/api/middlewares.ts` to require `authenticate("user", ["bearer", "session"])` for `GET /admin/inventory/turnover` and `GET /admin/inventory/report`.

### Testing
- Ran `npm run build`, which failed in this environment with `medusa: not found` because the Medusa CLI/runtime is not present. (expected in CI-free local sandbox)
- Ran `npx tsc --noEmit`, which reported repository-wide type resolution errors due to missing installed dependencies/type packages; the new files themselves compile logically but full typecheck failed in this environment.
- No additional automated tests were present or run for these endpoints in this environment; changes were committed on branch `feat/q041-m13a-inventory-final`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0c488ab588333939c7baa5cf22ed7)