### PR TITLE
feat(ci): complete issue #112 check-roadmap-ref upgrade

### DIFF
--- a/.github/workflows/check-roadmap-ref.yml
+++ b/.github/workflows/check-roadmap-ref.yml
@@ -66,7 +66,7 @@ jobs:
             console.log(`Found ${validIds.size} ROADMAP IDs in docs/ROADMAP.md`);
 
             // -- 5. Check each linked issue --
-            const exemptValues = ['HOTFIX', 'INFRA'];
+            const exemptValues = ['HOTFIX', 'INFRA', 'DOCS', 'RESEARCH'];
 
             for (const match of matches) {
               const issueNumber = parseInt(match[1]);
@@ -88,7 +88,7 @@ jobs:
                 core.setFailed(
                   `Issue #${issueNumber} has no ROADMAP Ref field.\n` +
                   `Every issue must include a ROADMAP Ref (e.g., R-P1-01).\n` +
-                  `For urgent bugs use HOTFIX, for infra maintenance use INFRA.`
+                  `For urgent bugs use HOTFIX, for infra maintenance use INFRA, for docs tasks use DOCS, and for research tasks use RESEARCH.`
                 );
                 return;
               }
@@ -108,7 +108,7 @@ jobs:
                 core.setFailed(
                   `Issue #${issueNumber} has invalid ROADMAP Ref format: "${ref}"\n` +
                   `Expected format: R-Px-xx (e.g., R-P1-01)\n` +
-                  `Allowed exemptions: HOTFIX, INFRA`
+                  `Allowed exemptions: HOTFIX, INFRA, DOCS, RESEARCH`
                 );
                 return;
               }


### PR DESCRIPTION
Closes #112

### Motivation
- Allow non-feature issue types (docs and research) to be exempt from ROADMAP reference enforcement so maintenance and exploratory work can be tracked without a roadmap ID.
- Keep error messages and audit behavior consistent with the updated exemption policy.

### Description
- Updated `exemptValues` in `.github/workflows/check-roadmap-ref.yml` to include `DOCS` and `RESEARCH` in addition to `HOTFIX` and `INFRA`.
- Updated validation failure messages in the same workflow to list the full set of allowed exemptions `HOTFIX, INFRA, DOCS, RESEARCH`.
- Change is confined to `.github/workflows/check-roadmap-ref.yml` and follows the repo Conventional Commit format used for CI gates.

### Testing
- Parsed the modified workflow with Ruby YAML loader using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/check-roadmap-ref.yml'); puts 'YAML OK'"`, which succeeded.
- Attempted a Python `yaml.safe_load` check but the environment lacked `PyYAML`, causing the Python-based parse to fail. This is an environment limitation and did not indicate invalid YAML.

ROADMAP Ref: INFRA

Assignee: @Nickwenniyxiao-art

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b607e1a1948333a8c5f960ac4d132e)
<!-- compliance-fix: assignee added 20260315013306 -->