### PR TITLE
docs: upgrade ONBOARDING.md with 5-day reading plan

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,157 +1,223 @@
-# NordHjem 新 CTO 上手指南
+# NordHjem Backend 新人入职学习路径（5 天）
 
-> 预计阅读时间：5 分钟
-> 最后更新：2026-03-13
-
----
-
-## 欢迎
-
-欢迎加入 NordHjem 项目。
-
-**NordHjem**（北欧之家）是一个以北欧极简主义为核心审美的家居电商独立站，目标客群是追求高品质生活方式的消费者。项目从零自建，技术选型务实，团队精简、节奏快。
-
-作为新 CTO，你接手的是一个有清晰工程体系、有实际运行产品的项目，而不是一张白纸。本文件帮你在 5 分钟内建立基本认知。
+> 目标读者：新加入 NordHjem Backend 项目的工程师（后端/全栈/技术负责人）
+>
+> 学习周期：5 天（建议在入职第一周完成）
+>
+> 建议方式：每天按“阅读清单 → 动手操作 → 学习检查”完成闭环
 
 ---
 
-## 技术栈速览
+## 学习前准备
 
-| 层次 | 技术 | 说明 |
-|------|------|------|
-| 前端 | Next.js 15 | App Router，TypeScript |
-| 后端 | Medusa.js v2 | 电商引擎，Node.js |
-| 数据库 | PostgreSQL | 主数据库 |
-| 缓存 | Redis | 会话、队列、缓存 |
-| 容器化 | Docker + Docker Compose | 后端及依赖服务 |
-| 前端进程 | PM2 | Node.js 进程管理 |
-| Web 服务器 | Nginx | 反向代理 + SSL |
-| 服务器 | VPS 66.94.127.117 | 单节点部署 |
-| CI/CD | GitHub Actions | 自动化构建、测试、部署 |
+- 已安装 Node.js 20+ 与 npm
+- 已安装 Docker 与 Docker Compose
+- 已具备仓库访问权限（代码仓库、Issue、PR、Actions）
+- 已准备本地 `.env`（参考开发文档）
 
----
+参考文档：
 
-## GitHub 仓库
-
-| 仓库 | 地址 | 说明 |
-|------|------|------|
-| 前端 | `Nickwenniyxiao-art/nextjs-starter-medusa` | Next.js 前端 |
-| 后端 | `Nickwenniyxiao-art/nordhjem-medusa-backend` | Medusa.js 后端 |
-
-GitHub 组织：**Nickwenniyxiao-art**
+- [项目总览](./PROJECT.md)
+- [本地开发指南](./LOCAL-DEV-GUIDE.md)
+- [仓库根 README](../README.md)
 
 ---
 
-## 域名
+## Day 1：项目概览（预估 2-3 小时）
 
-| 用途 | 域名 |
-|------|------|
-| 前端（用户访问） | `nordhjem.store` |
-| 后端 API | `api.nordhjem.store` |
+### 学习目标
 
----
+- 理解 NordHjem 的业务背景、项目目标与整体技术栈。
+- 完成本地开发环境初始化并启动服务。
 
-## 阅读路线图
+### 阅读清单
 
-按顺序阅读，总耗时约 60 分钟，读完即可独立作战。
+1. [PROJECT.md](./PROJECT.md) —— 了解项目背景、目标与边界。
+2. [README.md](../README.md) —— 快速上手运行方式与基础命令。
+3. [LOCAL-DEV-GUIDE.md](./LOCAL-DEV-GUIDE.md) —— 按步骤完成本地环境配置。
 
-| 步骤 | 文件 | 时间 | 目的 |
-|------|------|------|------|
-| 第 1 步 | 本文件（ONBOARDING.md） | 5 min | 建立基本认知 |
-| 第 2 步 | `INDEX.md` | 2 min | 了解文档目录结构 |
-| 第 3 步 | `CURRENT-STATUS.md` | 5 min | 了解项目当前所处位置 |
-| 第 4 步 | `ROADMAP.md` | 5 min | 知道接下来要做什么 |
-| 第 5 步 | `ENGINEERING-PLAYBOOK.md` | 30 min | 知道怎么做（核心纲领） |
-| 第 6 步 | `ADR/` 目录 | 15 min | 知道为什么这么做（决策历史） |
-| 第 7 步 | `SPRINT-LOG.md` | 5 min | 了解最近在做什么 |
+### 重点理解
 
----
+- 技术栈：Medusa.js v2、Next.js、PostgreSQL、Redis、Docker。
+- 仓库职责：本仓库是后端服务（Medusa.js v2）。
+- 本地运行链路：依赖服务启动 → 环境变量加载 → 后端启动 → 健康检查。
 
-## 角色定义速览
+### 学习检查（完成即打勾）
 
