### PR TITLE
feat(ci): add duplicate issue detection workflow

### DIFF
--- a/.github/workflows/find-duplicate-issue.yml
+++ b/.github/workflows/find-duplicate-issue.yml
@@ -1,0 +1,68 @@
+name: Find Duplicate Issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  find-duplicates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const newIssue = context.payload.issue;
+            const newTitle = newIssue.title.toLowerCase();
+
+            // 分词：去掉常见前缀标记如 [Phase 2B] 等
+            const cleanTitle = newTitle.replace(/\[.*?\]/g, '').trim();
+            const newWords = cleanTitle.split(/[\s\-_\/\(\)（）【】]+/).filter(w => w.length > 1);
+
+            if (newWords.length === 0) return;
+
+            // 获取所有 open issues
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const duplicates = [];
+
+            for (const issue of issues.data) {
+              if (issue.number === newIssue.number) continue;
+              if (issue.pull_request) continue; // 排除 PR
+
+              const existingTitle = issue.title.toLowerCase().replace(/\[.*?\]/g, '').trim();
+              const existingWords = existingTitle.split(/[\s\-_\/\(\)（）【】]+/).filter(w => w.length > 1);
+
+              if (existingWords.length === 0) continue;
+
+              // 计算关键词重合度
+              const intersection = newWords.filter(w => existingWords.includes(w));
+              const similarity = intersection.length / Math.max(newWords.length, existingWords.length);
+
+              if (similarity > 0.5) {
+                duplicates.push({ number: issue.number, title: issue.title, similarity: Math.round(similarity * 100) });
+              }
+            }
+
+            if (duplicates.length === 0) return; // 无重复，不评论
+
+            const list = duplicates
+              .sort((a, b) => b.similarity - a.similarity)
+              .map(d => `- #${d.number}: ${d.title}（相似度 ${d.similarity}%）`)
+              .join('\n');
+
+            const body = `🔍 **可能重复的 Issue**：\n以下已有 Issue 与本 Issue 标题相似，请确认是否重复：\n${list}\n\n如确认不重复，请忽略此提示。`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: newIssue.number,
+              body: body
+            });


### PR DESCRIPTION
Closes #125

### Motivation
- Add an automated guard to detect potentially duplicate Issues on creation by scanning open issues and alerting the author to avoid redundant work.

### Description
- Add `.github/workflows/find-duplicate-issue.yml` which triggers on `issues.opened`, tokenizes and cleans titles, computes keyword-overlap similarity and, when similarity > 50%, comments (in Chinese) listing matching open issues and their similarity while excluding the new issue itself and PRs.

### Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/find-duplicate-issue.yml')"` returned `YAML OK`, confirming YAML syntax validation passed.
- `node --check` against the workflow script content completed without syntax errors, confirming the JavaScript logic is syntactically correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b62b6ff9a483338f51edfca088c2c8)