### PR TITLE
test: add backend operations regression suite (7 files)

### DIFF
--- a/tests/admin-analytics-sales-summary.regression.test.ts
+++ b/tests/admin-analytics-sales-summary.regression.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { GET } from "../src/api/admin/analytics/sales-summary/route"
+
+function createRes() {
+  const res: any = { statusCode: 200, body: null }
+  res.status = (code: number) => ((res.statusCode = code), res)
+  res.json = (payload: unknown) => ((res.body = payload), res)
+  return res
+}
+
+test("sales summary calculates totals, aov and refund rate", async () => {
+  let call = 0
+  const req: any = {
+    query: { currency_code: "USD", granularity: "month" },
+    scope: {
+      resolve: (key: string) => {
+        if (key === ContainerRegistrationKeys.PG_CONNECTION) {
+          return {
+            raw: async () => {
+              call += 1
+              if (call === 1) {
+                return { rows: [{ date: "2026-02-01", sales: "200", orders: "4" }, { date: "2026-01-01", sales: "100", orders: "1" }] }
+              }
+              return { rows: [{ refunded: "2" }] }
+            },
+          }
+        }
+        if (key === "logger") return { error: () => undefined }
+        return null
+      },
+    },
+  }
+  const res = createRes()
+  await GET(req, res)
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.body.total_sales, 300)
+  assert.equal(res.body.order_count, 5)
+  assert.equal(res.body.avg_order_value, 60)
+  assert.equal(res.body.refund_rate, 40)
+})

--- a/tests/admin-finance-profit.regression.test.ts
+++ b/tests/admin-finance-profit.regression.test.ts
@@ -1,0 +1,46 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { GET } from "../src/api/admin/finance/profit/route"
+
+function createRes() {
+  const res: any = { statusCode: 200, body: null }
+  res.status = (code: number) => ((res.statusCode = code), res)
+  res.json = (payload: unknown) => ((res.body = payload), res)
+  return res
+}
+
+test("finance profit validates period parameter", async () => {
+  const req: any = {
+    query: { period: "yearly" },
+    scope: { resolve: () => ({}) },
+  }
+  const res = createRes()
+  await GET(req, res)
+  assert.equal(res.statusCode, 400)
+})
+
+test("finance profit returns payload on successful query and emits event", async () => {
+  let emitted = false
+  const req: any = {
+    query: { period: "weekly", metadata: "regression" },
+    scope: {
+      resolve: (key: string) => {
+        if (key === ContainerRegistrationKeys.PG_CONNECTION) {
+          return {
+            raw: async () => ({ rows: [{ gross_profit: "15", net_profit: "12", total_revenue: "30", total_cost: "15", order_count: "3", period_start: "2026-01-01", period_end: "2026-01-07" }] }),
+          }
+        }
+        if (key === Modules.EVENT_BUS) return { emit: async () => { emitted = true } }
+        if (key === "logger") return { error: () => undefined }
+        return null
+      },
+    },
+  }
+  const res = createRes()
+  await GET(req, res)
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.body.net_profit, 12)
+  assert.equal(res.body.metadata, "regression")
+  assert.equal(emitted, true)
+})

--- a/tests/admin-finance-summary.regression.test.ts
+++ b/tests/admin-finance-summary.regression.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { GET } from "../src/api/admin/finance/summary/route"
+
+function createRes() {
+  const res: any = { statusCode: 200, body: null }
+  res.status = (code: number) => ((res.statusCode = code), res)
+  res.json = (payload: unknown) => ((res.body = payload), res)
+  return res
+}
+
+test("finance summary aggregates data points and rounds fee", async () => {
+  let call = 0
+  const pgConnection = {
+    raw: async () => {
+      call += 1
+      if (call === 1) {
+        return { rows: [{ period: "2026-01-01", revenue: 100.1, refunds: 10, net: 90.1 }] }
+      }
+      if (call === 2) {
+        return { rows: [{ estimated_fees: 3.205 }] }
+      }
+      return { rows: [{ pending: 4.5 }] }
+    },
+  }
+
+  const req: any = {
+    query: { currency_code: "EUR", granularity: "invalid" },
+    scope: {
+      resolve: (key: string) => {
+        if (key === ContainerRegistrationKeys.PG_CONNECTION) return pgConnection
+        if (key === "logger") return { error: () => undefined }
+        return null
+      },
+    },
+  }
+
+  const res = createRes()
+  await GET(req, res)
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.body.currency_code, "eur")
+  assert.equal(res.body.total_revenue, 100.1)
+  assert.equal(res.body.total_refunds, 10)
+  assert.equal(res.body.net_revenue, 90.1)
+  assert.equal(res.body.estimated_stripe_fees, 3.21)
+  assert.equal(res.body.pending_refunds, 4.5)
+})
+
+test("finance summary returns 200 with note when table missing", async () => {
+  const req: any = {
+    query: {},
+    scope: {
+      resolve: (key: string) => {
+        if (key === ContainerRegistrationKeys.PG_CONNECTION) {
+          return { raw: async () => { throw new Error('relation "order" does not exist') } }
+        }
+        if (key === "logger") return { error: () => undefined }
+        return null
+      },
+    },
+  }
+
+  const res = createRes()
+  await GET(req, res)
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.body.note, "Order table not initialized.")
+})

