### PR TITLE
feat(ci): add dependency audit workflow and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "type: dependencies"
+      - "priority: P2"
+    commit-message:
+      prefix: "chore(deps):"
+    ignore:
+      # 忽略 Medusa 核心包的自动更新（需要手动测试兼容性）
+      - dependency-name: "@medusajs/*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "type: dependencies"
+    commit-message:
+      prefix: "chore(ci):"

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,38 @@
+name: Dependency Audit
+
+on:
+  pull_request:
+    branches: [develop]
+  schedule:
+    - cron: '0 6 * * 1' # 每周一 UTC 6:00
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - name: Run npm audit
+        run: |
+          echo "## 依赖安全审计报告" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # 运行 audit，捕获输出
+          npm audit --audit-level=high 2>&1 | tee audit-output.txt || true
+
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat audit-output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          # 严格检查：high 和 critical 级别
+          npm audit --audit-level=high


### PR DESCRIPTION
Closes #129

ROADMAP Ref: INFRA

### Motivation
- Add automated dependency vulnerability scanning to catch `high`/`critical` issues early and surface audit output in the Actions UI. 
- Enable Dependabot to keep `npm` and GitHub Actions dependencies up-to-date while excluding core `@medusajs/*` packages that require manual compatibility testing.

### Description
- Add ` .github/workflows/dependency-audit.yml` which runs on `pull_request` to `develop`, on a weekly schedule (`cron: '0 6 * * 1'`), and via `workflow_dispatch`, installs Node 20, runs `npm ci`, writes `npm audit` output to the job summary via `$GITHUB_STEP_SUMMARY`, and fails the job on `high`/`critical` vulnerabilities using `npm audit --audit-level=high`.
- Add `.github/dependabot.yml` to configure weekly `npm` updates (every Monday) with a maximum of 5 open PRs, labels `type: dependencies` and `priority: P2`, commit prefix `chore(deps):`, and an `ignore` rule for `@medusajs/*` packages; also enable weekly `github-actions` updates with commit prefix `chore(ci):`.
- Keep existing workflows and business code untouched and do not modify `package.json` or dependency versions as required.

### Testing
- YAML syntax for both ` .github/workflows/dependency-audit.yml` and ` .github/dependabot.yml` was validated successfully using `ruby -e 'require "yaml"; YAML.load_file(...)'` and returned `YAML parse OK`.
- An attempted validation using `python` with `PyYAML` failed because the test environment lacked the `PyYAML` module, so Python-based parsing was not executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b62bb14e588333a09f9f7a39f0505b)