### PR TITLE
feat(security): enhance audit logging with global middleware and advanced filters for Q-041 M18a

### DIFF
--- a/src/api/admin/security/audit-logs/route.ts
+++ b/src/api/admin/security/audit-logs/route.ts
@@ -8,52 +8,74 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   }
 
   const query = req.query as Record<string, string | undefined>
-  const action = query.action
+  const actionType = query.action_type
   const actorId = query.actor_id
-  const date = query.date
+  const startDate = query.start_date
+  const endDate = query.end_date
+  const resource = query.resource
   const limit = Number.parseInt(query.limit || "50", 10) || 50
   const offset = Number.parseInt(query.offset || "0", 10) || 0
 
   try {
     await pgConnection.raw(
-      `CREATE TABLE IF NOT EXISTS security_audit_log (
-        id BIGSERIAL PRIMARY KEY,
-        action VARCHAR(64) NOT NULL,
-        actor_id VARCHAR(128),
-        target_id VARCHAR(128),
-        resource VARCHAR(128),
-        metadata JSONB DEFAULT '{}'::jsonb,
-        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      `CREATE TABLE IF NOT EXISTS audit_log (
+        id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+        action_type TEXT NOT NULL,
+        resource TEXT NOT NULL,
+        resource_id TEXT,
+        actor_id TEXT,
+        timestamp TIMESTAMPTZ DEFAULT now(),
+        request_body_summary TEXT,
+        metadata JSONB DEFAULT '{}'
       )`
     )
 
-    let sql = `SELECT * FROM security_audit_log WHERE 1=1`
-    const params: unknown[] = []
+    let whereSql = ` WHERE 1=1`
+    const whereParams: unknown[] = []
 
-    if (action) {
-      sql += ` AND action = ?`
-      params.push(action)
+    if (actionType) {
+      whereSql += ` AND action_type = ?`
+      whereParams.push(actionType)
     }
 
     if (actorId) {
-      sql += ` AND actor_id = ?`
-      params.push(actorId)
+      whereSql += ` AND actor_id = ?`
+      whereParams.push(actorId)
     }
 
-    if (date) {
-      sql += ` AND DATE(created_at) = ?`
-      params.push(date)
+    if (resource) {
+      whereSql += ` AND resource LIKE ?`
+      whereParams.push(`%${resource}%`)
     }
 
-    sql += ` ORDER BY created_at DESC LIMIT ? OFFSET ?`
-    params.push(limit, offset)
+    if (startDate) {
+      whereSql += ` AND timestamp >= ?::timestamptz`
+      whereParams.push(startDate)
+    }
 
-    const result = await pgConnection.raw(sql, params)
+    if (endDate) {
+      whereSql += ` AND timestamp <= ?::timestamptz`
+      whereParams.push(endDate)
+    }
+
+    const listResult = await pgConnection.raw(
+      `SELECT * FROM audit_log ${whereSql} ORDER BY timestamp DESC LIMIT ? OFFSET ?`,
+      [...whereParams, limit, offset]
+    )
+
+    const totalResult = await pgConnection.raw(
+      `SELECT COUNT(*)::int AS total FROM audit_log ${whereSql}`,
+      whereParams
+    )
+
+    const total = Number((totalResult.rows?.[0] as { total?: number } | undefined)?.total || 0)
 
     return res.status(200).json({
-      logs: result?.rows || [],
-      limit,
+      audit_logs: listResult?.rows || [],
+      total,
       offset,
+      limit,
+      metadata: {},
     })
   } catch (err: any) {
     logger.error(`[security-audit-logs] GET error: ${err.message}`)

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -3,6 +3,7 @@ import { securityAuditMiddleware } from "./middlewares/security-audit"
 import { stripeWebhookAuditMiddleware } from "./middlewares/stripe-webhook-audit"
 import { loginTrackerMiddleware } from "./middlewares/login-tracker"
 import { brandContextMiddleware } from "./middlewares/brand-context"
+import { adminAuditLogMiddleware } from "./middlewares/admin-audit-log"
 import { StoreCreateRestockSubscription } from "./store/restock-subscriptions/validators"
 
 export default defineMiddlewares({
@@ -10,6 +11,11 @@ export default defineMiddlewares({
     {
       matcher: "/store/*",
       middlewares: [brandContextMiddleware],
+    },
+    {
+      matcher: "/admin/*",
+      method: ["POST", "PATCH", "DELETE"],
+      middlewares: [adminAuditLogMiddleware],
     },
     {
       matcher: "/admin/brands",

--- a/src/api/middlewares/admin-audit-log.ts
+++ b/src/api/middlewares/admin-audit-log.ts
@@ -1,0 +1,92 @@
+import type {
+  MedusaNextFunction,
+  MedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+function extractResourceId(req: MedusaRequest): string | null {
+  const paramId = (req.params as Record<string, string | undefined> | undefined)?.id
+  if (paramId) {
+    return paramId
+  }
+
+  const path = req.path || ""
+  const segments = path.split("/").filter(Boolean)
+
+  if (segments.length < 3) {
+    return null
+  }
+
+  const lastSegment = segments[segments.length - 1]
+  if (["admin", "store"].includes(lastSegment)) {
+    return null
+  }
+
+  return lastSegment
+}
+
+export async function adminAuditLogMiddleware(
+  req: MedusaRequest,
+  res: MedusaResponse,
+  next: MedusaNextFunction
+) {
+  const logger = req.scope.resolve("logger") as { error: (message: string) => void }
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
+    raw: (query: string, params?: unknown[]) => Promise<{ rows?: Record<string, unknown>[] }>
+  }
+
+  const method = (req.method || "").toUpperCase()
+  const actorId = (req as Record<string, any>).auth_context?.actor_id ?? null
+  const resourcePath = req.path || ""
+  const resourceId = extractResourceId(req)
+  const requestBodySummary = JSON.stringify(req.body ?? {}).substring(0, 500)
+
+  res.on("finish", async () => {
+    if (res.statusCode >= 400) {
+      return
+    }
+
+    try {
+      await pgConnection.raw(
+        `CREATE TABLE IF NOT EXISTS audit_log (
+          id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+          action_type TEXT NOT NULL,
+          resource TEXT NOT NULL,
+          resource_id TEXT,
+          actor_id TEXT,
+          timestamp TIMESTAMPTZ DEFAULT now(),
+          request_body_summary TEXT,
+          metadata JSONB DEFAULT '{}'
+        )`
+      )
+
+      await pgConnection.raw(
+        `INSERT INTO audit_log (
+          id,
+          action_type,
+          resource,
+          resource_id,
+          actor_id,
+          timestamp,
+          request_body_summary,
+          metadata
+        ) VALUES (
+          gen_random_uuid()::text,
+          ?,
+          ?,
+          ?,
+          ?,
+          now(),
+          ?,
+          ?::jsonb
+        )`,
+        [method, resourcePath, resourceId, actorId, requestBodySummary, JSON.stringify({})]
+      )
+    } catch (err: any) {
+      logger.error(`[admin-audit-log] write error: ${err.message}`)
+    }
+  })
+
+  next()
+}


### PR DESCRIPTION
### Motivation
- Provide a centralized audit trail for all admin mutations so POST/PATCH/DELETE operations under `/admin/*` are recorded for compliance and incident investigation (Q-041 M18a).
- Offer an API to query audit events with flexible filters, pagination and ordering to support investigations and dashboards.

### Description
- Added a new middleware `adminAuditLogMiddleware` (`src/api/middlewares/admin-audit-log.ts`) that records successful `POST|PATCH|DELETE` requests after the handler finishes into an `audit_log` table using `pgConnection.raw()` and `INSERT` with `gen_random_uuid()` for `id`.
- The middleware captures `action_type` (HTTP method), `resource` (request path), `resource_id` (from `req.params.id` or last path segment), `actor_id` (`req.auth_context?.actor_id`), `timestamp` (`now()`), `request_body_summary` (JSON.stringify(req.body) truncated to 500 chars) and `metadata` (empty JSON by default), and ensures the `audit_log` table exists with `CREATE TABLE IF NOT EXISTS`.
- Registered the middleware globally for admin write routes by adding a route rule in `src/api/middlewares.ts` to mount `adminAuditLogMiddleware` for `matcher: "/admin/*"` and `method: ["POST","PATCH","DELETE"]` without altering existing route-specific middleware configurations.
- Enhanced the `GET /admin/security/audit-logs` handler (`src/api/admin/security/audit-logs/route.ts`) to support filters `action_type`, `actor_id`, `start_date`, `end_date`, `resource`, pagination `offset`/`limit` (defaults `0`/`50`), ordering by `timestamp DESC`, and return shape `{ audit_logs, total, offset, limit, metadata: {} }` while using `CREATE TABLE IF NOT EXISTS audit_log` to ensure schema presence.

### Testing
- Ran `npm run build` to validate TypeScript/build surface, which failed in this environment because the `medusa` CLI binary is not available on PATH (`sh: 1: medusa: not found`).
- No other automated tests were available or executed in this environment; SQL writes are guarded by `CREATE TABLE IF NOT EXISTS` to avoid runtime schema errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0c491660c8333a65cb1d95206ab6a)