### PR TITLE
feat(ci): add semgrep static security analysis workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,56 @@
+name: Semgrep Security Scan
+
+on:
+  pull_request:
+    branches: [develop]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config "p/javascript" \
+            --config "p/nodejs" \
+            --config "p/typescript" \
+            --exclude "node_modules" \
+            --exclude "dist" \
+            --exclude ".next" \
+            --exclude "build" \
+            --exclude "package-lock.json" \
+            --error \
+            --sarif \
+            --output semgrep-results.sarif \
+            .
+        continue-on-error: true
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep-results.sarif
+        continue-on-error: true
+
+      - name: Check for errors
+        run: |
+          semgrep scan \
+            --config "p/javascript" \
+            --config "p/nodejs" \
+            --config "p/typescript" \
+            --exclude "node_modules" \
+            --exclude "dist" \
+            --exclude ".next" \
+            --exclude "build" \
+            --exclude "package-lock.json" \
+            --error \
+            --severity ERROR \
+            .


### PR DESCRIPTION
Closes #128

ROADMAP Ref: INFRA

### Motivation
- Add automated static security scanning on PRs to catch common JavaScript/TypeScript/Node.js vulnerabilities early in the CI pipeline.

### Description
- Add ` .github/workflows/semgrep.yml` which runs Semgrep using the official `semgrep/semgrep` container, generates a SARIF report (uploaded via `github/codeql-action/upload-sarif@v3` with graceful failure), and enforces CI failure for `ERROR`-severity findings only.

### Testing
- YAML syntax validated with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/semgrep.yml")'`, which returned `YAML OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b62ba427d48333b0fbed3c179b9997)