### PR TITLE
feat(account): add email change verification and GDPR account deletion for Q-041 M6

### DIFF
--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -259,6 +259,16 @@ export default defineMiddlewares({
       middlewares: [authenticate("customer", ["bearer", "session"])],
     },
     {
+      matcher: "/store/me",
+      method: ["DELETE"],
+      middlewares: [authenticate("customer", ["bearer"])],
+    },
+    {
+      matcher: "/store/me/change-email",
+      method: ["POST", "GET"],
+      middlewares: [authenticate("customer", ["bearer"])],
+    },
+    {
       matcher: "/store/me/login-history",
       method: "GET",
       middlewares: [authenticate("customer", ["bearer", "session"])],

--- a/src/api/store/me/change-email/route.ts
+++ b/src/api/store/me/change-email/route.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from "node:crypto"
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+async function ensureEmailChangeTable(pgConnection: any) {
+  await pgConnection.raw(
+    `CREATE TABLE IF NOT EXISTS email_change_request (
+      id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      customer_id TEXT NOT NULL,
+      new_email TEXT NOT NULL,
+      token TEXT NOT NULL UNIQUE,
+      expires_at TIMESTAMPTZ NOT NULL,
+      confirmed BOOLEAN DEFAULT false,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )`
+  )
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const body = (req.body || {}) as { new_email?: string }
+  const newEmail = body.new_email?.trim().toLowerCase()
+
+  if (!newEmail) {
+    return res.status(400).json({ error: "new_email is required" })
+  }
+
+  await ensureEmailChangeTable(pgConnection)
+
+  const token = randomUUID()
+
+  await pgConnection.raw(
+    `INSERT INTO email_change_request (customer_id, new_email, token, expires_at, confirmed, created_at)
+     VALUES (?, ?, ?, NOW() + INTERVAL '24 hours', false, NOW())`,
+    [customerId, newEmail, token]
+  )
+
+  await eventBus.emit({
+    name: "customer.email_change.requested",
+    data: {
+      customer_id: customerId,
+      new_email: newEmail,
+      token,
+    },
+  })
+
+  return res.status(200).json({ message: "Verification email sent", token })
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  const token = (req.query.token as string | undefined)?.trim()
+
+  if (!token) {
+    return res.status(400).json({ error: "token is required" })
+  }
+
+  await ensureEmailChangeTable(pgConnection)
+
+  const requestResult = await pgConnection.raw(
+    `SELECT customer_id, new_email
+     FROM email_change_request
+     WHERE token = ?
+       AND confirmed = false
+       AND expires_at > NOW()
+     LIMIT 1`,
+    [token]
+  )
+
+  const requestRow = requestResult.rows?.[0]
+
+  if (!requestRow) {
+    return res.status(404).json({ error: "Invalid or expired token" })
+  }
+
+  await pgConnection.raw(`UPDATE customer SET email = ? WHERE id = ?`, [
+    requestRow.new_email,
+    requestRow.customer_id,
+  ])
+
+  await pgConnection.raw(
+    `UPDATE email_change_request
+     SET confirmed = true
+     WHERE token = ?`,
+    [token]
+  )
+
+  await eventBus.emit({
+    name: "customer.email_change.confirmed",
+    data: {
+      customer_id: requestRow.customer_id,
+      new_email: requestRow.new_email,
+      token,
+    },
+  })
+
+  return res.status(200).json({ message: "Email updated successfully" })
+}

--- a/src/api/store/me/route.ts
+++ b/src/api/store/me/route.ts
@@ -1,0 +1,40 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+export async function DELETE(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+
+  const customerId = (req as any).auth_context?.actor_id
+  if (!customerId) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  await pgConnection.raw(`UPDATE customer SET deleted_at = NOW() WHERE id = ?`, [
+    customerId,
+  ])
+
+  await pgConnection.raw(
+    `UPDATE customer
+     SET email = '[DELETED_' || extract(epoch from NOW())::text || ']',
+         first_name = '[DELETED]',
+         last_name = '[DELETED]',
+         phone = NULL
+     WHERE id = ?`,
+    [customerId]
+  )
+
+  await pgConnection.raw(
+    `UPDATE customer_address
+     SET deleted_at = NOW()
+     WHERE customer_id = ?`,
+    [customerId]
+  )
+
+  await eventBus.emit({
+    name: "customer.account.deleted",
+    data: { customer_id: customerId },
+  })
+
+  return res.status(200).json({ message: "Account deleted and anonymized" })
+}

--- a/src/subscribers/account-events-subscriber.ts
+++ b/src/subscribers/account-events-subscriber.ts
@@ -1,0 +1,60 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+
+export default async function accountEventsSubscriber({
+  event,
+  container,
+}: SubscriberArgs<Record<string, unknown>>) {
+  const webhookUrl = process.env.WEBHOOK_RELAY_URL
+  if (!webhookUrl) {
+    return
+  }
+
+  const logger = container.resolve("logger") as {
+    info: (message: string) => void
+    error: (message: string) => void
+  }
+
+  const eventName = (event as any).name || "unknown"
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-NordHjem-Event": eventName,
+        ...(process.env.WEBHOOK_RELAY_SECRET
+          ? { "X-Webhook-Secret": process.env.WEBHOOK_RELAY_SECRET }
+          : {}),
+      },
+      body: JSON.stringify({
+        event: eventName,
+        data: event.data,
+        metadata: (event as any).metadata ?? null,
+        timestamp: new Date().toISOString(),
+      }),
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) {
+      logger.error(
+        `[account-events-subscriber] Failed to relay ${eventName}: HTTP ${response.status}`
+      )
+      return
+    }
+
+    logger.info(
+      `[account-events-subscriber] Relayed ${eventName} with status ${response.status}`
+    )
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : JSON.stringify(error)
+    logger.error(`[account-events-subscriber] Error relaying ${eventName}: ${errMsg}`)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: [
+    "customer.email_change.requested",
+    "customer.email_change.confirmed",
+    "customer.account.deleted",
+  ],
+}