-### Owner（产品负责人）
-
-Owner 只做两件事：
-1. **确认 ROADMAP**：确认每个里程碑的目标和优先级
-2. **Approve production**：每次生产部署前给予明确授权（在 GitHub PR 上 Approve 或在 GitHub Actions 中手动触发）
-
-Owner 不参与技术实现、不干预分支、不修改环境变量、不操作服务器。
-
-### CTO（技术负责人，即你）
-
-CTO 全权负责以下所有技术工作：
-
-- 技术架构设计与演进
-- 工程规范制定与执行
-- CI/CD 流水线设计与维护
-- 代码审查（Code Review）
-- Sprint 计划与执行
-- Codex 任务起草与验收
-- 文档撰写与更新
-- 服务器运维与监控
-- 事故响应与复盘
-
-### 8 条铁律（摘要）
-
-1. **不绕过 CI/CD**：所有代码通过 PR + GitHub Actions 合并，禁止直接 push main
-2. **不在生产服务器手动改代码**：服务器只运行容器，不是开发环境
-3. **不手动修改生产环境变量**：变量变更须走 PR + 审核流程，并更新文档
-4. **不跳过 Code Review**：任何代码合并 main/develop 前必须有 review 记录
-5. **不删除备份**：备份保留策略严格执行，手动删除须事先确认
-6. **不忽略监控告警**：收到告警必须在 30 分钟内响应并记录
-7. **不在 Sprint 中途随意加任务**：新任务进 Backlog，下个 Sprint 评估
-8. **不遗漏文档更新**：任何架构/流程变更，当天更新对应文档
-
-> 完整铁律和背景说明见 `ENGINEERING-PLAYBOOK.md`。
+- [ ] 我可以说明项目解决的核心业务问题。
+- [ ] 我可以列出后端关键技术栈及其作用。
+- [ ] 我已在本地成功启动项目并通过健康检查。
 
 ---
 
-## 第一天行动清单
+## Day 2：开发工作流（预估 2-3 小时）
 
-完成以下事项，即可结束第一天。
+### 学习目标
 
-- [ ] 读完本文件（ONBOARDING.md）
-- [ ] 浏览 GitHub 仓库代码结构（前端 + 后端各 10 分钟）
-- [ ] 查看 GitHub Projects 看板，了解当前 Sprint 状态
-- [ ] 阅读 `CURRENT-STATUS.md`，了解项目进度和已知问题
-- [ ] 阅读 `ROADMAP.md`，确认下一个里程碑目标
-- [ ] 检查 CI/CD 流水线状态（GitHub Actions → 查看最近 10 次 workflow 运行结果）
+- 掌握团队协作流程：分支策略、PR 规则、CI/CD 与 Code Review。
+- 理解如何提交一个符合规范的首个 PR。
 
----
+### 阅读清单
 
-## 第一周行动清单
+1. [ENGINEERING-PLAYBOOK.md](./ENGINEERING-PLAYBOOK.md) —— 团队工程规范与协作流程。
+2. [ADR/002-branch-strategy.md](./ADR/002-branch-strategy.md) —— 分支策略与演进背景。
+3. [CI-GATE-V2-SUMMARY.md](./CI-GATE-V2-SUMMARY.md) —— CI 门禁与自动化检查概览。
 
-- [ ] 读完 `ENGINEERING-PLAYBOOK.md`（13 章 + 2 附录）
-- [ ] 读完所有 ADR（`docs/ADR/` 目录，当前 8 篇）
-- [ ] 熟悉 CI/CD 流程：提一个测试 PR，观察 workflow 全流程
-- [ ] 接手当前 Sprint 任务，认领至少一个 Issue
-- [ ] 更新 `CURRENT-STATUS.md`，写入你的观察和接手声明
+### 重点理解
 
----
+- 分支流转：`develop → staging → main`。
+- PR 要求：Conventional Commits、Issue 关联、Review 与门禁通过。
+- CI/CD 基本路径：提交 PR → 自动检查 → 合并 → 环境部署。
 
-## 关键链接汇总
+### 学习检查（完成即打勾）
 
-| 资源 | 地址 |
-|------|------|
-| 前端仓库 | https://github.com/Nickwenniyxiao-art/nextjs-starter-medusa |
-| 后端仓库 | https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend |
-| GitHub Projects 看板 | https://github.com/orgs/Nickwenniyxiao-art/projects |
-| 前端线上地址 | https://nordhjem.store |
-| 后端 API | https://api.nordhjem.store |
-| 后端 Admin 面板 | https://api.nordhjem.store/app |
-| 后端健康检查 | https://api.nordhjem.store/health |
-| VPS 地址 | 66.94.127.117 |
+- [ ] 我理解如何创建合规分支并提交规范 commit。
+- [ ] 我理解 PR 描述需要包含哪些关键信息。
+- [ ] 我能描述“从开发到合并”的完整流程。
 
 ---
 
