### PR TITLE
fix(admin): inventory report SQL and audit-log route compatibility

### DIFF
--- a/src/api/admin/audit-log/route.ts
+++ b/src/api/admin/audit-log/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "../security/audit-logs/route"

--- a/src/api/admin/inventory/report/route.ts
+++ b/src/api/admin/inventory/report/route.ts
@@ -7,6 +7,10 @@ function toNum(value: unknown, fallback = 0): number {
 }
 
 export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const logger = req.scope.resolve("logger") as {
+    error: (message: string) => void
+  }
+
   try {
     const pgConnection = req.scope.resolve(
       ContainerRegistrationKeys.PG_CONNECTION
@@ -62,7 +66,15 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
         LEFT JOIN sales_by_product sbp ON sbp.product_id = ibp.product_id
       )
       SELECT
-        COALESCE(SUM(ibi.total_stock * COALESCE(ii.unit_cost, 0)), 0)::numeric AS total_inventory_value,
+        COALESCE(SUM(
+          ibi.total_stock * COALESCE(
+            CASE
+              WHEN (ii.metadata->>'unit_cost') ~ '^-?[0-9]+(\.[0-9]+)?$' THEN (ii.metadata->>'unit_cost')::numeric
+              ELSE NULL
+            END,
+            0
+          )
+        ), 0)::numeric AS total_inventory_value,
         COALESCE(ss.stockout_items / NULLIF(ss.total_items, 0), 0)::numeric AS stockout_rate,
         CASE
           WHEN COALESCE(t.avg_turnover_rate, 0) = 0 THEN 0
@@ -99,9 +111,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
 
     return res.status(200).json(report)
   } catch (err: any) {
-    return res.status(200).json({
-      data: [],
-      message: "Query failed, check schema",
-    })
+    logger.error(`[inventory-report] Query error: ${err?.message || "Unknown error"}`)
+    return res.status(500).json({ error: "Failed to generate inventory report" })
   }
 }

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -83,6 +83,11 @@ export default defineMiddlewares({
       middlewares: [authenticate("user", ["bearer", "session"])],
     },
     {
+      matcher: "/admin/audit-log",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
       matcher: "/admin/security/roles",
       method: ["GET", "POST"],
       middlewares: [


### PR DESCRIPTION
### Motivation
- The `/admin/inventory/report` endpoint was returning 500 due to schema mismatch: code referenced a non-existent `inventory_item.unit_cost` column in Medusa v2 schema.  
- The `/admin/audit-log` path produced 404 because only `/admin/security/audit-logs` existed; a compatibility alias and middleware entry were needed to match expected route and auth behavior.

### Description
- Updated `src/api/admin/inventory/report/route.ts` to safely compute `total_inventory_value` by reading `unit_cost` from `inventory_item.metadata->>'unit_cost'` with a numeric format check, avoiding references to a missing `unit_cost` column.  
- Added structured error logging in the inventory report handler (`logger.error('[inventory-report] Query error: ...')`) and changed the error response to return HTTP 500 with a clear message on real query failures.  
- Added a compatibility route `src/api/admin/audit-log/route.ts` that re-exports the existing security audit logs handler to avoid 404s.  
- Registered `/admin/audit-log` in `src/api/middlewares.ts` with the same authentication middleware as `/admin/security/audit-logs` to enforce consistent access control.

### Testing
- Ran `npm run build` which failed in the environment because the `medusa` binary is not available (`sh: 1: medusa: not found`). (failure)  
- Ran `npx tsc --noEmit` which failed due to missing type definition packages in the environment (multiple `TS2688` errors for type libs). (failure)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3d96660e48333a3daa03efa2b29a4)