### PR TITLE
feat(ci): add release automation workflow with semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BOT_PAT }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install semantic-release
+        run: |
+          npm install --no-save \
+            semantic-release@24 \
+            @semantic-release/changelog@6 \
+            @semantic-release/git@10 \
+            @semantic-release/github@10 \
+            @semantic-release/commit-analyzer@13 \
+            @semantic-release/release-notes-generator@14
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
+        run: npx semantic-release

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -1,0 +1,47 @@
+name: Trigger Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.BOT_PAT }}
+
+      - name: Create release commit
+        run: |
+          git config user.name "nickwenniyxiao-bot"
+          git config user.email "bot@nordhjem.com"
+          
+          RELEASE_TYPE="${{ github.event.inputs.release_type }}"
+          
+          case $RELEASE_TYPE in
+            major)
+              COMMIT_MSG="feat!: trigger major release"
+              ;;
+            minor)
+              COMMIT_MSG="feat: trigger minor release"
+              ;;
+            patch)
+              COMMIT_MSG="fix: trigger patch release"
+              ;;
+          esac
+          
+          git commit --allow-empty -m "$COMMIT_MSG"
+          git push origin main

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,10 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
+    ["@semantic-release/git", { "assets": ["CHANGELOG.md"], "message": "chore(release): ${nextRelease.version} [skip ci]" }],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
Closes #126

ROADMAP Ref: INFRA

### Motivation
- Provide a lightweight semantic-release automation that does not modify `package.json` or `package-lock.json` to avoid previous CI failures.

### Description
- Add `.github/workflows/release.yml` that runs on `push` to `main`, installs `semantic-release` and required plugins with `npm install --no-save`, and runs `npx semantic-release` using `BOT_PAT` as the token.
- Add `.github/workflows/trigger-release.yml` that exposes a `workflow_dispatch` `release_type` input and creates an empty conventional commit to trigger the release flow.
- Add `.releaserc.json` configured for the `main` branch with the standard plugins and with the git plugin assets restricted to `CHANGELOG.md` (no `package.json`).

### Testing
- Validated YAML syntax for both workflows using Ruby's `YAML.load_file`, which succeeded.
- Validated JSON syntax of `.releaserc.json` with `python -m json.tool`, which succeeded.
- Confirmed that `package.json` and `package-lock.json` were not modified and that the new files are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b634d88790833387f13196f86df423)