### PR TITLE
feat(ci): add nightly build regression workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,76 @@
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: "0 2 * * *"  # UTC 2:00 每天运行
+  workflow_dispatch:      # 支持手动触发
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop branch
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npx eslint . --ext .ts,.js --max-warnings 0
+
+      - name: Run type check
+        run: npx tsc --noEmit
+
+      - name: Run tests
+        run: npm test --if-present
+        continue-on-error: true
+
+  report-failure:
+    runs-on: ubuntu-latest
+    needs: nightly
+    if: failure()
+    steps:
+      - name: Create failure Issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString().split('T')[0];
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // Check if there's already an open nightly-failure Issue
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'nightly-failure',
+              state: 'open'
+            });
+
+            if (existing.data.length > 0) {
+              // Comment on existing issue instead of creating a new one
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body: `⚠️ Nightly build failed again on ${date}.\n\n[Workflow Run](${runUrl})`
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `[Nightly] Build failed on ${date}`,
+                body: `## Nightly Build 失败\n\n日期：${date}\n\n[查看 Workflow 运行详情](${runUrl})\n\n请检查以下步骤的输出：\n- Lint\n- Type Check\n- Tests\n\n修复后关闭此 Issue。`,
+                labels: ['type: bug', 'nightly-failure']
+              });
+            }


### PR DESCRIPTION
Closes #156

ROADMAP Ref: INFRA

### Motivation
- Add a scheduled nightly regression workflow to detect lint/type/test regressions on the `develop` branch early.
- Automate failure reporting by creating or commenting on a `nightly-failure` Issue to reduce alert noise and avoid duplicate issues.

### Description
- Add `.github/workflows/nightly.yml` which runs on `schedule` `"0 2 * * *"` (UTC 02:00) and supports `workflow_dispatch` for manual runs.
- Implement a `nightly` job that checks out `develop`, sets up Node.js 20, runs `npm ci`, `npx eslint . --ext .ts,.js --max-warnings 0`, `npx tsc --noEmit`, and `npm test --if-present` with `continue-on-error: true`.
- Implement a `report-failure` job using `actions/github-script@v7` that triggers on failure and deduplicates failures by commenting on an existing open issue labeled `nightly-failure` or creating a new `type: bug` + `nightly-failure` issue when none exists.

### Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/nightly.yml')"` succeeded, validating YAML syntax.
- The embedded `actions/github-script` block was validated by static inspection and confirmed to use `github.rest.issues.listForRepo`, `createComment`, and `create` with the intended deduplication logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b63984fe708333bd301f2e801d634d)