### PR TITLE
fix(types): cast eventBus through unknown for TS2352 compatibility

### DIFF
--- a/src/api/admin/inventory/report/route.ts
+++ b/src/api/admin/inventory/report/route.ts
@@ -10,7 +10,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
     raw: (query: string, params?: any[]) => Promise<{ rows?: any[] }>
   }
-  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as {
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as unknown as {
     emit: (eventName: string, data: Record<string, unknown>) => Promise<void>
   }
 

--- a/src/api/admin/inventory/turnover/route.ts
+++ b/src/api/admin/inventory/turnover/route.ts
@@ -18,7 +18,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as {
     raw: (query: string, params?: any[]) => Promise<{ rows?: any[] }>
   }
-  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as {
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as unknown as {
     emit: (eventName: string, data: Record<string, unknown>) => Promise<void>
   }
 


### PR DESCRIPTION
### Motivation
- Fix TypeScript TS2352 by avoiding a direct incompatible cast when resolving the event bus from the DI container by routing the value through `unknown` before narrowing.

### Description
- Replaced `req.scope.resolve(Modules.EVENT_BUS) as {` with `req.scope.resolve(Modules.EVENT_BUS) as unknown as {` in `src/api/admin/inventory/report/route.ts` and `src/api/admin/inventory/turnover/route.ts` without changing any business logic.

### Testing
- Ran `rg -n "resolve\(Modules\.EVENT_BUS\) as \{"` to confirm no other occurrences remain and attempted `npx tsc --noEmit`, which failed due to unrelated missing module/type dependencies (`@medusajs/*`, Node typings) in the environment so full compilation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0cc202bd08333b51329bb638683f9)