### PR TITLE
feat(ci): add stale bot for issue and PR management

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,0 +1,27 @@
+name: Stale Bot
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # 每天 UTC 0:00
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 30
+          stale-issue-message: '此 Issue 已超过 30 天无活动，已标记为 stale。如仍需处理请回复或移除 stale 标签，否则将在 30 天后自动关闭。'
+          stale-pr-message: '此 PR 已超过 30 天无活动，已标记为 stale。请尽快完成或关闭。'
+          close-issue-message: '此 Issue 因长期不活跃已自动关闭。如需重新打开请评论说明。'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'pinned,security,priority: P0,type: incident'
+          exempt-pr-labels: 'pinned,security'
+          operations-per-run: 30


### PR DESCRIPTION
Closes #124

ROADMAP Ref: INFRA

### Motivation
- Add an automated stale-management workflow to mark and close long‑inactive Issues and PRs to reduce backlog noise and enforce housekeeping.
- Ensure exempt labels and Chinese messages are used to comply with repository policy and maintain clear communication to contributors.

### Description
- Add `.github/workflows/stale-bot.yml` which runs `actions/stale@v9` on a daily cron (`0 0 * * *`) and on manual dispatch. 
- Configure `days-before-stale: 30` and `days-before-close: 30` (total 60 days), with Chinese `stale`/close messages and `stale` labels for Issues and PRs. 
- Set exempt labels for issues to `pinned,security,priority: P0,type: incident` and for PRs to `pinned,security`, with `operations-per-run: 30` and permissions `issues: write` and `pull-requests: write`.

### Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/stale-bot.yml'); puts 'YAML OK'"` succeeded and validated the workflow YAML syntax. 
- A `python` based YAML check failed due to missing `PyYAML` in the environment (module not installed). 
- The file was committed on branch `codex/124-stale-bot` and is present at `.github/workflows/stale-bot.yml` as shown by `git status`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b62b686a188333b9d35ca0431c7e1c)