### PR TITLE
fix(ci): update codex-autofix trigger to monitor CI workflow

### DIFF
--- a/.github/workflows/codex-autofix.yml
+++ b/.github/workflows/codex-autofix.yml
@@ -2,7 +2,7 @@ name: Codex Auto-Fix on Failure
 
 on:
   workflow_run:
-    workflows: ["CD Pipeline"]
+    workflows: ["CI"]
     types: [completed]
 
 permissions:


### PR DESCRIPTION
### Motivation
- The Codex auto-fix workflow was listening for the removed "CD Pipeline" workflow and therefore never ran; monitoring the "CI" workflow captures code-level failures that the auto-fix can address.

### Description
- Replace `workflows: ["CD Pipeline"]` with `workflows: ["CI"]` in `.github/workflows/codex-autofix.yml` and leave all other workflow content unchanged.

### Testing
- Verified the workflow file now contains `workflows: ["CI"]` and that the change is the only diff in the file (one insertion, one deletion), validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b48923683c8333868362adc6341360)