### PR TITLE
ci: add bug postmortem gate and update bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,6 +22,15 @@ body:
       required: true
 
   - type: textarea
+    id: symptom
+    attributes:
+      label: "现象"
+      description: "出了什么问题？怎么复现？影响范围是什么？"
+      placeholder: "用户在 xxx 页面点击 yyy 按钮后，出现 zzz 错误。影响所有用户/部分用户/特定条件下触发..."
+    validations:
+      required: true
+
+  - type: textarea
     id: description
     attributes:
       label: Bug 描述
@@ -63,5 +72,32 @@ body:
         - "P1 — 主流程受影响"
         - "P2 — 次要功能问题"
         - "P3 — 外观/体验"
+    validations:
+      required: true
+
+  - type: textarea
+    id: root-cause
+    attributes:
+      label: "根因分析"
+      description: "为什么出了这个问题？排查过程是什么？最终定位到哪里？（创建时如未排查可先填「待排查」，提交修复 PR 前必须补充实际内容，否则 CI 会拦截）"
+      placeholder: "排查发现是 xxx 函数中 yyy 变量未做空值检查，导致..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: fix
+    attributes:
+      label: "修复方案"
+      description: "怎么修的？改了哪些文件？为什么选择这个方案？（创建时如未修复可先填「待修复」，提交修复 PR 前必须补充实际内容，否则 CI 会拦截）"
+      placeholder: "在 xxx.ts 第 N 行增加空值检查..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: prevention
+    attributes:
+      label: "防止再发"
+      description: "怎么避免以后再出同样的问题？需要加测试/告警/文档吗？（创建时如未确定可先填「待确认」，提交修复 PR 前必须补充实际内容，否则 CI 会拦截）"
+      placeholder: "已补充单元测试覆盖该场景 / 已添加 CI 检查 / ..."
     validations:
       required: true

