### PR TITLE
fix(cd): add branch promotion — develop → staging → main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,3 +1,16 @@
+# =============================================================
+# CD Pipeline — Branch Promotion Model
+# =============================================================
+# Flow: develop → staging → main
+# 
+# 回退策略 / Rollback:
+# - Staging 验收不通过：不审批 promote-to-production，staging 保持当前版本。
+#   下次 develop 推进时会覆盖 staging。
+# - 生产出问题：
+#   1. 首选：使用 deploy-production.yml 手动触发回滚到上一版本
+#   2. 紧急：SSH 到 VPS 手动 git reset --hard <上一个 commit> 或 docker rollback
+#   3. Git：git revert 问题 commit，走正常 PR → CI → CD 流程
+# =============================================================
 name: CD Pipeline
 
 on:
@@ -165,7 +178,7 @@ jobs:
   # ============================================================
   deploy-staging:
     name: "🚀 Deploy → Staging"
-    needs: e2e-test
+    needs: promote-to-staging
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -262,3 +275,125 @@ jobs:
           fi
 
           echo "✅ All staging E2E checks passed"
+
+  promote-to-staging:
+    name: "🔀 Promote → Staging"
+    needs: e2e-test
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge develop into staging
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin staging
+          git checkout staging
+          git merge origin/develop --no-edit --ff-only
+          if [ $? -ne 0 ]; then
+            echo "❌ Fast-forward merge failed — staging has diverged from develop."
+            echo "Please manually resolve the conflict or reset staging."
+            exit 1
+          fi
+          git push origin staging
+
+  promote-to-production:
+    name: "🔀 Promote → Production"
+    needs: e2e-staging
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge staging into main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
+          git merge origin/staging --no-edit --ff-only
+          if [ $? -ne 0 ]; then
+            echo "❌ Fast-forward merge failed — main has diverged from staging."
+            echo "Please manually resolve the conflict or reset main."
+            exit 1
+          fi
+          git push origin main
+
+  deploy-production:
+    name: "🚀 Deploy → Production"
+    needs: promote-to-production
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Deploy to production
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 10m
+          script: |
+            set -e
+            CONTAINER="nordhjem_medusa"
+            REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+            IMAGE="ghcr.io/${REPO_LOWER}:develop"
+            PORT=9000
+
+            echo "=== Pulling latest image ==="
+            docker pull $IMAGE
+
+            echo "=== Saving env vars ==="
+            ENV_FILE="/tmp/${CONTAINER}_env.txt"
+            docker inspect $CONTAINER --format '{{range .Config.Env}}{{println .}}{{end}}' > $ENV_FILE 2>/dev/null || true
+
+            echo "=== Running DB migration ==="
+            if [ -f "$ENV_FILE" ] && [ -s "$ENV_FILE" ]; then
+              docker run --rm --network nordhjem_backend --env-file $ENV_FILE $IMAGE npx medusa db:migrate || echo "Migration warning"
+            fi
+
+            echo "=== Replacing container ==="
+            docker stop $CONTAINER 2>/dev/null || true
+            docker rm $CONTAINER 2>/dev/null || true
+
+            if [ -f "$ENV_FILE" ] && [ -s "$ENV_FILE" ]; then
+              docker create --name $CONTAINER --publish $PORT:9000 --restart unless-stopped --env-file $ENV_FILE $IMAGE npx medusa start
+            else
+              echo "ERROR: No env file" && exit 1
+            fi
+
+            docker network connect nordhjem_backend $CONTAINER 2>/dev/null || true
+            docker network connect nordhjem_frontend $CONTAINER 2>/dev/null || true
+            docker start $CONTAINER
+            rm -f $ENV_FILE
+            echo "=== Deploy production complete ==="
+
+      - name: Health check (production)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 3m
+          script: |
+            sleep 30
+            for i in 1 2 3 4 5 6; do
+              STATUS=$(curl -sf -o /dev/null -w "%{http_code}" http://localhost:9000/health 2>/dev/null || echo "000")
+              if [ "$STATUS" = "200" ]; then
+                echo "✅ Production health check passed"
+                exit 0
+              fi
+              echo "Attempt $i: HTTP $STATUS, waiting 15s..."
+              sleep 15
+            done
+            echo "❌ Health check failed"
+            docker logs nordhjem_medusa --tail 30 2>&1 || true
+            exit 1


### PR DESCRIPTION
### Motivation
- Introduce a branch-promotion flow so code moves develop → staging → main with manual approvals for staging/production.
- Ensure promotion merges are safe by requiring fast-forward (`--ff-only`) and failing the job on divergence to force human intervention.
- Provide an automated production deploy job for the backend and document rollback guidance at the top of the workflow.

### Description
- Added a header comment block at the top of `.github/workflows/cd.yml` describing the branch promotion flow and rollback strategy.
- Added `promote-to-staging` job (uses `actions/checkout@v4`, `environment: staging`, fast-forward merge `origin/develop` → `staging` and `git push`) and set `deploy-staging` to `needs: promote-to-staging`.
- Added `promote-to-production` job (uses `actions/checkout@v4`, `environment: production`, fast-forward merge `origin/staging` → `main` and `git push`).
- Added backend `deploy-production` job that pulls the backend image, runs migrations, replaces/creates container `nordhjem_medusa` and performs health checks on port `9000`; backend staging continues to use the `develop` image tag.

### Testing
- Parsed the modified workflow YAML successfully using `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cd.yml")'` which returned `ok` (syntax valid).
- Created branch `fix/cd-branch-promotion` and committed the change with message `fix(cd): add branch promotion — develop → staging → main` which succeeded.
- Attempted to fetch and modify the frontend repository `nextjs-starter-medusa` but cloning failed due to a network/permission error (`git clone` returned HTTP 403), so frontend workflow changes were not applied in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b449138a388333abfb1d2c2714eccf)