--- a/tests/admin-inventory-report.regression.test.ts
+++ b/tests/admin-inventory-report.regression.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { GET } from "../src/api/admin/inventory/report/route"
+
+function createRes() {
+  const res: any = { statusCode: 200, body: null }
+  res.status = (code: number) => ((res.statusCode = code), res)
+  res.json = (payload: unknown) => ((res.body = payload), res)
+  return res
+}
+
+test("inventory report returns typed numbers and metadata", async () => {
+  let emitted = false
+  const req: any = {
+    scope: {
+      resolve: (key: string) => {
+        if (key === ContainerRegistrationKeys.PG_CONNECTION) {
+          return {
+            raw: async () => ({ rows: [{ total_inventory_value: "12.5", stockout_rate: "0.2", avg_turnover_days: 25, items_below_threshold: "3", total_items: 10 }] }),
+          }
+        }
+        if (key === Modules.EVENT_BUS) return { emit: async () => { emitted = true } }
+        return null
+      },
+    },
+  }
+  const res = createRes()
+  await GET(req, res)
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.body.total_inventory_value, 12.5)
+  assert.equal(res.body.items_below_threshold, 3)
+  assert.deepEqual(res.body.metadata, {})
+  assert.equal(emitted, true)
+})
+
+test("inventory report returns schema failure fallback payload", async () => {
+  const req: any = {
+    scope: {
+      resolve: (key: string) => {
+        if (key === ContainerRegistrationKeys.PG_CONNECTION) return { raw: async () => { throw new Error("bad query") } }
+        if (key === Modules.EVENT_BUS) return { emit: async () => undefined }
+        return null
+      },
+    },
+  }
+  const res = createRes()
+  await GET(req, res)
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.body.message, "Query failed, check schema")
+})

--- a/tests/admin-inventory-turnover.regression.test.ts
+++ b/tests/admin-inventory-turnover.regression.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { GET } from "../src/api/admin/inventory/turnover/route"
+
+function createRes() {
+  const res: any = { statusCode: 200, body: null }
+  res.status = (code: number) => ((res.statusCode = code), res)
+  res.json = (payload: unknown) => ((res.body = payload), res)
+  return res
+}
+
+test("inventory turnover maps rows and includes period bounds", async () => {
+  const req: any = {
+    query: { start_date: "2026-01-01", end_date: "2026-01-31" },
+    scope: {
+      resolve: (key: string) => {
+        if (key === ContainerRegistrationKeys.PG_CONNECTION) {
+          return {
+            raw: async () => ({ rows: [{ product_id: "prod_1", product_title: "Chair", sold_quantity: "10", avg_inventory: "5", turnover_rate: "2" }] }),
+          }
+        }
+        if (key === Modules.EVENT_BUS) return { emit: async () => undefined }
+        return null
+      },
+    },
+  }
+
+  const res = createRes()
+  await GET(req, res)
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.body.items[0].turnover_rate, 2)
+  assert.equal(res.body.period_start, "2026-01-01")
+})

--- a/tests/admin-orders-stats.regression.test.ts
+++ b/tests/admin-orders-stats.regression.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { GET } from "../src/api/admin/orders/stats/route"
+
+function createRes() {
+  const res: any = { statusCode: 200, body: null }
+  res.status = (code: number) => {
+    res.statusCode = code
+    return res
+  }
+  res.json = (payload: unknown) => {
+    res.body = payload
+    return res
+  }
+  return res
+}
+
+test("orders stats returns normalized ranges and emits event", async () => {
+  const calls: string[] = []
+  const pgConnection = {
+    raw: async (_query: string) => {
+      calls.push("raw")
+      const rows = [
+        { count: 2, gmv: 100, avg_order_value: 50 },
+        { count: 3, gmv: 210, avg_order_value: 70 },
+        { count: 4, gmv: 320, avg_order_value: 80 },
+      ]
+      return { rows: [rows[calls.length - 1]] }
+    },
+  }
+  let emitted: any = null
+  const req: any = {
+    scope: {
+      resolve: (key: string) => {
+        if (key === ContainerRegistrationKeys.PG_CONNECTION) return pgConnection
+        if (key === Modules.EVENT_BUS) return { emit: async (_n: string, data: any) => (emitted = data) }
+        return null
+      },
+    },
+  }
+
+  const res = createRes()
+  await GET(req, res)
+
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(res.body.today, { count: 2, gmv: 100, avg_order_value: 50 })
+  assert.deepEqual(res.body.this_week, { count: 3, gmv: 210, avg_order_value: 70 })
+  assert.deepEqual(res.body.this_month, { count: 4, gmv: 320, avg_order_value: 80 })
+  assert.deepEqual(emitted, res.body)
+})
+
+test("orders stats falls back to zeros when query throws", async () => {
+  const req: any = {
+    scope: {
+      resolve: (key: string) => {
+        if (key === ContainerRegistrationKeys.PG_CONNECTION) return { raw: async () => { throw new Error("db down") } }
+        if (key === Modules.EVENT_BUS) return { emit: async () => undefined }
+        return null
+      },
+    },
+  }
+  const res = createRes()
+  await GET(req, res)
+
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(res.body.today, { count: 0, gmv: 0, avg_order_value: 0 })
+})