-## 紧急联系
+## Day 3：系统架构（预估 3-4 小时）
 
-Owner 的联系方式保存在以下位置（不在文档中明文记录）：
+### 学习目标
 
-- **GitHub**：查看组织 `Nickwenniyxiao-art` 的 Owner 成员
-- **私密联系信息**：由上一任 CTO 或 Owner 在交接时面告，存入你的私人密码管理器
-- **紧急情况**：如无法联系 Owner，CTO 有权独立处理生产事故，事后同步记录在 `SPRINT-LOG.md`
+- 建立后端系统架构全貌认知：模块边界、数据模型、API 组织方式。
+- 能从请求入口讲清核心数据流。
+
+### 阅读清单
+
+1. [docs/modules/README.md](./modules/README.md) —— 当前模块划分与说明（架构入口）。
+2. [ADR/001-tech-stack.md](./ADR/001-tech-stack.md) —— 技术选型与约束。
+3. [ADR/005-deployment-arch.md](./ADR/005-deployment-arch.md) —— 部署架构与运行结构。
+4. [README.md](../README.md) —— API 与运行命令补充说明。
+
+> 说明：若后续新增独立 `ARCHITECTURE.md`，请优先阅读该文件并回看本日清单。
+
+### 重点理解
+
+- `src/modules/` 的模块职责与依赖关系。
+- 数据库 Schema 的主要实体与关联关系（按业务域理解）。
+- API 结构（store/admin）及其与工作流、模块的调用关系。
+
+### 学习检查（完成即打勾）
+
+- [ ] 我可以说明 3-5 个核心模块及其职责。
+- [ ] 我可以画出“请求进入 API 到落库”的核心数据流。
+- [ ] 我可以指出新增功能应落在哪个模块或目录。
 
 ---
 
