### PR TITLE
feat: complete Phase 1 backend — SLA, customer prefs, finance, inventory, security

### DIFF
--- a/src/api/admin/after-sales/sla-breaches/route.ts
+++ b/src/api/admin/after-sales/sla-breaches/route.ts
@@ -1,0 +1,91 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+function toPositiveInt(value: unknown, fallback: number) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback
+  }
+  return Math.floor(parsed)
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  try {
+    const pgConnection = req.scope.resolve("pgConnection") as any
+
+    const query = req.query as Record<string, string | undefined>
+    const status = query.status
+    const severity = query.severity
+    const page = toPositiveInt(query.page, 1)
+    const limit = Math.min(toPositiveInt(query.limit, 20), 100)
+    const offset = (page - 1) * limit
+
+    const conditions: string[] = [
+      "t.sla_deadline IS NOT NULL",
+      "NOW() > t.sla_deadline",
+      "(t.status IS DISTINCT FROM 'resolved')",
+    ]
+    const params: unknown[] = []
+
+    if (status) {
+      params.push(status)
+      conditions.push(`t.status = $${params.length}`)
+    }
+
+    if (severity) {
+      params.push(severity)
+      conditions.push(`t.priority = $${params.length}`)
+    }
+
+    const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""
+
+    const totalQuery = `
+      SELECT COUNT(*)::int AS total
+      FROM ticket t
+      ${whereClause}
+    `
+    const totalResult = await pgConnection.raw(totalQuery, params)
+    const total = Number(totalResult?.rows?.[0]?.total ?? 0)
+
+    const listParams = [...params, limit, offset]
+
+    const listQuery = `
+      SELECT
+        t.id,
+        t.order_id,
+        t.customer_id,
+        t.subject,
+        t.status,
+        t.priority AS severity,
+        t.created_at,
+        t.sla_deadline,
+        EXTRACT(EPOCH FROM (NOW() - t.sla_deadline))::int AS overdue_seconds
+      FROM ticket t
+      ${whereClause}
+      ORDER BY t.sla_deadline ASC
+      LIMIT $${listParams.length - 1}
+      OFFSET $${listParams.length}
+    `
+
+    const result = await pgConnection.raw(listQuery, listParams)
+
+    return res.status(200).json({
+      page,
+      limit,
+      total,
+      sla_breaches: (result?.rows || []).map((row: any) => ({
+        id: row.id,
+        order_id: row.order_id,
+        customer_id: row.customer_id,
+        subject: row.subject,
+        status: row.status,
+        severity: row.severity,
+        created_at: row.created_at,
+        sla_deadline: row.sla_deadline,
+        overdue_seconds: Number(row.overdue_seconds || 0),
+      })),
+    })
+  } catch (err: any) {
+    console.error("[after-sales][sla-breaches][GET]", err)
+    return res.status(500).json({ error: "Failed to fetch SLA breaches" })
+  }
+}

