### PR TITLE
feat(M4): Order management — status validation, timeline, bulk update, search

### DIFF
--- a/src/api/admin/orders/[id]/route.ts
+++ b/src/api/admin/orders/[id]/route.ts
@@ -1,0 +1,83 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+const ALLOWED_TRANSITIONS: Record<string, string[]> = {
+  pending: ["processing", "canceled"],
+  processing: ["shipped", "canceled"],
+  shipped: ["delivered"],
+  delivered: ["completed"],
+  completed: [],
+  canceled: [],
+}
+
+const VALID_STATUSES = Object.keys(ALLOWED_TRANSITIONS)
+
+async function emitEvent(scope: MedusaRequest["scope"], name: string, data: Record<string, unknown>) {
+  try {
+    const eventBus = scope.resolve("event_bus") as any
+    await eventBus.emit(name, data)
+  } catch {
+    // optional – don't fail the API if event bus is unavailable
+  }
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const orderId = req.params.id
+
+  const result = await pgConnection.raw(`SELECT o.* FROM "order" o WHERE o.id = ?`, [orderId])
+
+  const order = result?.rows?.[0]
+  if (!order) {
+    return res.status(404).json({ error: "Order not found" })
+  }
+
+  return res.status(200).json({ order })
+}
+
+export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const orderId = req.params.id
+
+  const body = (req.body ?? {}) as Record<string, any>
+
+  const lookupResult = await pgConnection.raw(`SELECT id, status FROM "order" WHERE id = ?`, [orderId])
+  const order = lookupResult?.rows?.[0]
+
+  if (!order) {
+    return res.status(404).json({ error: "Order not found" })
+  }
+
+  if (body.status !== undefined) {
+    const currentStatus = order.status as string
+    const nextStatus = String(body.status)
+
+    if (!VALID_STATUSES.includes(nextStatus)) {
+      return res.status(400).json({
+        error: `Invalid status "${nextStatus}". Valid statuses: ${VALID_STATUSES.join(", ")}`,
+      })
+    }
+
+    const allowed = ALLOWED_TRANSITIONS[currentStatus]
+    if (!allowed || !allowed.includes(nextStatus)) {
+      return res.status(400).json({
+        error: `Cannot transition from "${currentStatus}" to "${nextStatus}". Allowed transitions: ${(allowed || []).join(", ") || "none"}`,
+      })
+    }
+
+    await pgConnection.raw(`UPDATE "order" SET status = ?, updated_at = NOW() WHERE id = ?`, [
+      nextStatus,
+      orderId,
+    ])
+
+    await emitEvent(req.scope, "order.status_updated", {
+      order_id: orderId,
+      previous_status: currentStatus,
+      status: nextStatus,
+    })
+  }
+
+  const updatedResult = await pgConnection.raw(`SELECT o.* FROM "order" o WHERE o.id = ?`, [orderId])
+
+  return res.status(200).json({ order: updatedResult?.rows?.[0] })
+}

