### PR TITLE
feat(ci): add trivy container image scanning workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,57 @@
+name: Trivy Container Scan
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - 'Dockerfile'
+      - 'docker-compose*.yml'
+      - '.dockerignore'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t nordhjem-backend:scan .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'nordhjem-backend:scan'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+          output: 'trivy-results.txt'
+
+      - name: Upload scan results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-results
+          path: trivy-results.txt
+
+      - name: Run Trivy for SARIF (optional)
+        if: always()
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'nordhjem-backend:scan'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          ignore-unfixed: true
+        continue-on-error: true
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+        continue-on-error: true


### PR DESCRIPTION
Closes #149
ROADMAP Ref: INFRA

### Motivation
- Add automated container image scanning to detect and block CRITICAL/HIGH vulnerabilities in Docker images produced from repository changes.

### Description
- Add `.github/workflows/trivy.yml` which triggers on PRs to `develop` when `Dockerfile`, `docker-compose*.yml`, or `.dockerignore` change and on `workflow_dispatch`, builds `nordhjem-backend:scan`, runs `aquasecurity/trivy-action` with `severity: 'CRITICAL,HIGH'`, `ignore-unfixed: true`, and `exit-code: '1'`, uploads `trivy-results.txt` as an artifact and optionally generates/uploads SARIF with `continue-on-error`.

### Testing
- YAML syntax validated using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/trivy.yml')"` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b63e6049c08333b5b5b3f17b904d65)