--- a/.github/workflows/check-bug-postmortem.yml
+++ b/.github/workflows/check-bug-postmortem.yml
@@ -1,0 +1,139 @@
+name: Check Bug Postmortem
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: [develop]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  check-bug-postmortem:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Check bug postmortem fields
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // --- 1. Check for hotfix/no-issue exemption ---
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            const prLabels = pr.labels.map(l => l.name.toLowerCase());
+            if (prLabels.includes('hotfix') || prLabels.includes('no-issue')) {
+              console.log('⏭️ PR has hotfix/no-issue label — skipping bug postmortem check');
+              return;
+            }
+
+            // --- 2. Extract linked issue number from PR body ---
+            const body = pr.body || '';
+            const match = body.match(/(?:closes|fixes|resolves)\s+#(\d+)/i);
+            if (!match) {
+              console.log('⏭️ No linked issue found in PR body — skipping (check-linked-issue handles this)');
+              return;
+            }
+
+            const issueNumber = parseInt(match[1]);
+            console.log(`🔗 Linked issue: #${issueNumber}`);
+
+            // --- 3. Get issue details ---
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+
+            // --- 4. Check if issue is type:bug or type:bugfix ---
+            const issueLabels = issue.labels.map(l => l.name.toLowerCase());
+            const isBug = issueLabels.some(l =>
+              l === 'type: bug' || l === 'type:bug' ||
+              l === 'type: bugfix' || l === 'type:bugfix'
+            );
+
+            if (!isBug) {
+              console.log(`⏭️ Issue #${issueNumber} is not a bug (labels: ${issueLabels.join(', ')}) — skipping`);
+              return;
+            }
+
+            console.log(`🐛 Issue #${issueNumber} is a bug — checking postmortem fields...`);
+
+            // --- 5. Check required postmortem sections ---
+            const issueBody = issue.body || '';
+            const requiredSections = [
+              { label: '现象', pattern: /^##\s*现象/m },
+              { label: '根因分析', pattern: /^##\s*根因分析/m },
+              { label: '修复方案', pattern: /^##\s*修复方案/m },
+              { label: '防止再发', pattern: /^##\s*防止再发/m }
+            ];
+
+            const missing = [];
+            const found = [];
+            const placeholder = [];
+
+            // Placeholder patterns — these are not valid content
+            const placeholderPatterns = [
+              /^待排查$/m, /^待修复$/m, /^待确认$/m,
+              /^TBD$/im, /^TODO$/im, /^N\/A$/im,
+              /^_No response_$/m
+            ];
+
+            for (const section of requiredSections) {
+              if (!section.pattern.test(issueBody)) {
+                missing.push(section.label);
+                continue;
+              }
+
+              // Extract section content (between this header and next ## or end)
+              const sectionRegex = new RegExp(
+                `^##\\s*${section.label}\\s*\\n([\\s\\S]*?)(?=^##\\s|$(?!\\n))`,
+                'm'
+              );
+              const sectionMatch = issueBody.match(sectionRegex);
+              const content = sectionMatch ? sectionMatch[1].trim() : '';
+
+              if (!content || content.length < 5) {
+                placeholder.push(section.label);
+              } else {
+                // Check if content is just a placeholder
+                const isPlaceholder = placeholderPatterns.some(p => p.test(content));
+                if (isPlaceholder) {
+                  placeholder.push(section.label);
+                } else {
+                  found.push(section.label);
+                }
+              }
+            }
+
+            console.log(`✅ Complete sections: ${found.join(', ') || '(none)'}`);
+            if (missing.length > 0) console.log(`❌ Missing sections: ${missing.join(', ')}`);
+            if (placeholder.length > 0) console.log(`⚠️ Placeholder-only sections: ${placeholder.join(', ')}`);
+
+            // --- 6. Fail if any sections are missing or placeholder ---
+            const problems = [...missing, ...placeholder];
+            if (problems.length > 0) {
+              const missingMsg = missing.length > 0
+                ? `缺少段落：${missing.join('、')}\n` : '';
+              const placeholderMsg = placeholder.length > 0
+                ? `内容为占位符或过短：${placeholder.join('、')}\n` : '';
+
+              core.setFailed(
+                `❌ Bug Issue #${issueNumber} Postmortem 信息不完整\n\n` +
+                missingMsg + placeholderMsg + '\n' +
+                `Bug 类型的 Issue 在提交修复 PR 前必须包含以下四个段落的实际内容：\n` +
+                `  - ## 现象（出了什么问题，怎么复现）\n` +
+                `  - ## 根因分析（为什么出了这个问题，排查过程）\n` +
+                `  - ## 修复方案（怎么修的，改了什么）\n` +
+                `  - ## 防止再发（怎么避免以后再出同样的问题）\n\n` +
+                `请在 Issue #${issueNumber} 中补全以上段落后重新触发 CI。\n` +
+                `注意：「待排查」「待修复」「待确认」「TBD」等占位符不算有效内容。`
+              );
+            } else {
+              console.log(`✅ Bug Issue #${issueNumber} Postmortem 段落完整且有实际内容`);
+            }

--- a/.github/workflows/check-project-board.yml
+++ b/.github/workflows/check-project-board.yml
@@ -47,7 +47,7 @@ jobs:
             // Check 1: Issue body must contain background/motivation section
             const bgRegex = /^##\s*(背景|动机|Background|Motivation)/mi;
             if (!bgRegex.test(issueBody)) {
-              core.setFailed(`Issue #${issueNumber} must contain a "## 背景" or "## 动机" or "## Background" section`);
+              core.setFailed(`Issue #${issueNumber} must contain a "## 背景" or "### 背景/动机" or "## Background" section`);
               return;
             }
             core.info('✅ Issue has background/motivation section');

--- a/.github/workflows/check-project-board.yml
+++ b/.github/workflows/check-project-board.yml
@@ -45,7 +45,7 @@ jobs:
             const issueBody = issueData.body || '';
 
             // Check 1: Issue body must contain background/motivation section
-            const bgRegex = /^##\s*(背景|动机|Background|Motivation)/mi;
+            const bgRegex = /^#{2,3}\s*(背景(\/动机)?|动机|Background|Motivation)/mi;
             if (!bgRegex.test(issueBody)) {
               core.setFailed(`Issue #${issueNumber} must contain a "## 背景" or "### 背景/动机" or "## Background" section`);
               return;


### PR DESCRIPTION
Closes #106

## 变更说明

新增 Bug Postmortem CI 门禁，强制所有 bug 修复必须记录排查过程和根因分析。

### 新增文件
- `.github/workflows/check-bug-postmortem.yml` — Bug Postmortem CI 门禁

### 修改文件
- `.github/ISSUE_TEMPLATE/bug.yml` — 增加「现象」「根因分析」「修复方案」「防止再发」四个字段

### 门禁逻辑
1. 从 PR body 提取关联 Issue 号
2. 检查 Issue 标签是否为 `type: bug` 或 `type: bugfix`
3. 非 bug 类型 → 跳过检查
4. Bug 类型 → 检查 Issue body 必须包含四个段落：`## 现象`、`## 根因分析`、`## 修复方案`、`## 防止再发`
5. 段落内容不能为空或占位符
6. PR 有 `hotfix` 或 `no-issue` 标签 → 豁免
