### PR TITLE
fix(ci): use CD_PAT in auto-merge to trigger downstream CD workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Enable auto-merge (squash)
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CD_PAT }}
         run: |
           echo "🔄 Enabling auto-merge for PR #${{ github.event.pull_request.number }}"
           gh pr merge ${{ github.event.pull_request.number }} \


### PR DESCRIPTION
### Motivation
- Replace `GH_TOKEN` value in the auto-merge workflow so auto-merged PRs use `secrets.CD_PAT` because `GITHUB_TOKEN`-generated events do not trigger downstream CD workflows.

### Description
- Updated `/.github/workflows/auto-merge.yml` to set `GH_TOKEN: ${{ secrets.CD_PAT }}` and kept all other workflow settings (triggers, `permissions`, and merge command) unchanged; change made on branch `codex/fix-auto-merge-token`.

### Testing
- Confirmed the edit by running `rg -n "GH_TOKEN" .github/workflows/auto-merge.yml`, inspecting the file contents, and reviewing the diff to ensure `GH_TOKEN` now resolves to `${{ secrets.CD_PAT }}` (checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b48f8aaedc8333b0b19e527da25524)