### PR DESCRIPTION
### Motivation
- Add a verified email-change flow so customers can request an email update and confirm it securely within 24 hours. 
- Provide a GDPR-friendly account deletion that soft-deletes and anonymizes customer data and related addresses. 
- Relay account lifecycle events to an external webhook for downstream systems and future Phase 2 email sending.

### Description
- Add `POST` and `GET` handlers at `src/api/store/me/change-email/route.ts` which create an `email_change_request` row (created via `CREATE TABLE IF NOT EXISTS`), generate a `randomUUID()` token, set `expires_at = NOW() + INTERVAL '24 hours'`, emit `customer.email_change.requested`, and confirm via token to update `customer.email` and emit `customer.email_change.confirmed`, with `POST` returning the token for Phase 1 testing. 
- Add a `DELETE` handler at `src/api/store/me/route.ts` which sets `customer.deleted_at = NOW()`, anonymizes `email`, `first_name`, `last_name`, and `phone`, soft-deletes related `customer_address` rows, and emits `customer.account.deleted`. 
- Add `src/subscribers/account-events-subscriber.ts` which subscribes to `customer.email_change.requested`, `customer.email_change.confirmed`, and `customer.account.deleted`, and relays events to `process.env.WEBHOOK_RELAY_URL` with optional `WEBHOOK_RELAY_SECRET` header. 
- Register the new store routes in `src/api/middlewares.ts` with `authenticate("customer", ["bearer"])` for `/store/me` `DELETE` and `/store/me/change-email` `POST`/`GET` so they require bearer authentication. 
- No external skill files were used; the changes were implemented directly in the codebase.

### Testing
- Run `npx tsc --noEmit` which failed due to missing project type/dependency declarations (numerous `Cannot find module '@medusajs/...` and missing Node type errors), so a full compile could not be validated in the current environment. 
- No additional automated unit or integration tests were present or executed for the new endpoints in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0c49a9b3c8333b638901ce8126c5c)