### PR TITLE
fix(ci): use API call instead of payload snapshot in check-pr-metadata (#94)

### DIFF
--- a/.github/workflows/check-pr-metadata.yml
+++ b/.github/workflows/check-pr-metadata.yml
@@ -17,7 +17,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = context.payload.pull_request;
+            // Fetch PR data via API (not payload snapshot) to get latest state
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
             const prLabels = pr.labels.map(l => l.name);
 
             // Skip for no-issue or hotfix PRs


### PR DESCRIPTION
## Summary

Fixes `check-pr-metadata` workflow which was using stale webhook payload snapshot instead of live API data.

Closes #94

## Problem

The `check-pr-metadata` workflow read assignees from `context.payload.pull_request` — a point-in-time snapshot from the webhook event. Assignees added after PR creation (e.g., via API) were not reflected, causing false failures.

Discovered in PR #93 where assignee was added via API after creation.

## Fix

Replace payload snapshot with `github.rest.pulls.get()` API call to fetch real-time PR data.

## Test Plan

- This PR has an assignee set at creation time
- `check-pr-metadata` should pass by fetching live data
- All other CI checks pass as before