### PR TITLE
feat(M4): Order management — status validation, timeline, bulk update, search

### DIFF
--- a/src/api/admin/orders/[id]/route.ts
+++ b/src/api/admin/orders/[id]/route.ts
@@ -1,0 +1,118 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+/**
+ * Valid order status transitions.
+ * pending → processing → shipped → delivered → completed
+ * pending/processing → canceled
+ */
+const VALID_TRANSITIONS: Record<string, string[]> = {
+  pending: ["processing", "canceled"],
+  processing: ["shipped", "canceled"],
+  shipped: ["delivered"],
+  delivered: ["completed"],
+  completed: [],
+  canceled: [],
+}
+
+const VALID_STATUSES = Object.keys(VALID_TRANSITIONS)
+
+async function emitEvent(scope: MedusaRequest["scope"], name: string, data: Record<string, unknown>) {
+  try {
+    const eventBus = scope.resolve("event_bus") as any
+    await eventBus.emit(name, data)
+  } catch {
+    // optional
+  }
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const orderId = req.params.id
+
+  const result = await pgConnection.raw(
+    `SELECT * FROM "order" WHERE id = ? LIMIT 1`,
+    [orderId]
+  )
+
+  const order = result?.rows?.[0]
+  if (!order) {
+    return res.status(404).json({ error: "Order not found" })
+  }
+
+  return res.status(200).json({ order })
+}
+
+export async function PATCH(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const orderId = req.params.id
+
+  const body = (req.body ?? {}) as { status?: string; metadata?: Record<string, unknown> }
+
+  const orderResult = await pgConnection.raw(
+    `SELECT id, status FROM "order" WHERE id = ? LIMIT 1`,
+    [orderId]
+  )
+
+  const order = orderResult?.rows?.[0]
+  if (!order) {
+    return res.status(404).json({ error: "Order not found" })
+  }
+
+  const updates: string[] = []
+  const params: any[] = []
+
+  if (body.status) {
+    const newStatus = String(body.status)
+
+    if (!VALID_STATUSES.includes(newStatus)) {
+      return res.status(400).json({
+        error: `Invalid status: ${newStatus}. Valid statuses: ${VALID_STATUSES.join(", ")}`,
+      })
+    }
+
+    const currentStatus = String(order.status || "pending")
+    const allowed = VALID_TRANSITIONS[currentStatus] || []
+
+    if (!allowed.includes(newStatus)) {
+      return res.status(400).json({
+        error: `Invalid status transition: ${currentStatus} → ${newStatus}. Allowed transitions from ${currentStatus}: ${allowed.length ? allowed.join(", ") : "none"}`,
+      })
+    }
+
+    updates.push("status = ?")
+    params.push(newStatus)
+  }
+
+  if (body.metadata !== undefined) {
+    updates.push("metadata = ?::jsonb")
+    params.push(JSON.stringify(body.metadata))
+  }
+
+  if (updates.length === 0) {
+    return res.status(400).json({ error: "No valid fields to update" })
+  }
+
+  updates.push("updated_at = NOW()")
+  params.push(orderId)
+
+  await pgConnection.raw(
+    `UPDATE "order" SET ${updates.join(", ")} WHERE id = ?`,
+    params
+  )
+
+  if (body.status) {
+    await emitEvent(req.scope, "order.status_updated", {
+      order_id: orderId,
+      previous_status: order.status,
+      status: body.status,
+    })
+  }
+
+  const updated = await pgConnection.raw(
+    `SELECT * FROM "order" WHERE id = ? LIMIT 1`,
+    [orderId]
+  )
+
+  return res.status(200).json({ order: updated?.rows?.[0] })
+}