--- a/src/api/admin/after-sales/sla-config/route.ts
+++ b/src/api/admin/after-sales/sla-config/route.ts
@@ -1,0 +1,98 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+type SlaConfig = {
+  response_time_hours: number
+  resolution_time_hours: number
+  escalation_enabled: boolean
+}
+
+const DEFAULT_CONFIG: SlaConfig = {
+  response_time_hours: 24,
+  resolution_time_hours: 72,
+  escalation_enabled: true,
+}
+
+async function ensureSlaConfigTable(pgConnection: any) {
+  await pgConnection.raw(`
+    CREATE TABLE IF NOT EXISTS after_sales_sla_config (
+      id INT PRIMARY KEY,
+      response_time_hours INT NOT NULL DEFAULT 24,
+      resolution_time_hours INT NOT NULL DEFAULT 72,
+      escalation_enabled BOOLEAN NOT NULL DEFAULT true,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+}
+
+async function getSlaConfig(pgConnection: any): Promise<SlaConfig> {
+  const result = await pgConnection.raw(
+    `SELECT response_time_hours, resolution_time_hours, escalation_enabled
+     FROM after_sales_sla_config
+     WHERE id = 1`
+  )
+
+  const row = result?.rows?.[0]
+  if (!row) {
+    await pgConnection.raw(
+      `INSERT INTO after_sales_sla_config (id, response_time_hours, resolution_time_hours, escalation_enabled)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (id) DO NOTHING`,
+      [1, DEFAULT_CONFIG.response_time_hours, DEFAULT_CONFIG.resolution_time_hours, DEFAULT_CONFIG.escalation_enabled]
+    )
+    return DEFAULT_CONFIG
+  }
+
+  return {
+    response_time_hours: Number(row.response_time_hours ?? DEFAULT_CONFIG.response_time_hours),
+    resolution_time_hours: Number(row.resolution_time_hours ?? DEFAULT_CONFIG.resolution_time_hours),
+    escalation_enabled: Boolean(row.escalation_enabled),
+  }
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  try {
+    const pgConnection = req.scope.resolve("pgConnection") as any
+    await ensureSlaConfigTable(pgConnection)
+
+    const config = await getSlaConfig(pgConnection)
+
+    return res.status(200).json({ sla_config: config })
+  } catch (err: any) {
+    console.error("[after-sales][sla-config][GET]", err)
+    return res.status(500).json({ error: "Failed to fetch SLA config" })
+  }
+}
+
+export async function PUT(req: MedusaRequest, res: MedusaResponse) {
+  try {
+    const pgConnection = req.scope.resolve("pgConnection") as any
+    await ensureSlaConfigTable(pgConnection)
+
+    const body = (req.body || {}) as Partial<SlaConfig>
+
+    const responseTimeHours = Number(body.response_time_hours ?? DEFAULT_CONFIG.response_time_hours)
+    const resolutionTimeHours = Number(body.resolution_time_hours ?? DEFAULT_CONFIG.resolution_time_hours)
+    const escalationEnabled =
+      typeof body.escalation_enabled === "boolean"
+        ? body.escalation_enabled
+        : DEFAULT_CONFIG.escalation_enabled
+
+    await pgConnection.raw(
+      `INSERT INTO after_sales_sla_config (id, response_time_hours, resolution_time_hours, escalation_enabled, updated_at)
+       VALUES ($1, $2, $3, $4, NOW())
+       ON CONFLICT (id)
+       DO UPDATE SET
+         response_time_hours = EXCLUDED.response_time_hours,
+         resolution_time_hours = EXCLUDED.resolution_time_hours,
+         escalation_enabled = EXCLUDED.escalation_enabled,
+         updated_at = NOW()`,
+      [1, responseTimeHours, resolutionTimeHours, escalationEnabled]
+    )
+
+    const config = await getSlaConfig(pgConnection)
+    return res.status(200).json({ sla_config: config })
+  } catch (err: any) {
+    console.error("[after-sales][sla-config][PUT]", err)
+    return res.status(500).json({ error: "Failed to update SLA config" })
+  }
+}

--- a/src/api/admin/finance/refund-summary/route.ts
+++ b/src/api/admin/finance/refund-summary/route.ts
@@ -1,0 +1,99 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+function toNumber(value: unknown, fallback = 0) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  try {
+    const pgConnection = req.scope.resolve("pgConnection") as any
+    const query = req.query as Record<string, string | undefined>
+
+    const startDate = query.start_date
+    const endDate = query.end_date
+    const currencyCode = (query.currency_code || "").toLowerCase().trim()
+
+    const conditions: string[] = ["1=1"]
+    const params: unknown[] = []
+
+    if (startDate) {
+      params.push(startDate)
+      conditions.push(`r.created_at >= $${params.length}::timestamptz`)
+    }
+
+    if (endDate) {
+      params.push(endDate)
+      conditions.push(`r.created_at < ($${params.length}::date + interval '1 day')`)
+    }
+
+    if (currencyCode) {
+      params.push(currencyCode)
+      conditions.push(`LOWER(COALESCE(r.currency_code, '')) = $${params.length}`)
+    }
+
+    const whereClause = `WHERE ${conditions.join(" AND ")}`
+
+    const summaryQuery = `
+      SELECT
+        COALESCE(SUM(
+          CASE
+            WHEN r.raw_amount IS NOT NULL AND r.raw_amount->>'value' IS NOT NULL
+              THEN (r.raw_amount->>'value')::numeric
+            WHEN r.amount IS NOT NULL
+              THEN r.amount::numeric
+            ELSE 0
+          END
+        ), 0) AS total_refunds,
+        COUNT(*)::int AS refund_count
+      FROM refund r
+      ${whereClause}
+    `
+
+    const summaryResult = await pgConnection.raw(summaryQuery, params)
+    const summary = summaryResult?.rows?.[0] || {}
+
+    const totalRefunds = toNumber(summary.total_refunds)
+    const refundCount = toNumber(summary.refund_count)
+
+    const reasonQuery = `
+      SELECT
+        COALESCE(NULLIF(r.reason, ''), r.metadata->>'reason', 'unknown') AS reason,
+        COUNT(*)::int AS count,
+        COALESCE(SUM(
+          CASE
+            WHEN r.raw_amount IS NOT NULL AND r.raw_amount->>'value' IS NOT NULL
+              THEN (r.raw_amount->>'value')::numeric
+            WHEN r.amount IS NOT NULL
+              THEN r.amount::numeric
+            ELSE 0
+          END
+        ), 0) AS total_amount
+      FROM refund r
+      ${whereClause}
+      GROUP BY COALESCE(NULLIF(r.reason, ''), r.metadata->>'reason', 'unknown')
+      ORDER BY total_amount DESC
+    `
+
+    const reasonResult = await pgConnection.raw(reasonQuery, params)
+
+    return res.status(200).json({
+      total_refunds: totalRefunds,
+      refund_count: refundCount,
+      average_refund: refundCount > 0 ? totalRefunds / refundCount : 0,
+      refunds_by_reason: (reasonResult?.rows || []).map((row: any) => ({
+        reason: row.reason,
+        count: toNumber(row.count),
+        total_amount: toNumber(row.total_amount),
+      })),
+      filters: {
+        start_date: startDate || null,
+        end_date: endDate || null,
+        currency_code: currencyCode || null,
+      },
+    })
+  } catch (err: any) {
+    console.error("[finance][refund-summary][GET]", err)
+    return res.status(500).json({ error: "Failed to query refund summary" })
+  }
+}

--- a/src/api/admin/finance/revenue-trend/route.ts
+++ b/src/api/admin/finance/revenue-trend/route.ts
@@ -1,0 +1,72 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+function toNumber(value: unknown, fallback = 0) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  try {
+    const pgConnection = req.scope.resolve("pgConnection") as any
+    const query = req.query as Record<string, string | undefined>
+
+    const period = query.period || "daily"
+    const startDate = query.start_date
+    const endDate = query.end_date
+
+    const periodMap: Record<string, string> = {
+      daily: "day",
+      weekly: "week",
+      monthly: "month",
+    }
+
+    const granularity = periodMap[period] || "day"
+    const conditions: string[] = ["o.canceled_at IS NULL"]
+    const params: unknown[] = []
+
+    if (startDate) {
+      params.push(startDate)
+      conditions.push(`o.created_at >= $${params.length}::timestamptz`)
+    }
+
+    if (endDate) {
+      params.push(endDate)
+      conditions.push(`o.created_at < ($${params.length}::date + interval '1 day')`)
+    }
+
+    const whereClause = `WHERE ${conditions.join(" AND ")}`
+
+    const trendQuery = `
+      SELECT
+        date_trunc('${granularity}', o.created_at) AS period,
+        COALESCE(SUM(
+          CASE
+            WHEN o.raw_total IS NOT NULL AND o.raw_total->>'value' IS NOT NULL
+              THEN (o.raw_total->>'value')::numeric
+            ELSE COALESCE(o.total, 0)::numeric
+          END
+        ), 0) AS revenue,
+        COUNT(*)::int AS order_count
+      FROM "order" o
+      ${whereClause}
+      GROUP BY period
+      ORDER BY period ASC
+    `
+
+    const result = await pgConnection.raw(trendQuery, params)
+
+    return res.status(200).json({
+      period,
+      start_date: startDate || null,
+      end_date: endDate || null,
+      revenue_trend: (result?.rows || []).map((row: any) => ({
+        period: row.period,
+        revenue: toNumber(row.revenue),
+        order_count: toNumber(row.order_count),
+      })),
+    })
+  } catch (err: any) {
+    console.error("[finance][revenue-trend][GET]", err)
+    return res.status(500).json({ error: "Failed to query revenue trend" })
+  }
+}

--- a/src/api/admin/inventory/low-stock-alerts/route.ts
+++ b/src/api/admin/inventory/low-stock-alerts/route.ts
@@ -1,0 +1,87 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+function toPositiveInt(value: unknown, fallback: number) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback
+  }
+  return Math.floor(parsed)
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  try {
+    const pgConnection = req.scope.resolve("pgConnection") as any
+    const query = req.query as Record<string, string | undefined>
+
+    const threshold = toPositiveInt(query.threshold, 5)
+    const locationId = query.location_id
+    const page = toPositiveInt(query.page, 1)
+    const limit = Math.min(toPositiveInt(query.limit, 20), 100)
+    const offset = (page - 1) * limit
+
+    const conditions: string[] = [
+      "(COALESCE(il.stocked_quantity, 0) - COALESCE(il.reserved_quantity, 0)) < $1",
+    ]
+    const params: unknown[] = [threshold]
+
+    if (locationId) {
+      params.push(locationId)
+      conditions.push(`il.location_id = $${params.length}`)
+    }
+
+    const whereClause = `WHERE ${conditions.join(" AND ")}`
+
+    const totalQuery = `
+      SELECT COUNT(*)::int AS total
+      FROM inventory_level il
+      ${whereClause}
+    `
+
+    const totalResult = await pgConnection.raw(totalQuery, params)
+    const total = Number(totalResult?.rows?.[0]?.total ?? 0)
+
+    const listParams = [...params, limit, offset]
+
+    const listQuery = `
+      SELECT
+        il.id,
+        il.inventory_item_id,
+        il.location_id,
+        COALESCE(il.stocked_quantity, 0) AS stocked_quantity,
+        COALESCE(il.reserved_quantity, 0) AS reserved_quantity,
+        (COALESCE(il.stocked_quantity, 0) - COALESCE(il.reserved_quantity, 0)) AS available_quantity,
+        ii.sku,
+        COALESCE(ii.title, pv.title, '') AS title
+      FROM inventory_level il
+      LEFT JOIN inventory_item ii ON ii.id = il.inventory_item_id
+      LEFT JOIN product_variant_inventory_item pvii ON pvii.inventory_item_id = il.inventory_item_id
+      LEFT JOIN product_variant pv ON pv.id = pvii.variant_id
+      ${whereClause}
+      ORDER BY available_quantity ASC, il.updated_at DESC
+      LIMIT $${listParams.length - 1}
+      OFFSET $${listParams.length}
+    `
+
+    const result = await pgConnection.raw(listQuery, listParams)
+
+    return res.status(200).json({
+      page,
+      limit,
+      threshold,
+      total,
+      low_stock_alerts: (result?.rows || []).map((row: any) => ({
+        id: row.id,
+        inventory_item_id: row.inventory_item_id,
+        location_id: row.location_id,
+        sku: row.sku,
+        title: row.title,
+        stocked_quantity: Number(row.stocked_quantity || 0),
+        reserved_quantity: Number(row.reserved_quantity || 0),
+        available_quantity: Number(row.available_quantity || 0),
+      })),
+    })
+  } catch (err: any) {
+    console.error("[inventory][low-stock-alerts][GET]", err)
+    return res.status(500).json({ error: "Failed to fetch low stock alerts" })
+  }
+}

--- a/src/api/admin/inventory/movement-logs/route.ts
+++ b/src/api/admin/inventory/movement-logs/route.ts
@@ -1,0 +1,86 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+function toPositiveInt(value: unknown, fallback: number) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback
+  }
+  return Math.floor(parsed)
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  try {
+    const pgConnection = req.scope.resolve("pgConnection") as any
+    const query = req.query as Record<string, string | undefined>
+
+    const inventoryItemId = query.inventory_item_id
+    const startDate = query.start_date
+    const endDate = query.end_date
+    const page = toPositiveInt(query.page, 1)
+    const limit = Math.min(toPositiveInt(query.limit, 20), 100)
+    const offset = (page - 1) * limit
+
+    const conditions: string[] = ["1=1"]
+    const params: unknown[] = []
+
+    if (inventoryItemId) {
+      params.push(inventoryItemId)
+      conditions.push(`ml.inventory_item_id = $${params.length}`)
+    }
+
+    if (startDate) {
+      params.push(startDate)
+      conditions.push(`ml.created_at >= $${params.length}::timestamptz`)
+    }
+
+    if (endDate) {
+      params.push(endDate)
+      conditions.push(`ml.created_at < ($${params.length}::date + interval '1 day')`)
+    }
+
+    const whereClause = `WHERE ${conditions.join(" AND ")}`
+
+    const totalQuery = `SELECT COUNT(*)::int AS total FROM inventory_movement ml ${whereClause}`
+    const totalResult = await pgConnection.raw(totalQuery, params)
+    const total = Number(totalResult?.rows?.[0]?.total ?? 0)
+
+    const listParams = [...params, limit, offset]
+    const listQuery = `
+      SELECT
+        ml.id,
+        ml.inventory_item_id,
+        ml.location_id,
+        ml.type,
+        ml.quantity,
+        ml.reference,
+        ml.metadata,
+        ml.created_at
+      FROM inventory_movement ml
+      ${whereClause}
+      ORDER BY ml.created_at DESC
+      LIMIT $${listParams.length - 1}
+      OFFSET $${listParams.length}
+    `
+
+    const result = await pgConnection.raw(listQuery, listParams)
+
+    return res.status(200).json({
+      page,
+      limit,
+      total,
+      movement_logs: result?.rows || [],
+    })
+  } catch (err: any) {
+    console.error("[inventory][movement-logs][GET]", err)
+
+    if (String(err?.message || "").includes('relation "inventory_movement" does not exist')) {
+      return res.status(200).json({
+        page: 1,
+        limit: 20,
+        total: 0,
+        movement_logs: [],
+      })
+    }
+    return res.status(500).json({ error: "Failed to fetch inventory movement logs" })
+  }
+}

--- a/src/api/admin/security/events-summary/route.ts
+++ b/src/api/admin/security/events-summary/route.ts
@@ -1,0 +1,86 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+function toNumber(value: unknown, fallback = 0) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  try {
+    const pgConnection = req.scope.resolve("pgConnection") as any
+
+    await pgConnection.raw(
+      `CREATE TABLE IF NOT EXISTS audit_log (
+        id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+        action_type TEXT NOT NULL,
+        resource TEXT NOT NULL,
+        resource_id TEXT,
+        actor_id TEXT,
+        timestamp TIMESTAMPTZ DEFAULT now(),
+        request_body_summary TEXT,
+        metadata JSONB DEFAULT '{}'
+      )`
+    )
+
+    const failedLoginsResult = await pgConnection.raw(
+      `SELECT COUNT(*)::int AS count
+       FROM audit_log
+       WHERE timestamp >= NOW() - INTERVAL '24 hours'
+         AND (
+           action_type ILIKE $1
+           OR action_type ILIKE $2
+           OR resource ILIKE $3
+         )`,
+      ["%login_failed%", "%failed_login%", "%login%"]
+    )
+
+    const suspiciousIpsResult = await pgConnection.raw(
+      `SELECT COALESCE(json_agg(ip), '[]'::json) AS ips
+       FROM (
+         SELECT
+           COALESCE(metadata->>'ip_address', metadata->>'ip', metadata->>'client_ip') AS ip,
+           COUNT(*)::int AS hit_count
+         FROM audit_log
+         WHERE timestamp >= NOW() - INTERVAL '24 hours'
+         GROUP BY COALESCE(metadata->>'ip_address', metadata->>'ip', metadata->>'client_ip')
+         HAVING COUNT(*) >= 10
+       ) suspicious
+       WHERE ip IS NOT NULL`
+    )
+
+    const rateLimitHitsResult = await pgConnection.raw(
+      `SELECT COUNT(*)::int AS count
+       FROM audit_log
+       WHERE timestamp >= NOW() - INTERVAL '24 hours'
+         AND (
+           action_type ILIKE $1
+           OR action_type ILIKE $2
+           OR resource ILIKE $3
+         )`,
+      ["%rate_limit%", "%too_many_requests%", "%rate-limit%"]
+    )
+
+    const lastIncidentResult = await pgConnection.raw(
+      `SELECT id, action_type, resource, actor_id, timestamp, metadata
+       FROM audit_log
+       WHERE
+         action_type ILIKE $1
+         OR action_type ILIKE $2
+         OR action_type ILIKE $3
+         OR action_type ILIKE $4
+       ORDER BY timestamp DESC
+       LIMIT 1`,
+      ["%failed%", "%suspicious%", "%rate_limit%", "%incident%"]
+    )
+
+    return res.status(200).json({
+      failed_logins_24h: toNumber(failedLoginsResult?.rows?.[0]?.count),
+      suspicious_ips: suspiciousIpsResult?.rows?.[0]?.ips || [],
+      rate_limit_hits_24h: toNumber(rateLimitHitsResult?.rows?.[0]?.count),
+      last_security_incident: lastIncidentResult?.rows?.[0] || null,
+    })
+  } catch (err: any) {
+    console.error("[security][events-summary][GET]", err)
+    return res.status(500).json({ error: "Failed to query security events summary" })
+  }
+}

--- a/src/api/admin/security/health-check/route.ts
+++ b/src/api/admin/security/health-check/route.ts
@@ -1,0 +1,40 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+function envEnabled(name: string) {
+  const value = process.env[name]
+  if (!value) {
+    return false
+  }
+  return ["1", "true", "yes", "enabled", "on"].includes(value.toLowerCase())
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  try {
+    const pgConnection = req.scope.resolve("pgConnection") as any
+
+    const middlewareText = await pgConnection.raw(
+      `SELECT to_regclass('public.audit_log')::text AS audit_log_table`
+    )
+
+    const rateLimitingEnabled =
+      envEnabled("RATE_LIMIT_ENABLED") || envEnabled("MEDUSA_RATE_LIMIT_ENABLED")
+
+    const corsConfigured =
+      Boolean(process.env.STORE_CORS) ||
+      Boolean(process.env.ADMIN_CORS) ||
+      Boolean(process.env.AUTH_CORS)
+
+    const helmetEnabled = envEnabled("HELMET_ENABLED") || envEnabled("MEDUSA_HELMET_ENABLED")
+    const auditLoggingEnabled = Boolean(middlewareText?.rows?.[0]?.audit_log_table)
+
+    return res.status(200).json({
+      rate_limiting_enabled: rateLimitingEnabled,
+      cors_configured: corsConfigured,
+      helmet_enabled: helmetEnabled,
+      audit_logging_enabled: auditLoggingEnabled,
+    })
+  } catch (err: any) {
+    console.error("[security][health-check][GET]", err)
+    return res.status(500).json({ error: "Failed to run security health check" })
+  }
+}

--- a/src/api/store/customers/me/notification-preferences/route.ts
+++ b/src/api/store/customers/me/notification-preferences/route.ts
@@ -1,0 +1,85 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+type NotificationPreferences = {
+  order_updates: boolean
+  promotions: boolean
+  newsletter: boolean
+}
+
+const DEFAULT_PREFERENCES: NotificationPreferences = {
+  order_updates: true,
+  promotions: true,
+  newsletter: true,
+}
+
+function normalizePreferences(input: any): NotificationPreferences {
+  return {
+    order_updates:
+      typeof input?.order_updates === "boolean"
+        ? input.order_updates
+        : DEFAULT_PREFERENCES.order_updates,
+    promotions:
+      typeof input?.promotions === "boolean"
+        ? input.promotions
+        : DEFAULT_PREFERENCES.promotions,
+    newsletter:
+      typeof input?.newsletter === "boolean"
+        ? input.newsletter
+        : DEFAULT_PREFERENCES.newsletter,
+  }
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  try {
+    const customerService = req.scope.resolve("customerModuleService") as any
+    const customerId = (req as any).auth_context?.actor_id
+
+    if (!customerId) {
+      return res.status(401).json({ error: "Authentication required" })
+    }
+
+    const customer = await customerService.retrieveCustomer(customerId)
+    if (!customer) {
+      return res.status(404).json({ error: "Customer not found" })
+    }
+
+    const preferences = normalizePreferences(customer?.metadata?.notification_preferences)
+    return res.status(200).json({ notification_preferences: preferences })
+  } catch (err: any) {
+    console.error("[customers][notification-preferences][GET]", err)
+    return res.status(500).json({ error: "Failed to fetch notification preferences" })
+  }
+}
+
+export async function PUT(req: MedusaRequest, res: MedusaResponse) {
+  try {
+    const customerService = req.scope.resolve("customerModuleService") as any
+    const customerId = (req as any).auth_context?.actor_id
+
+    if (!customerId) {
+      return res.status(401).json({ error: "Authentication required" })
+    }
+
+    const body = (req.body || {}) as Partial<NotificationPreferences>
+    const updatedPreferences = normalizePreferences(body)
+
+    const customer = await customerService.retrieveCustomer(customerId)
+    if (!customer) {
+      return res.status(404).json({ error: "Customer not found" })
+    }
+
+    const nextMetadata = {
+      ...(customer.metadata || {}),
+      notification_preferences: updatedPreferences,
+    }
+
+    await customerService.updateCustomers(customerId, {
+      metadata: nextMetadata,
+    })
+
+    return res.status(200).json({ notification_preferences: updatedPreferences })
+  } catch (err: any) {
+    console.error("[customers][notification-preferences][PUT]", err)
+    return res.status(500).json({ error: "Failed to update notification preferences" })
+  }
+}


### PR DESCRIPTION
### Motivation
- 完成 Phase 1 中剩余后端功能，使售后、用户账户、财务、库存与安全合规模块达到 100% 要求。 
- 这些接口需要在现有 Medusa v2 风格的路由与数据库访问层上补齐并保持一致的错误处理与参数约定。 
- 提供可分页/可筛选的管理端汇总与告警接口，以便前端和运维消费自动化监控与报表。 

### Description
- M5 (After-sales): 新增 SLA 配置与超时检查接口，包含 `GET /admin/after-sales/sla-config` 与 `PUT /admin/after-sales/sla-config`（默认 `response_time_hours=24`、`resolution_time_hours=72`、`escalation_enabled=true`），以及 `GET /admin/after-sales/sla-breaches` 支持 `status`/`severity`/`page`/`limit`，文件：`src/api/admin/after-sales/sla-config/route.ts`、`src/api/admin/after-sales/sla-breaches/route.ts`。 
- M6 (User Account): 新增用户通知偏好 `GET` / `PUT` 接口，偏好存储在 customer 的 `metadata.notification_preferences`，默认全 `true`，文件：`src/api/store/customers/me/notification-preferences/route.ts`。 
- M11 (Finance): 新增退款汇总与收入趋势报告，`GET /admin/finance/refund-summary` 支持 `start_date`/`end_date`/`currency_code` 返回 `total_refunds`/`refund_count`/`average_refund`/`refunds_by_reason`，以及 `GET /admin/finance/revenue-trend` 支持 `period`/日期范围按日/周/月聚合，文件：`src/api/admin/finance/refund-summary/route.ts`、`src/api/admin/finance/revenue-trend/route.ts`。 
- M13a (Inventory Manual): 新增低库存预警与库存变动日志，`GET /admin/inventory/low-stock-alerts` 支持 `threshold`/`location_id`/分页并关联 SKU/title，`GET /admin/inventory/movement-logs` 支持按 `inventory_item_id` 和时间区间筛选且在表不存在时安全返回空列表，文件：`src/api/admin/inventory/low-stock-alerts/route.ts`、`src/api/admin/inventory/movement-logs/route.ts`。 
- M18a (Security Compliance): 新增安全事件汇总与健康检查，`GET /admin/security/events-summary` 聚合 `failed_logins_24h`/`suspicious_ips`/`rate_limit_hits_24h`/`last_security_incident`，以及 `GET /admin/security/health-check` 报告 `rate_limiting_enabled`/`cors_configured`/`helmet_enabled`/`audit_logging_enabled`，文件：`src/api/admin/security/events-summary/route.ts`、`src/api/admin/security/health-check/route.ts`。 
- 所有新增路由遵循项目约定使用 `req.scope.resolve(...)` 获取服务或 `pgConnection`，SQL 占位符为 `$1,$2,...`，并在 `catch` 中统一使用 `console.error()` 打日志。 

### Testing
- 运行了 `npx tsc --noEmit`，TypeScript 检查在当前环境中失败，原因为仓库中缺少外部依赖与 Node/Medusa 类型声明（例如 `@medusajs/*` 及 `@types/node`），这些错误为预先存在的依赖/类型配置问题，与本次新增的路由实现逻辑无直接语法错误迹象。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b44dde68a883339eac076b8105a831)