--- a/src/api/admin/orders/[id]/timeline/route.ts
+++ b/src/api/admin/orders/[id]/timeline/route.ts
@@ -1,0 +1,158 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+interface TimelineEvent {
+  type: string
+  timestamp: string
+  description: string
+  actor: string | null
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const orderId = req.params.id
+
+  // Verify order exists
+  const orderResult = await pgConnection.raw(
+    `SELECT id, status, created_at, updated_at, canceled_at FROM "order" WHERE id = ?`,
+    [orderId]
+  )
+  const order = orderResult?.rows?.[0]
+
+  if (!order) {
+    return res.status(404).json({ error: "Order not found" })
+  }
+
+  const events: TimelineEvent[] = []
+
+  // 1. Order created event
+  events.push({
+    type: "order.created",
+    timestamp: order.created_at,
+    description: "Order was placed",
+    actor: null,
+  })
+
+  // 2. Order canceled event (if applicable)
+  if (order.canceled_at) {
+    events.push({
+      type: "order.canceled",
+      timestamp: order.canceled_at,
+      description: "Order was canceled",
+      actor: null,
+    })
+  }
+
+  // 3. Notes
+  try {
+    const notesResult = await pgConnection.raw(
+      `SELECT id, content, author, created_at FROM order_note WHERE order_id = ? ORDER BY created_at ASC`,
+      [orderId]
+    )
+    for (const note of notesResult?.rows || []) {
+      events.push({
+        type: "order.note_added",
+        timestamp: note.created_at,
+        description: `Note added: ${note.content}`,
+        actor: note.author || null,
+      })
+    }
+  } catch {
+    // order_note table may not exist yet – skip
+  }
+
+  // 4. Return requests
+  try {
+    const returnsResult = await pgConnection.raw(
+      `SELECT id, status, reason, created_at FROM "return" WHERE order_id = ? ORDER BY created_at ASC`,
+      [orderId]
+    )
+    for (const ret of returnsResult?.rows || []) {
+      events.push({
+        type: "order.return_requested",
+        timestamp: ret.created_at,
+        description: `Return requested${ret.reason ? ": " + ret.reason : ""}`,
+        actor: null,
+      })
+    }
+  } catch {
+    // return table may not exist – skip
+  }
+
+  // 5. Exchanges
+  try {
+    const exchangesResult = await pgConnection.raw(
+      `SELECT id, created_at FROM "order_exchange" WHERE order_id = ? ORDER BY created_at ASC`,
+      [orderId]
+    )
+    for (const exchange of exchangesResult?.rows || []) {
+      events.push({
+        type: "order.exchange_created",
+        timestamp: exchange.created_at,
+        description: "Exchange was created",
+        actor: null,
+      })
+    }
+  } catch {
+    // order_exchange table may not exist – skip
+  }
+
+  // 6. Fulfillments
+  try {
+    const fulfillmentsResult = await pgConnection.raw(
+      `SELECT id, created_at, shipped_at, delivered_at FROM "fulfillment" WHERE order_id = ? ORDER BY created_at ASC`,
+      [orderId]
+    )
+    for (const ful of fulfillmentsResult?.rows || []) {
+      events.push({
+        type: "order.fulfillment_created",
+        timestamp: ful.created_at,
+        description: "Fulfillment created",
+        actor: null,
+      })
+      if (ful.shipped_at) {
+        events.push({
+          type: "order.shipped",
+          timestamp: ful.shipped_at,
+          description: "Order was shipped",
+          actor: null,
+        })
+      }
+      if (ful.delivered_at) {
+        events.push({
+          type: "order.delivered",
+          timestamp: ful.delivered_at,
+          description: "Order was delivered",
+          actor: null,
+        })
+      }
+    }
+  } catch {
+    // fulfillment table may not exist – skip
+  }
+
+  // 7. Payment captures
+  try {
+    const paymentsResult = await pgConnection.raw(
+      `SELECT id, captured_at, created_at FROM "payment" WHERE order_id = ? ORDER BY created_at ASC`,
+      [orderId]
+    )
+    for (const payment of paymentsResult?.rows || []) {
+      if (payment.captured_at) {
+        events.push({
+          type: "payment.captured",
+          timestamp: payment.captured_at,
+          description: "Payment was captured",
+          actor: null,
+        })
+      }
+    }
+  } catch {
+    // payment table may not exist in this schema – skip
+  }
+
+  // Sort chronologically
+  events.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+
+  return res.status(200).json({ events })
+}

--- a/src/api/admin/orders/batch/route.ts
+++ b/src/api/admin/orders/batch/route.ts
@@ -4,6 +4,15 @@ import { randomUUID } from "node:crypto"
 
 type BatchAction = "update_status" | "create_fulfillment" | "export"
 
