### PR TITLE
feat(ci): complete issue #114 bug-archive workflow

### DIFF
--- a/.github/workflows/bug-archive.yml
+++ b/.github/workflows/bug-archive.yml
@@ -1,0 +1,79 @@
+name: Bug Archive
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  archive-bug:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event.issue.pull_request == null
+    steps:
+      - name: Check issue type and build archive row
+        id: row
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const labels = (issue.labels || []).map((l) => l.name.toLowerCase());
+            const isBug = labels.some((l) =>
+              l === 'type: bug' || l === 'type:bug' ||
+              l === 'type: bugfix' || l === 'type:bugfix'
+            );
+
+            if (!isBug) {
+              core.notice(`Issue #${issue.number} is not bug type. Skip archive.`);
+              core.setOutput('should_archive', 'false');
+              return;
+            }
+
+            const issueBody = issue.body || '';
+            const extractSection = (header) => {
+              const regex = new RegExp(`^##\\s*${header}\\s*\\n([\\s\\S]*?)(?=^##\\s|$)`, 'm');
+              const match = issueBody.match(regex);
+              if (!match) return 'N/A';
+              const cleaned = match[1]
+                .trim()
+                .replace(/\r?\n+/g, ' / ')
+                .replace(/\|/g, '\\|');
+              return cleaned || 'N/A';
+            };
+
+            const escape = (value) =>
+              String(value ?? '')
+                .replace(/\|/g, '\\|')
+                .replace(/\r?\n+/g, ' ')
+                .trim();
+
+            const closedDate = new Date(issue.closed_at || Date.now()).toISOString().slice(0, 10);
+            const issueLink = `[#${issue.number}](${issue.html_url})`;
+            const title = escape(issue.title);
+            const labelList = escape((issue.labels || []).map((l) => l.name).join(', '));
+
+            const row = `| ${closedDate} | ${issueLink} | ${title} | ${labelList} | ${extractSection('现象')} | ${extractSection('根因分析')} | ${extractSection('修复方案')} | ${extractSection('防止再发')} |`;
+
+            core.setOutput('should_archive', 'true');
+            core.setOutput('row', row);
+
+      - name: Checkout repository
+        if: steps.row.outputs.should_archive == 'true'
+        uses: actions/checkout@v4
+
+      - name: Append bug archive row
+        if: steps.row.outputs.should_archive == 'true'
+        run: |
+          echo "${{ steps.row.outputs.row }}" >> docs/bugs/bug-archive.md
+
+      - name: Commit and push archive update
+        if: steps.row.outputs.should_archive == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/bugs/bug-archive.md
+          git diff --staged --quiet || git commit -m "chore(ci): archive bug issue #${{ github.event.issue.number }}"
+          git push

--- a/docs/bugs/bug-archive.md
+++ b/docs/bugs/bug-archive.md
@@ -1,0 +1,7 @@
+# Bug Archive
+
+This file is automatically maintained by `.github/workflows/bug-archive.yml`.
+It records closed bug issues and key postmortem details for future reference.
+
+| Closed Date | Issue | Title | Labels | 现象 | 根因分析 | 修复方案 | 防止再发 |
+| --- | --- | --- | --- | --- | --- | --- | --- |


### PR DESCRIPTION
Closes #114

ROADMAP Ref: INFRA

### Motivation
- Add an automated, auditable way to record closed bug issues and their postmortem summaries into repository documentation to improve incident traceability. 
- Provide a lightweight workflow that only archives issues labeled as `type: bug`/`type: bugfix` and skips PRs to avoid noise.

### Description
- Add a new GitHub Actions workflow at `.github/workflows/bug-archive.yml` that triggers on `issues.closed`, skips PRs, filters for bug labels, extracts `## 现象`, `## 根因分析`, `## 修复方案`, and `## 防止再发` sections, and appends a formatted row to `docs/bugs/bug-archive.md`.
- Create `docs/bugs/bug-archive.md` with a header and table schema to store archived bug records and key postmortem fields.
- The workflow commits the updated `docs/bugs/bug-archive.md` back to the repository when a bug issue is archived, and the PR metadata requests assignment to `@Nickwenniyxiao-art`.

### Testing
- Ran `npm run lint`, which failed in this environment due to a missing ESLint flat config (`eslint.config.*`).
- Ran `npx tsc --noEmit`, which failed due to missing project dependencies and type declarations in the current environment. 
- Ran `npm test`, which failed because there is no `test` script defined in `package.json` in this repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6114881b08333a373c5a2d392e858)