-*读完本文件后，下一步：阅读 `INDEX.md`，了解所有文档目录。*
+## Day 4：质量与安全（预估 2-3 小时）
+
+### 学习目标
+
+- 理解项目质量保障手段与安全要求。
+- 明确哪些检查会阻塞 PR，避免无效迭代。
+
+### 阅读清单
+
+1. [TESTING-STRATEGY.md](./TESTING-STRATEGY.md) —— 测试分层与验证策略。
+2. [SECURITY-POLICY.md](./SECURITY-POLICY.md) —— 安全规范与风险控制。
+3. [CI-GATE-V2-SUMMARY.md](./CI-GATE-V2-SUMMARY.md) —— 各类 CI Gate 的作用与结果解释。
+4. [ENGINEERING-PLAYBOOK.md](./ENGINEERING-PLAYBOOK.md) —— 代码质量与提交规范章节。
+
+### 重点理解
+
+- 后端变更默认验证：lint、type-check、test（按受影响范围执行）。
+- 常见阻塞项：commit/PR 命名不合规、Issue 元数据缺失、必需检查未通过。
+- 安全底线：环境变量管理、最小权限、敏感信息保护与响应流程。
+
+### 学习检查（完成即打勾）
+
+- [ ] 我知道提交前至少要执行哪些验证。
+- [ ] 我能列出会阻塞 PR 的关键 CI 检查。
+- [ ] 我理解安全问题上报与处理的基本流程。
+
+---
+
+## Day 5：运维与进阶（预估 2-3 小时）
+
+### 学习目标
+
+- 理解服务上线、运行监控与事故响应机制。
+- 掌握生产问题的定位与处理路径。
+
+### 阅读清单
+
+1. [RUNBOOK.md](./RUNBOOK.md) —— 运维手册、常见操作与故障排查。
+2. [SPRINT-LOG.md](./SPRINT-LOG.md) —— 最近迭代背景与关键变更记录。
+3. [CURRENT-STATUS.md](./CURRENT-STATUS.md) —— 当前系统状态、风险与待办。
+4. [ROADMAP.md](./ROADMAP.md) —— 中长期目标与优先级。
+5. [CI-GATE-V2-SUMMARY.md](./CI-GATE-V2-SUMMARY.md) —— 发布前后门禁与质量保障补充。
+
+> 说明：若后续新增独立 `RELEASE-CHECKLIST.md`，请将其加入本日必读并按清单执行发布演练。
+
+### 重点理解
+
+- 发布流程：变更准备 → 检查通过 → 合并/部署 → 验证/回滚。
+- 监控与告警：如何识别高优先级异常并升级处理。
+- 事故响应：按 P0-P3 分级执行沟通、止血、复盘。
+
+### 学习检查（完成即打勾）
+
+- [ ] 我能描述一次标准发布流程。
+- [ ] 我知道生产事故分级与首要响应动作。
+- [ ] 我知道故障后需要补充哪些记录（日志/复盘/行动项）。
+
+---
+
+## 附录 A：新人常见问题（FAQ）
+
+1. **Q：第一天最重要的产出是什么？**  
+   A：能够在本地成功运行后端并理解项目基础结构，这是后续开发与排障的前提。
+
+2. **Q：我应该先读代码还是先读文档？**  
+   A：先按本清单读文档建立全局认知，再从 `src/modules/` 进入代码，可显著降低理解成本。
+
+3. **Q：提 PR 前最容易漏掉什么？**  
+   A：Issue 关联、PR 首行 `Closes #<id>`、commit/PR 标题格式，以及必需 CI 检查项。
+
+4. **Q：如果 CI 失败应该怎么处理？**  
+   A：先定位失败的 gate 类型（格式、测试、门禁元数据），修复后重新推送；必要时在 PR 中记录原因与处理方式。
+
+5. **Q：遇到线上故障但信息不全怎么办？**  
+   A：先按 RUNBOOK 做止血和影响面评估，再同步负责人并补齐证据（日志、时间线、变更记录），最后进入复盘闭环。
+
+6. **Q：什么时候需要更新文档？**  
+   A：任何影响架构、流程、规范、运维方式的改动都应在同一 PR 或紧随其后更新对应文档。
+
+---
+
+## 附录 B：必读文档清单（相对路径）
+
+- [../README.md](../README.md)
+- [./PROJECT.md](./PROJECT.md)
+- [./LOCAL-DEV-GUIDE.md](./LOCAL-DEV-GUIDE.md)
+- [./ENGINEERING-PLAYBOOK.md](./ENGINEERING-PLAYBOOK.md)
+- [./modules/README.md](./modules/README.md)
+- [./TESTING-STRATEGY.md](./TESTING-STRATEGY.md)
+- [./SECURITY-POLICY.md](./SECURITY-POLICY.md)
+- [./RUNBOOK.md](./RUNBOOK.md)
+- [./CURRENT-STATUS.md](./CURRENT-STATUS.md)
+- [./ROADMAP.md](./ROADMAP.md)
+- [./CI-GATE-V2-SUMMARY.md](./CI-GATE-V2-SUMMARY.md)
+
+---
+
+## 附录 C：可选进阶阅读
+
+- [./ADR/README.md](./ADR/README.md)（架构决策索引）
+- [./ADR/003-ci-cd-design.md](./ADR/003-ci-cd-design.md)（CI/CD 设计细节）
+- [./ADR/004-ai-workflow.md](./ADR/004-ai-workflow.md)（AI 协作流程）
+- [./research/2026-03-13-engineering-practices-benchmark.md](./research/2026-03-13-engineering-practices-benchmark.md)（工程实践调研）
+- [./CHANGELOG.md](./CHANGELOG.md)（历史变更追踪）
+
+---
+
+## 完成标准（自检）
+
+- [ ] 5 天学习内容全部完成并完成每日日检。
+- [ ] 能独立完成本地运行、分支开发、提交流程。
+- [ ] 能说明核心架构与主要数据流。
+- [ ] 能识别 PR 阻塞项并快速修复。
+- [ ] 能在事故场景下按流程进行初步响应。


### PR DESCRIPTION
Closes #166

### Motivation

- Provide a clear, actionable 5-day onboarding learning path for new backend/Full‑stack engineers to accelerate ramp-up. 
- Replace the previous single-page CTO-focused note with a structured Day 1–Day 5 plan including goals, reading lists and hands-on checkpoints. 
- Ensure newcomers have a reproducible starting checklist and relative links to core docs for traceability and quick access (also satisfies ROADMAP traceability requirement).

### Description

- Restructured `docs/ONBOARDING.md` into a Day 1–Day 5 learning path with estimated time per day, reading checklists, key focus points and learning checkpoints. 
- Added a short "Learning prerequisites" section, an FAQ (6 items), an appendix of required relative-path document links, optional advanced reading, and a completion/self-check checklist. 
- All doc links use relative paths and the file is documentation-only, with no changes to runtime code, workflows, or package files. 
- Branch and commit were created on `codex/upgrade-onboarding-md-5day-reading-plan` with the Conventional Commit title `docs: upgrade ONBOARDING.md with 5-day reading plan`.

### Testing

- Ran a local link validation script (`python` script) that checked 38 links in `docs/ONBOARDING.md` and reported all targets exist. 
- Ran formatting check with `npx prettier --check docs/ONBOARDING.md` which passed. 
- No automated unit/integration tests required because this is a documentation-only change and CI gates remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b641d7dd648333a06cbb4644270bfd)

ROADMAP Ref: INFRA