--- a/tests/admin-tickets-stats.regression.test.ts
+++ b/tests/admin-tickets-stats.regression.test.ts
@@ -1,0 +1,58 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { GET } from "../src/api/admin/tickets/stats/route"
+
+function createRes() {
+  const res: any = { statusCode: 200, body: null }
+  res.status = (code: number) => ((res.statusCode = code), res)
+  res.json = (payload: unknown) => ((res.body = payload), res)
+  return res
+}
+
+test("ticket stats computes payload and emits analytics event", async () => {
+  let call = 0
+  let emitted = false
+  const req: any = {
+    scope: {
+      resolve: (key: string) => {
+        if (key === ContainerRegistrationKeys.PG_CONNECTION) {
+          return {
+            raw: async () => {
+              call += 1
+              if (call < 3) return { rows: [] }
+              return { rows: [{ total_tickets: 12, open_tickets: 3, avg_resolution_time_hours: 10.5, sla_compliance_rate: 0.95 }] }
+            },
+          }
+        }
+        if (key === Modules.EVENT_BUS) return { emit: async () => { emitted = true } }
+        if (key === "logger") return { error: () => undefined }
+        return null
+      },
+    },
+  }
+
+  const res = createRes()
+  await GET(req, res)
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.body.total_tickets, 12)
+  assert.equal(res.body.sla_compliance_rate, 0.95)
+  assert.equal(emitted, true)
+})
+
+test("ticket stats returns 500 when query fails", async () => {
+  const req: any = {
+    scope: {
+      resolve: (key: string) => {
+        if (key === ContainerRegistrationKeys.PG_CONNECTION) return { raw: async () => { throw new Error("broken") } }
+        if (key === Modules.EVENT_BUS) return { emit: async () => undefined }
+        if (key === "logger") return { error: () => undefined }
+        return null
+      },
+    },
+  }
+  const res = createRes()
+  await GET(req, res)
+  assert.equal(res.statusCode, 500)
+  assert.equal(res.body.error, "Failed to generate ticket stats")
+})


### PR DESCRIPTION
### Motivation
- Implement Issue #56 by adding a backend运营回归测试套件 that validates key admin/store analytics and finance endpoints at the route-handler level.

### Description
- Added seven regression test files under `tests/` that exercise route handlers directly using lightweight DI scope mocks and a fake `req/res` implementation: `admin-orders-stats.regression.test.ts`, `admin-finance-summary.regression.test.ts`, `admin-inventory-report.regression.test.ts`, `admin-tickets-stats.regression.test.ts`, `admin-analytics-sales-summary.regression.test.ts`, `admin-inventory-turnover.regression.test.ts`, and `admin-finance-profit.regression.test.ts`.
- Tests use Node's built-in `node:test` runner and `assert` to validate successful paths and fallback/error handling by calling the exported `GET` handlers and mocking `req.scope.resolve(...)` for `ContainerRegistrationKeys.PG_CONNECTION`, `Modules.EVENT_BUS`, and `logger` when needed.
- Committed the new files and prepared a PR titled `test: add backend operations regression suite (7 files)`.

### Testing
- Attempted to run the tests with `node --test --require ts-node/register tests/*.test.ts`, which failed because `ts-node/register` is not available in the current environment (module not found).
- Ran `npm install` to provision dev deps, but installing `ts-node` via `npm` failed due to a registry `403` preventing adding `ts-node` to the environment.
- Ran `npx tsc --noEmit`, which failed due to missing type definition packages producing multiple `TS2688` errors in the current environment.
- All test files were committed successfully; no test run completed successfully in this environment due to dependency / registry constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3a1a3a5b88333bc3cdecea238c743)