### PR TITLE
feat(cd): add pre-deploy pg_dump backups for staging and production

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -182,6 +182,54 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Backup staging database
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 5m
+          script: |
+            set -e
+            TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+            BACKUP_DIR="/opt/nordhjem/backups/staging"
+            MEDUSA_CONTAINER="nordhjem_medusa_staging"
+            mkdir -p "$BACKUP_DIR"
+
+            POSTGRES_CONTAINER=""
+            for candidate in nordhjem_postgres_staging nordhjem_postgres nordhjem-postgres; do
+              if docker ps -a --format '{{.Names}}' | grep -qx "$candidate"; then
+                POSTGRES_CONTAINER="$candidate"
+                break
+              fi
+            done
+
+            if [ -z "$POSTGRES_CONTAINER" ]; then
+              echo "❌ PostgreSQL container not found for staging backup"
+              exit 1
+            fi
+
+            DATABASE_URL=$(docker inspect "$MEDUSA_CONTAINER" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | grep '^DATABASE_URL=' | cut -d= -f2- || true)
+            DB_NAME=$(echo "$DATABASE_URL" | sed -n 's|.*/\([^?]*\).*|\1|p')
+            DB_USER=$(echo "$DATABASE_URL" | sed -n 's|.*://\([^:]*\):.*|\1|p')
+            DB_NAME=${DB_NAME:-nordhjem_staging}
+            DB_USER=${DB_USER:-medusa}
+
+            echo "=== Backing up staging database ($DB_NAME) from $POSTGRES_CONTAINER ==="
+            docker exec "$POSTGRES_CONTAINER" pg_dump \
+              -U "$DB_USER" \
+              -d "$DB_NAME" \
+              -F c \
+              -f "/tmp/backup_staging_${TIMESTAMP}.dump"
+
+            docker cp "${POSTGRES_CONTAINER}:/tmp/backup_staging_${TIMESTAMP}.dump" \
+              "${BACKUP_DIR}/backup_staging_${TIMESTAMP}.dump"
+            docker exec "$POSTGRES_CONTAINER" rm -f "/tmp/backup_staging_${TIMESTAMP}.dump"
+
+            cd "$BACKUP_DIR" && ls -t *.dump | tail -n +6 | xargs -r rm
+
+            echo "✅ Staging backup complete: backup_staging_${TIMESTAMP}.dump"
+
       - name: Deploy to staging environment
         uses: appleboy/ssh-action@v1
         with:
@@ -334,6 +382,54 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Backup production database
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 5m
+          script: |
+            set -e
+            TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+            BACKUP_DIR="/opt/nordhjem/backups/production"
+            MEDUSA_CONTAINER="nordhjem_medusa"
+            mkdir -p "$BACKUP_DIR"
+
+            POSTGRES_CONTAINER=""
+            for candidate in nordhjem_postgres nordhjem-postgres nordhjem_postgres_production; do
+              if docker ps -a --format '{{.Names}}' | grep -qx "$candidate"; then
+                POSTGRES_CONTAINER="$candidate"
+                break
+              fi
+            done
+
+            if [ -z "$POSTGRES_CONTAINER" ]; then
+              echo "❌ PostgreSQL container not found for production backup"
+              exit 1
+            fi
+
+            DATABASE_URL=$(docker inspect "$MEDUSA_CONTAINER" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | grep '^DATABASE_URL=' | cut -d= -f2- || true)
+            DB_NAME=$(echo "$DATABASE_URL" | sed -n 's|.*/\([^?]*\).*|\1|p')
+            DB_USER=$(echo "$DATABASE_URL" | sed -n 's|.*://\([^:]*\):.*|\1|p')
+            DB_NAME=${DB_NAME:-nordhjem_production}
+            DB_USER=${DB_USER:-medusa}
+
+            echo "=== Backing up production database ($DB_NAME) from $POSTGRES_CONTAINER ==="
+            docker exec "$POSTGRES_CONTAINER" pg_dump \
+              -U "$DB_USER" \
+              -d "$DB_NAME" \
+              -F c \
+              -f "/tmp/backup_production_${TIMESTAMP}.dump"
+
+            docker cp "${POSTGRES_CONTAINER}:/tmp/backup_production_${TIMESTAMP}.dump" \
+              "${BACKUP_DIR}/backup_production_${TIMESTAMP}.dump"
+            docker exec "$POSTGRES_CONTAINER" rm -f "/tmp/backup_production_${TIMESTAMP}.dump"
+
+            cd "$BACKUP_DIR" && ls -t *.dump | tail -n +11 | xargs -r rm
+
+            echo "✅ Production backup complete: backup_production_${TIMESTAMP}.dump"
+
       - name: Deploy to production
         uses: appleboy/ssh-action@v1
         with:


### PR DESCRIPTION
### Motivation

- Ensure a full database backup is taken before any deployment to staging or production so a failed deployment or data corruption can be rolled back. 
- Preserve recent backups on the VPS with distinct retention policies for staging and production to limit disk usage.

### Description

- Added a pre-deploy `Backup staging database` step to the `deploy-staging` job in `/.github/workflows/cd.yml` that runs over SSH using `appleboy/ssh-action@v1` and stores dumps in `/opt/nordhjem/backups/staging`.
- Added a pre-deploy `Backup production database` step to the `deploy-production` job in `/.github/workflows/cd.yml` that runs over SSH using `appleboy/ssh-action@v1` and stores dumps in `/opt/nordhjem/backups/production`.
- Each backup step detects likely PostgreSQL container names (`nordhjem_postgres_staging`, `nordhjem_postgres`, `nordhjem-postgres`, etc.), reads `DATABASE_URL` from the Medusa container env as available, falls back to sensible defaults, uses `pg_dump -F c` to create a `/tmp/*.dump` inside the DB container, copies the file out, and removes the temp file from the container.
- Retention policy: staging keeps the latest 5 dumps and production keeps the latest 10 dumps, and each step uses `set -e` so a backup failure will stop the workflow before deployment.

### Testing

- Ran `git diff --check` to verify there are no whitespace/patch errors and it passed.
- Attempted a YAML parse check using a small Python script but it failed because `PyYAML` is not installed in the environment, so a full local YAML validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b469c248388333a33f1706fdaa8f5e)