### PR TITLE
feat(ci): complete issue #113 check-bug-postmortem upgrade

### DIFF
--- a/.github/workflows/check-bug-postmortem.yml
+++ b/.github/workflows/check-bug-postmortem.yml
@@ -67,11 +67,16 @@ jobs:
             // --- 5. Check required postmortem sections ---
             const issueBody = issue.body || '';
             const requiredSections = [
+              { label: '影响范围（impact_scope）', pattern: /^###\s*影响范围（impact_scope）/m },
+              { label: '回归测试（regression_test）', pattern: /^###\s*回归测试（regression_test）/m },
               { label: '现象', pattern: /^##\s*现象/m },
               { label: '根因分析', pattern: /^##\s*根因分析/m },
               { label: '修复方案', pattern: /^##\s*修复方案/m },
               { label: '防止再发', pattern: /^##\s*防止再发/m }
             ];
+
+            const escapeRegExp = (str) =>
+              str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
             const missing = [];
             const found = [];
@@ -91,8 +96,9 @@ jobs:
               }
 
               // Extract section content (between this header and next ## or end)
+              const escapedLabel = escapeRegExp(section.label);
               const sectionRegex = new RegExp(
-                `^##\\s*${section.label}\\s*\\n([\\s\\S]*?)(?=^##\\s|$(?!\\n))`,
+                `^#{2,3}\\s*${escapedLabel}\\s*\\n([\\s\\S]*?)(?=^#{2,3}\\s|$(?!\\n))`,
                 'm'
               );
               const sectionMatch = issueBody.match(sectionRegex);
@@ -126,7 +132,9 @@ jobs:
               core.setFailed(
                 `❌ Bug Issue #${issueNumber} Postmortem 信息不完整\n\n` +
                 missingMsg + placeholderMsg + '\n' +
-                `Bug 类型的 Issue 在提交修复 PR 前必须包含以下四个段落的实际内容：\n` +
+                `Bug 类型的 Issue 在提交修复 PR 前必须包含以下六个段落的实际内容：\n` +
+                `  - ### 影响范围（impact_scope）（用户/系统受影响范围与优先级）\n` +
+                `  - ### 回归测试（regression_test）（修复后的验证与防回归方案）\n` +
                 `  - ## 现象（出了什么问题，怎么复现）\n` +
                 `  - ## 根因分析（为什么出了这个问题，排查过程）\n` +
                 `  - ## 修复方案（怎么修的，改了什么）\n` +


### PR DESCRIPTION
Closes #113

ROADMAP Ref: INFRA

### Motivation
- Ensure bug postmortems include explicit `impact_scope` and `regression_test` fields so fixes document scope and anti-regression verification. 
- Make the postmortem field extraction robust to header level and to labels containing special characters so CI reliably validates Issue content.

### Description
- Require two new postmortem sections by matching `### 影响范围（impact_scope）` and `### 回归测试（regression_test）` in ` .github/workflows/check-bug-postmortem.yml`.
- Add `escapeRegExp` and use escaped labels with a regex that supports both `##` and `###` headers when extracting section content.
- Update the CI failure guidance to list six required sections (including the two new ones) and clarify expected content.
- Assignee: `@Nickwenniyxiao-art`.

### Testing
- Verified YAML parse of ` .github/workflows/check-bug-postmortem.yml` using `ruby -e "require 'yaml'; YAML.load_file(...)"`, which returned `YAML OK`.
- Ran `npm run lint` which failed due to the repository's ESLint v9 flat-config missing `eslint.config.*` (an existing repo configuration issue), not caused by this change.
- No new unit tests were added because this change updates a workflow script; validation focused on YAML/syntax and lint attempts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6113e833c83339a54be8eedcc159d)