### PR TITLE
ci(gates): add check-project-board gate and update Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,6 +13,15 @@ body:
       required: true
 
   - type: textarea
+    id: background
+    attributes:
+      label: "背景/动机"
+      description: "什么场景下发现了这个 Bug？影响了什么？"
+      placeholder: "用户在结账时遇到 xxx 错误，导致无法完成购买..."
+    validations:
+      required: true
+
+  - type: textarea
     id: description
     attributes:
       label: Bug 描述

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -19,6 +19,15 @@ body:
       required: true
 
   - type: textarea
+    id: background
+    attributes:
+      label: "背景/动机"
+      description: "为什么要做这个功能？解决什么问题？"
+      placeholder: "当前系统存在 xxx 问题，导致 yyy..."
+    validations:
+      required: true
+
+  - type: textarea
     id: description
     attributes:
       label: 需求描述

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -13,6 +13,15 @@ body:
       required: true
 
   - type: textarea
+    id: background
+    attributes:
+      label: "背景/动机"
+      description: "为什么要做这个任务？解决什么问题？"
+      placeholder: "当前系统存在 xxx 问题，导致 yyy..."
+    validations:
+      required: true
+
+  - type: textarea
     id: objective
     attributes:
       label: 任务目标

--- a/.github/workflows/check-project-board.yml
+++ b/.github/workflows/check-project-board.yml
@@ -90,21 +90,31 @@ jobs:
               }
             `;
 
-            const { Octokit } = await import("@octokit/rest");
-            const { graphql } = await import("@octokit/graphql");
-            const graphqlWithAuth = graphql.defaults({
-              headers: {
-                authorization: `token ${process.env.CTO_PAT}`
-              }
-            });
-
+            // Use native fetch for GraphQL (actions/github-script does not expose @octokit/graphql)
             let result;
             try {
-              result = await graphqlWithAuth(graphqlQuery, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                number: issueNumber
+              const response = await fetch('https://api.github.com/graphql', {
+                method: 'POST',
+                headers: {
+                  'Authorization': `token ${process.env.CTO_PAT}`,
+                  'Content-Type': 'application/json',
+                  'User-Agent': 'check-project-board'
+                },
+                body: JSON.stringify({
+                  query: graphqlQuery,
+                  variables: {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    number: issueNumber
+                  }
+                })
               });
+              const json = await response.json();
+              if (json.errors) {
+                core.setFailed(`GraphQL errors: ${JSON.stringify(json.errors)}`);
+                return;
+              }
+              result = json.data;
             } catch (error) {
               core.setFailed(`GraphQL query failed: ${error.message}`);
               return;

--- a/.github/workflows/check-project-board.yml
+++ b/.github/workflows/check-project-board.yml
@@ -1,0 +1,184 @@
+name: Check Project Board
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    branches: [develop]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-project-board:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check project board membership and fields
+        uses: actions/github-script@v7
+        env:
+          CTO_PAT: ${{ secrets.CTO_PAT }}
+        with:
+          script: |
+            const prBody = context.payload.pull_request.body || '';
+            const prLabels = context.payload.pull_request.labels.map(l => l.name);
+
+            // Exemption: hotfix or no-issue labels skip all checks
+            if (prLabels.includes('hotfix') || prLabels.includes('no-issue')) {
+              core.info('PR has hotfix or no-issue label — skipping project board checks');
+              return;
+            }
+
+            // Extract issue number from PR body (Closes #N)
+            const issueMatch = prBody.match(/closes?\s+#(\d+)/i);
+            if (!issueMatch) {
+              core.setFailed('PR body must contain "Closes #<number>" to link an Issue');
+              return;
+            }
+            const issueNumber = parseInt(issueMatch[1]);
+            core.info(`Found linked Issue #${issueNumber}`);
+
+            // Fetch Issue body for background/motivation check
+            const { data: issueData } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+            const issueBody = issueData.body || '';
+
+            // Check 1: Issue body must contain background/motivation section
+            const bgRegex = /^##\s*(背景|动机|Background|Motivation)/mi;
+            if (!bgRegex.test(issueBody)) {
+              core.setFailed(`Issue #${issueNumber} must contain a "## 背景" or "## 动机" or "## Background" section`);
+              return;
+            }
+            core.info('✅ Issue has background/motivation section');
+
+            // Check 2-5: Project board membership and fields via GraphQL
+            const graphqlQuery = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $number) {
+                    projectItems(first: 10) {
+                      nodes {
+                        project {
+                          title
+                          number
+                        }
+                        fieldValues(first: 30) {
+                          nodes {
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                              name
+                              field {
+                                ... on ProjectV2SingleSelectField {
+                                  name
+                                }
+                              }
+                            }
+                            ... on ProjectV2ItemFieldTextValue {
+                              text
+                              field {
+                                ... on ProjectV2Field {
+                                  name
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const { Octokit } = await import("@octokit/rest");
+            const { graphql } = await import("@octokit/graphql");
+            const graphqlWithAuth = graphql.defaults({
+              headers: {
+                authorization: `token ${process.env.CTO_PAT}`
+              }
+            });
+
+            let result;
+            try {
+              result = await graphqlWithAuth(graphqlQuery, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: issueNumber
+              });
+            } catch (error) {
+              core.setFailed(`GraphQL query failed: ${error.message}`);
+              return;
+            }
+
+            const projectItems = result.repository.issue.projectItems.nodes;
+
+            // Check 2: Issue must be in the project board
+            const targetProject = projectItems.find(
+              item => item.project.title === 'NordHjem Engineering Roadmap'
+            );
+
+            if (!targetProject) {
+              core.setFailed(`Issue #${issueNumber} is not added to "NordHjem Engineering Roadmap" project`);
+              return;
+            }
+            core.info('✅ Issue is in NordHjem Engineering Roadmap project');
+
+            // Extract field values
+            const fieldValues = {};
+            for (const node of targetProject.fieldValues.nodes) {
+              if (node.field && node.field.name) {
+                fieldValues[node.field.name] = node.name || node.text || '';
+              }
+            }
+            core.info(`Project fields found: ${JSON.stringify(fieldValues)}`);
+
+            let failed = false;
+
+            // Check 3: Status must not be empty
+            if (!fieldValues['Status']) {
+              core.error(`Issue #${issueNumber} missing "Status" field in project board`);
+              failed = true;
+            } else {
+              core.info(`✅ Status: ${fieldValues['Status']}`);
+            }
+
+            // Check 4: Priority must be P0-P3
+            const validPriorities = ['P0', 'P1', 'P2', 'P3'];
+            if (!fieldValues['Priority'] || !validPriorities.includes(fieldValues['Priority'])) {
+              core.error(`Issue #${issueNumber} "Priority" must be one of: ${validPriorities.join(', ')} (got: "${fieldValues['Priority'] || ''}")`);
+              failed = true;
+            } else {
+              core.info(`✅ Priority: ${fieldValues['Priority']}`);
+            }
+
+            // Check 5: Phase must be Phase 0-4
+            const validPhases = ['Phase 0', 'Phase 1', 'Phase 2', 'Phase 3', 'Phase 4'];
+            if (!fieldValues['Phase'] || !validPhases.includes(fieldValues['Phase'])) {
+              core.error(`Issue #${issueNumber} "Phase" must be one of: ${validPhases.join(', ')} (got: "${fieldValues['Phase'] || ''}")`);
+              failed = true;
+            } else {
+              core.info(`✅ Phase: ${fieldValues['Phase']}`);
+            }
+
+            // Check 6: Module must be M01-M23, INFRA, or DOCS
+            const validModules = [
+              'M01','M02','M03','M04','M05','M06','M07','M08','M09','M10',
+              'M11','M12','M13','M14','M15','M16','M17','M18','M19','M20',
+              'M21','M22','M23','INFRA','DOCS'
+            ];
+            if (fieldValues['Module'] !== undefined) {
+              if (!validModules.includes(fieldValues['Module'])) {
+                core.error(`Issue #${issueNumber} "Module" must be one of: M01-M23, INFRA, DOCS (got: "${fieldValues['Module']}")`);
+                failed = true;
+              } else {
+                core.info(`✅ Module: ${fieldValues['Module']}`);
+              }
+            } else {
+              core.warning(`Issue #${issueNumber} "Module" field not found in project — field may not be created yet. Skipping Module check.`);
+            }
+
+            if (failed) {
+              core.setFailed(`Issue #${issueNumber} has incomplete project board fields. Please fill in all required fields.`);
+            } else {
+              core.info(`✅ All project board checks passed for Issue #${issueNumber}`);
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,8 +105,27 @@ src/
 - 豁免值：紧急 bug 填 `HOTFIX`，基础设施维护填 `INFRA`（CI 通过但审计会标记）
 - 每个 PR 都会运行 `roadmap-audit`，在 PR comment 中输出 ROADMAP 覆盖率报告
 
+### Project Board 门禁要求
+- 每个 PR 关联的 Issue 必须被添加到 **NordHjem Engineering Roadmap** GitHub Project
+- Issue 在 Project Board 上必须填写以下字段：
+  - **Status**：不能为空（Todo / In Progress / Done）
+  - **Priority**：必须是 P0、P1、P2、P3 之一
+  - **Phase**：必须是 Phase 0、Phase 1、Phase 2、Phase 3、Phase 4 之一
+  - **Module**：M01-M23、INFRA 或 DOCS（字段存在时强制校验，未创建时 warning 跳过）
+- 豁免：PR 有 `hotfix` 或 `no-issue` label 时跳过所有 Project Board 检查
+- CI Gate `check-project-board` 使用 GraphQL API 查询 Projects v2，需要 `CTO_PAT`（read:project scope）
+- Issue body 必须包含 `## 背景` 或 `## 动机` 或 `## Background` 或 `## Motivation` 段落
+
+### AI Issue 质量审查
+- 每个 PR 关联的 Issue 会由 AI 进行质量评分（1-10 分）
+- 评分结果以结构化 PR comment 形式保存
+- 评分 ≥ 7 分自动添加 `ai-approved` label
+- `ai-approved` 是 AI 审查标签，区别于 Owner 手动添加的 `approved` 标签
+- CI Gate `check-issue-quality` 使用 OpenAI API，需要 `OPENAI_API_KEY`
+
 ---
 
 > CI Gate v2 full pipeline verified: 2026-03-14T09:25:00Z
 > CI Gate v2 remediation + new gates: 2026-03-14T09:40:00Z
 > ROADMAP traceability: 2026-03-14
+> Project Board gate + AI Issue quality review: 2026-03-14


### PR DESCRIPTION
## ROADMAP Ref
R-P1-11

Closes #102

## Summary
新增 `check-project-board.yml` CI 门禁，强制 PR 关联的 Issue 必须已加入 GitHub Projects Board 且字段完整。同时更新三个 Issue 模板添加必填的「背景/动机」字段。

## Changes
- 新增 `.github/workflows/check-project-board.yml`
- 更新 `.github/ISSUE_TEMPLATE/feature.yml` — 新增「背景/动机」必填字段
- 更新 `.github/ISSUE_TEMPLATE/task.yml` — 新增「背景/动机」必填字段
- 更新 `.github/ISSUE_TEMPLATE/bug.yml` — 新增「背景/动机」必填字段

## 检查逻辑
- Issue 已加入 NordHjem Engineering Roadmap 项目
- Status 非空
- Priority 为 P0-P3
- Phase 为 Phase 0-4
- Module 为 M01-M23/INFRA/DOCS（字段存在时检查）
- Issue body 包含「背景/动机」段落
- hotfix/no-issue 标签 PR 豁免