--- a/src/api/admin/orders/[id]/timeline/route.ts
+++ b/src/api/admin/orders/[id]/timeline/route.ts
@@ -1,0 +1,161 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+type TimelineEvent = {
+  type: string
+  timestamp: string
+  description: string
+  actor: string | null
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+  const orderId = req.params.id
+
+  const orderResult = await pgConnection.raw(
+    `SELECT id, status, created_at, updated_at, canceled_at FROM "order" WHERE id = ? LIMIT 1`,
+    [orderId]
+  )
+
+  const order = orderResult?.rows?.[0]
+  if (!order) {
+    return res.status(404).json({ error: "Order not found" })
+  }
+
+  const events: TimelineEvent[] = []
+
+  // 1. Order created
+  events.push({
+    type: "order.created",
+    timestamp: order.created_at,
+    description: "Order was created",
+    actor: null,
+  })
+
+  // 2. Order notes
+  try {
+    const notesResult = await pgConnection.raw(
+      `SELECT content, author, created_at FROM order_note WHERE order_id = ? ORDER BY created_at ASC`,
+      [orderId]
+    )
+    for (const note of notesResult?.rows || []) {
+      events.push({
+        type: "order.note_added",
+        timestamp: note.created_at,
+        description: `Note: ${note.content}`,
+        actor: note.author || null,
+      })
+    }
+  } catch {
+    // order_note table may not exist yet
+  }
+
+  // 3. Return requests
+  try {
+    const returnsResult = await pgConnection.raw(
+      `SELECT id, status, created_at FROM "return" WHERE order_id = ? ORDER BY created_at ASC`,
+      [orderId]
+    )
+    for (const ret of returnsResult?.rows || []) {
+      events.push({
+        type: "order.return_requested",
+        timestamp: ret.created_at,
+        description: `Return request ${ret.id} created (status: ${ret.status})`,
+        actor: null,
+      })
+    }
+  } catch {
+    // return table may not exist
+  }
+
+  // 4. Exchanges
+  try {
+    const exchangesResult = await pgConnection.raw(
+      `SELECT id, status, created_at FROM order_exchange WHERE order_id = ? ORDER BY created_at ASC`,
+      [orderId]
+    )
+    for (const exch of exchangesResult?.rows || []) {
+      events.push({
+        type: "order.exchange_created",
+        timestamp: exch.created_at,
+        description: `Exchange ${exch.id} created (status: ${exch.status})`,
+        actor: null,
+      })
+    }
+  } catch {
+    // order_exchange table may not exist
+  }
+
+  // 5. Payment captures
+  try {
+    const paymentsResult = await pgConnection.raw(
+      `SELECT pc.id, pc.amount, pc.created_at
+       FROM payment_capture pc
+       JOIN payment p ON p.id = pc.payment_id
+       JOIN payment_collection pcol ON pcol.id = p.payment_collection_id
+       JOIN order_payment_collection opc ON opc.payment_collection_id = pcol.id
+       WHERE opc.order_id = ?
+       ORDER BY pc.created_at ASC`,
+      [orderId]
+    )
+    for (const capture of paymentsResult?.rows || []) {
+      events.push({
+        type: "order.payment_captured",
+        timestamp: capture.created_at,
+        description: `Payment captured: ${capture.amount}`,
+        actor: null,
+      })
+    }
+  } catch {
+    // payment tables may not exist in all setups
+  }
+
+  // 6. Fulfillments
+  try {
+    const fulfillmentsResult = await pgConnection.raw(
+      `SELECT id, created_at, shipped_at, delivered_at FROM fulfillment WHERE order_id = ? ORDER BY created_at ASC`,
+      [orderId]
+    )
+    for (const ful of fulfillmentsResult?.rows || []) {
+      events.push({
+        type: "order.fulfillment_created",
+        timestamp: ful.created_at,
+        description: `Fulfillment ${ful.id} created`,
+        actor: null,
+      })
+      if (ful.shipped_at) {
+        events.push({
+          type: "order.shipped",
+          timestamp: ful.shipped_at,
+          description: `Fulfillment ${ful.id} shipped`,
+          actor: null,
+        })
+      }
+      if (ful.delivered_at) {
+        events.push({
+          type: "order.delivered",
+          timestamp: ful.delivered_at,
+          description: `Fulfillment ${ful.id} delivered`,
+          actor: null,
+        })
+      }
+    }
+  } catch {
+    // fulfillment table may not exist
+  }
+
+  // 7. Canceled
+  if (order.canceled_at) {
+    events.push({
+      type: "order.canceled",
+      timestamp: order.canceled_at,
+      description: "Order was canceled",
+      actor: null,
+    })
+  }
+
+  // Sort chronologically
+  events.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+
+  return res.status(200).json({ events })
+}

