### PR TITLE
feat(ci): add lint and type-check to backend CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,37 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  lint-and-typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
   build:
+    needs: lint-and-typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
### Motivation
- Ensure the CI pipeline enforces linting and TypeScript type correctness before building the Docker image.
- Run lint and `tsc` checks on PRs and pushes to prevent regressions reaching later stages.
- Keep the existing `build` job unchanged while making it depend on the new verification step.

### Description
- Replaced the `jobs:` section in `.github/workflows/ci.yml` to add a new `lint-and-typecheck` job that runs on `ubuntu-latest`.
- The `lint-and-typecheck` job checks out the repo, sets up Node 20 with `actions/setup-node@v4`, caches `node_modules`, runs `npm ci --legacy-peer-deps`, runs `npm run lint`, and runs `npx tsc --noEmit`.
- Updated the existing `build` job to include `needs: lint-and-typecheck` while preserving the build job name and all other build steps exactly.

### Testing
- Ran `git diff -- .github/workflows/ci.yml` to confirm the expected diff was produced and it succeeded.
- Ran `git status --short` to confirm the workflow file was staged for commit and it succeeded.
- Displayed the updated file with `nl -ba .github/workflows/ci.yml | sed -n '1,220p'` to validate the final contents and it succeeded.
- Committed the change with the message `feat(ci): add lint and type-check to backend CI pipeline` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b4b787d02483339236ae3840ac43ce)