+const ALLOWED_TRANSITIONS: Record<string, string[]> = {
+  pending: ["processing", "canceled"],
+  processing: ["shipped", "canceled"],
+  shipped: ["delivered"],
+  delivered: ["completed"],
+  completed: [],
+  canceled: [],
+}
+
 async function emitEvent(scope: MedusaRequest["scope"], name: string, data: Record<string, unknown>) {
   try {
     const eventBus = scope.resolve("event_bus") as any
@@ -20,6 +29,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
   const body = (req.body ?? {}) as {
     action?: BatchAction
     order_ids?: string[]
+    status?: string
     data?: {
       status?: string
       fulfillment_data?: Record<string, unknown>
@@ -50,6 +60,71 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     })
   }
 
+  if (body.action === "update_status") {
+    const targetStatus = body.status || body.data?.status
+    if (!targetStatus) {
+      return res.status(400).json({ error: "status is required for update_status action" })
+    }
+
+    // Pre-validate: fetch all orders and check transitions before applying any
+    const failed: Array<{ id: string; reason: string }> = []
+    const validOrders: Array<{ id: string; current_status: string }> = []
+
+    for (const orderId of body.order_ids) {
+      try {
+        const result = await pgConnection.raw(
+          `SELECT id, status FROM "order" WHERE id = ?`,
+          [orderId]
+        )
+        const order = result?.rows?.[0]
+        if (!order) {
+          failed.push({ id: orderId, reason: "Order not found" })
+          continue
+        }
+
+        const currentStatus = order.status as string
+        const allowed = ALLOWED_TRANSITIONS[currentStatus]
+
+        if (!allowed || !allowed.includes(targetStatus)) {
+          failed.push({
+            id: orderId,
+            reason: `Cannot transition from "${currentStatus}" to "${targetStatus}"`,
+          })
+          continue
+        }
+
+        validOrders.push({ id: orderId, current_status: currentStatus })
+      } catch (err: any) {
+        failed.push({ id: orderId, reason: err.message || "Unknown error" })
+      }
+    }
+
+    // Apply updates only to valid orders
+    for (const order of validOrders) {
+      await pgConnection.raw(
+        `UPDATE "order" SET status = ?, updated_at = NOW() WHERE id = ?`,
+        [targetStatus, order.id]
+      )
+      await emitEvent(req.scope, "order.status_updated", {
+        order_id: order.id,
+        previous_status: order.current_status,
+        status: targetStatus,
+      })
+    }
+
+    return res.status(200).json({
+      success: validOrders.length,
+      failed,
+      processed: body.order_ids.length,
+      succeeded: validOrders.length,
+      results: [
+        ...validOrders.map((o) => ({ order_id: o.id, success: true })),
+        ...failed.map((f) => ({ order_id: f.id, success: false, error: f.reason })),
+      ],
+    })
+  }
+
+  // Other actions (create_fulfillment) – keep existing behavior
   const results: Array<{ order_id: string; success: boolean; error?: string }> = []
 
   for (const orderId of body.order_ids) {
@@ -58,22 +133,6 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
 
       if (!order || order.canceled_at) {
         throw new Error("Order is canceled")
-      }
-
-      if (body.action === "update_status") {
-        if (!body.data?.status) {
-          throw new Error("data.status is required")
-        }
-
-        await pgConnection.raw(`UPDATE "order" SET status = ?, updated_at = NOW() WHERE id = ?`, [
-          body.data.status,
-          orderId,
-        ])
-
-        await emitEvent(req.scope, "order.status_updated", {
-          order_id: orderId,
-          status: body.data.status,
-        })
       }
 
       if (body.action === "create_fulfillment") {

--- a/src/api/admin/orders/route.ts
+++ b/src/api/admin/orders/route.ts
@@ -8,13 +8,42 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   const limit = Math.min(Number(query.limit) || 20, 100)
   const offset = Math.max(Number(query.offset) || 0, 0)
 
-  const sortBy = query.sort_by === "total" ? "total" : "created_at"
+  const sortAllowList = ["created_at", "total", "status"]
+  const sortBy = sortAllowList.includes(query.sort_by) ? query.sort_by : "created_at"
   const sortOrder = String(query.sort_order || "desc").toLowerCase() === "asc" ? "ASC" : "DESC"
 
-  const statusAllowList = ["pending", "completed", "canceled", "archived", "requires_action"]
+  const statusAllowList = [
+    "pending", "processing", "shipped", "delivered",
+    "completed", "canceled", "archived", "requires_action",
+  ]
 
   const conditions: string[] = []
   const params: any[] = []
+
+  // Free-text search: match against customer email or display_id
+  if (query.q) {
+    const searchTerm = `%${String(query.q)}%`
+    conditions.push(
+      `(o.display_id::text ILIKE ? OR EXISTS (
+        SELECT 1 FROM "customer" c WHERE c.id = o.customer_id AND c.email ILIKE ?
+      ))`
+    )
+    params.push(searchTerm, searchTerm)
+  }
+
+  // Customer email filter
+  if (query.email) {
+    conditions.push(
+      `EXISTS (SELECT 1 FROM "customer" c WHERE c.id = o.customer_id AND c.email ILIKE ?)`
+    )
+    params.push(`%${String(query.email)}%`)
+  }
+
+  // Order number (display_id) filter
+  if (query.order_number) {
+    conditions.push("o.display_id::text = ?")
+    params.push(String(query.order_number))
+  }
 
   if (query.date_from) {
     conditions.push("o.created_at >= ?::timestamptz")
@@ -29,6 +58,12 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   if (query.status && statusAllowList.includes(String(query.status))) {
     conditions.push("o.status = ?")
     params.push(query.status)
+  }
+
+  // Payment status filter
+  if (query.payment_status) {
+    conditions.push("o.payment_status = ?")
+    params.push(String(query.payment_status))
   }
 
   const minAmount = query.amount_min ?? query.min_amount
@@ -67,10 +102,14 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     params
   )
 
+  const orderByColumn = sortBy === "total"
+    ? "COALESCE((o.raw_total->>'value')::numeric, o.total, 0)"
+    : `o.${sortBy}`
+
   const listResult = await pgConnection.raw(
     `SELECT o.* FROM "order" o
      ${whereClause}
-     ORDER BY o.${sortBy === "total" ? "total" : "created_at"} ${sortOrder}
+     ORDER BY ${orderByColumn} ${sortOrder}
      LIMIT ? OFFSET ?`,
     [...params, limit, offset]
   )

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -134,6 +134,16 @@ export default defineMiddlewares({
       middlewares: [authenticate("user", ["bearer", "session"])],
     },
     {
+      matcher: "/admin/orders/:id",
+      method: ["GET", "PATCH"],
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/orders/:id/timeline",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
       matcher: "/admin/orders/:id/return-request",
       method: "POST",
       middlewares: [authenticate("user", ["bearer", "session"])],


### PR DESCRIPTION
## Summary

- **Status transition validation**: New `PATCH /admin/orders/:id` endpoint validates order status transitions against a defined state machine (`pending → processing → shipped → delivered → completed`, with `canceled` allowed from `pending`/`processing`). Rejects invalid transitions with descriptive error messages.
- **Order timeline**: New `GET /admin/orders/:id/timeline` endpoint returns a chronological activity log aggregating events from order creation, notes, return requests, exchanges, fulfillments, and payment captures.
- **Bulk status update enhancement**: `POST /admin/orders/batch` with `action: "update_status"` now pre-validates all transitions before applying any updates. Returns `{ success, failed: [{ id, reason }] }` format. Accepts `status` at body root level in addition to `data.status`.
- **Search enhancement**: `GET /admin/orders` now supports free-text search (`q` param matching customer email/order number), dedicated `email` and `order_number` filters, `payment_status` filter, and sorting by `status` column.
- Registered new routes (`/admin/orders/:id`, `/admin/orders/:id/timeline`) with authentication middleware.

## Test plan

- [ ] `PATCH /admin/orders/:id` with valid transition (e.g., `pending` → `processing`) returns 200
- [ ] `PATCH /admin/orders/:id` with invalid transition (e.g., `completed` → `pending`) returns 400
- [ ] `PATCH /admin/orders/:id` with nonexistent order returns 404
- [ ] `GET /admin/orders/:id/timeline` returns chronological events for an order
- [ ] `POST /admin/orders/batch` with `update_status` pre-validates and reports failures per order
- [ ] `GET /admin/orders?q=email@example.com` searches by customer email
- [ ] `GET /admin/orders?order_number=123` filters by display_id
- [ ] `GET /admin/orders?payment_status=captured` filters by payment status
- [ ] `GET /admin/orders?sort_by=status` sorts by status column
- [ ] Existing order endpoints (notes, exchange, return-request, export, stats) remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)