--- a/src/api/admin/orders/batch/route.ts
+++ b/src/api/admin/orders/batch/route.ts
@@ -4,6 +4,17 @@ import { randomUUID } from "node:crypto"
 
 type BatchAction = "update_status" | "create_fulfillment" | "export"
 
+const VALID_TRANSITIONS: Record<string, string[]> = {
+  pending: ["processing", "canceled"],
+  processing: ["shipped", "canceled"],
+  shipped: ["delivered"],
+  delivered: ["completed"],
+  completed: [],
+  canceled: [],
+}
+
+const VALID_STATUSES = Object.keys(VALID_TRANSITIONS)
+
 async function emitEvent(scope: MedusaRequest["scope"], name: string, data: Record<string, unknown>) {
   try {
     const eventBus = scope.resolve("event_bus") as any
@@ -20,6 +31,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
   const body = (req.body ?? {}) as {
     action?: BatchAction
     order_ids?: string[]
+    status?: string
     data?: {
       status?: string
       fulfillment_data?: Record<string, unknown>
@@ -50,6 +62,85 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     })
   }
 
+  // For update_status: support both body.status and body.data.status
+  const targetStatus = body.action === "update_status"
+    ? (body.status || body.data?.status)
+    : undefined
+
+  if (body.action === "update_status") {
+    if (!targetStatus) {
+      return res.status(400).json({ error: "status is required for update_status action" })
+    }
+
+    if (!VALID_STATUSES.includes(targetStatus)) {
+      return res.status(400).json({
+        error: `Invalid status: ${targetStatus}. Valid statuses: ${VALID_STATUSES.join(", ")}`,
+      })
+    }
+
+    // Pre-validate: check all orders can transition before applying any
+    const placeholders = body.order_ids.map(() => "?").join(",")
+    const ordersResult = await pgConnection.raw(
+      `SELECT id, status, canceled_at FROM "order" WHERE id IN (${placeholders})`,
+      body.order_ids
+    )
+
+    const orderMap = new Map<string, any>()
+    for (const row of ordersResult?.rows || []) {
+      orderMap.set(row.id, row)
+    }
+
+    const preValidationErrors: Array<{ id: string; reason: string }> = []
+
+    for (const orderId of body.order_ids) {
+      const order = orderMap.get(orderId)
+      if (!order) {
+        preValidationErrors.push({ id: orderId, reason: "Order not found" })
+        continue
+      }
+      if (order.canceled_at) {
+        preValidationErrors.push({ id: orderId, reason: "Order is canceled" })
+        continue
+      }
+      const currentStatus = String(order.status || "pending")
+      const allowed = VALID_TRANSITIONS[currentStatus] || []
+      if (!allowed.includes(targetStatus)) {
+        preValidationErrors.push({
+          id: orderId,
+          reason: `Invalid transition: ${currentStatus} → ${targetStatus}`,
+        })
+      }
+    }
+
+    if (preValidationErrors.length > 0) {
+      return res.status(400).json({
+        error: "Some orders cannot transition to the target status. No changes were applied.",
+        success: 0,
+        failed: preValidationErrors,
+      })
+    }
+
+    // All validated — apply updates
+    for (const orderId of body.order_ids) {
+      const order = orderMap.get(orderId)
+      await pgConnection.raw(
+        `UPDATE "order" SET status = ?, updated_at = NOW() WHERE id = ?`,
+        [targetStatus, orderId]
+      )
+      await emitEvent(req.scope, "order.status_updated", {
+        order_id: orderId,
+        previous_status: order?.status,
+        status: targetStatus,
+      })
+    }
+
+    return res.status(200).json({
+      success: body.order_ids.length,
+      failed: [],
+    })
+  }
+
+  // Non-update_status actions (create_fulfillment, etc.)
   const results: Array<{ order_id: string; success: boolean; error?: string }> = []
 
   for (const orderId of body.order_ids) {
@@ -58,22 +149,6 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
 
       if (!order || order.canceled_at) {
         throw new Error("Order is canceled")
-      }
-
-      if (body.action === "update_status") {
-        if (!body.data?.status) {
-          throw new Error("data.status is required")
-        }
-
-        await pgConnection.raw(`UPDATE "order" SET status = ?, updated_at = NOW() WHERE id = ?`, [
-          body.data.status,
-          orderId,
-        ])
-
-        await emitEvent(req.scope, "order.status_updated", {
-          order_id: orderId,
-          status: body.data.status,
-        })
       }
 
       if (body.action === "create_fulfillment") {

--- a/src/api/admin/orders/route.ts
+++ b/src/api/admin/orders/route.ts
@@ -8,14 +8,20 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
   const limit = Math.min(Number(query.limit) || 20, 100)
   const offset = Math.max(Number(query.offset) || 0, 0)
 
-  const sortBy = query.sort_by === "total" ? "total" : "created_at"
+  const sortAllowList = ["created_at", "total", "status"]
+  const sortBy = sortAllowList.includes(String(query.sort_by)) ? String(query.sort_by) : "created_at"
   const sortOrder = String(query.sort_order || "desc").toLowerCase() === "asc" ? "ASC" : "DESC"
 
-  const statusAllowList = ["pending", "completed", "canceled", "archived", "requires_action"]
+  const statusAllowList = [
+    "pending", "processing", "shipped", "delivered",
+    "completed", "canceled", "archived", "requires_action",
+  ]
 
   const conditions: string[] = []
   const params: any[] = []
+  const joins: string[] = []
 
+  // Date range filters
   if (query.date_from) {
     conditions.push("o.created_at >= ?::timestamptz")
     params.push(query.date_from)
@@ -26,11 +32,13 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     params.push(query.date_to)
   }
 
+  // Status filter
   if (query.status && statusAllowList.includes(String(query.status))) {
     conditions.push("o.status = ?")
     params.push(query.status)
   }
 
+  // Amount filters
   const minAmount = query.amount_min ?? query.min_amount
   if (minAmount !== undefined && minAmount !== "") {
     conditions.push("COALESCE((o.raw_total->>'value')::numeric, o.total, 0) >= ?")
@@ -43,11 +51,36 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     params.push(Number(maxAmount))
   }
 
+  // Customer ID filter
   if (query.customer_id) {
     conditions.push("o.customer_id = ?")
     params.push(String(query.customer_id))
   }
 
+  // Customer email filter (JOIN to customer table)
+  if (query.email) {
+    joins.push(`LEFT JOIN customer c ON c.id = o.customer_id`)
+    conditions.push("c.email ILIKE ?")
+    params.push(`%${String(query.email)}%`)
+  }
+
+  // Order number / display_id filter
+  if (query.order_number) {
+    conditions.push("o.display_id::text = ?")
+    params.push(String(query.order_number))
+  }
+
+  // Payment status filter
+  if (query.payment_status) {
+    joins.push(
+      `LEFT JOIN order_payment_collection opc ON opc.order_id = o.id
+       LEFT JOIN payment_collection pcol ON pcol.id = opc.payment_collection_id`
+    )
+    conditions.push("pcol.status = ?")
+    params.push(String(query.payment_status))
+  }
+
+  // Product ID filter
   if (query.product_id) {
     conditions.push(
       `EXISTS (
@@ -60,17 +93,31 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
     params.push(String(query.product_id))
   }
 
+  // Free text search (searches across display_id, email, customer name)
+  if (query.q) {
+    const searchTerm = `%${String(query.q)}%`
+    if (!joins.some((j) => j.includes("LEFT JOIN customer c"))) {
+      joins.push(`LEFT JOIN customer c ON c.id = o.customer_id`)
+    }
+    conditions.push(
+      `(o.display_id::text ILIKE ? OR c.email ILIKE ? OR c.first_name ILIKE ? OR c.last_name ILIKE ?)`
+    )
+    params.push(searchTerm, searchTerm, searchTerm, searchTerm)
+  }
+
+  const joinClause = joins.length ? joins.join(" ") : ""
   const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""
 
   const countResult = await pgConnection.raw(
-    `SELECT COUNT(*)::int AS count FROM "order" o ${whereClause}`,
+    `SELECT COUNT(DISTINCT o.id)::int AS count FROM "order" o ${joinClause} ${whereClause}`,
     params
   )
 
   const listResult = await pgConnection.raw(
-    `SELECT o.* FROM "order" o
+    `SELECT DISTINCT o.* FROM "order" o
+     ${joinClause}
      ${whereClause}
-     ORDER BY o.${sortBy === "total" ? "total" : "created_at"} ${sortOrder}
+     ORDER BY o.${sortBy} ${sortOrder}
      LIMIT ? OFFSET ?`,
     [...params, limit, offset]
   )

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -134,6 +134,16 @@ export default defineMiddlewares({
       middlewares: [authenticate("user", ["bearer", "session"])],
     },
     {
+      matcher: "/admin/orders/:id",
+      method: ["GET", "PATCH"],
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
+      matcher: "/admin/orders/:id/timeline",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
       matcher: "/admin/orders/:id/return-request",
       method: "POST",
       middlewares: [authenticate("user", ["bearer", "session"])],


### PR DESCRIPTION
## Summary

- **Order status transition validation**: Added `PATCH /admin/orders/:id` with state machine validation (`pending→processing→shipped→delivered→completed`, `pending/processing→canceled`). Rejects invalid transitions with descriptive error messages. Also added `GET /admin/orders/:id` for single order retrieval.
- **Order timeline/activity log**: New `GET /admin/orders/:id/timeline` endpoint that aggregates events from order creation, notes, return requests, exchanges, payment captures, fulfillments, and cancellation into a chronological timeline with `{ events: [{ type, timestamp, description, actor }] }` response format.
- **Bulk order status update**: Enhanced `POST /admin/orders/batch` with `update_status` action supporting pre-validation — checks all orders can transition to target status before applying any changes (all-or-nothing). Returns `{ success, failed: [{ id, reason }] }`.
- **Order search enhancement**: Enhanced `GET /admin/orders` with new filters: `email` (customer email, ILIKE), `order_number` (display_id), `payment_status`, and free-text `q` param (searches across display_id, email, customer name). Added `status` as a sortable field.

## Test plan

- [ ] `PATCH /admin/orders/:id` with valid transition (e.g., `pending→processing`) returns 200
- [ ] `PATCH /admin/orders/:id` with invalid transition (e.g., `completed→pending`) returns 400 with descriptive error
- [ ] `GET /admin/orders/:id/timeline` returns chronological events array for an order
- [ ] `POST /admin/orders/batch` with `update_status` validates all orders before applying — returns 400 if any cannot transition
- [ ] `POST /admin/orders/batch` with `update_status` and all valid orders applies updates and returns success count
- [ ] `GET /admin/orders?email=customer@example.com` filters by customer email
- [ ] `GET /admin/orders?order_number=1234` filters by display_id
- [ ] `GET /admin/orders?payment_status=captured` filters by payment status
- [ ] `GET /admin/orders?q=search_term` searches across display_id, email, and customer name
- [ ] `GET /admin/orders?sort_by=status` sorts by status
- [ ] `npx tsc --noEmit` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)