### PR TITLE
docs: add module documentation for active modules

### DIFF
--- a/docs/modules/MODULE-REGISTRY.md
+++ b/docs/modules/MODULE-REGISTRY.md
@@ -1,0 +1,10 @@
+# Module Documentation Registry
+
+> Active modules under `src/modules/` and their detailed docs.
+
+## Active Modules (M01-M10 Scope)
+
+- [Brand 模块](./brand.md) — `src/modules/brand`
+- [Restock 模块](./restock.md) — `src/modules/restock`
+- [Ticket 模块](./ticket.md) — `src/modules/ticket`
+- [Resend Notification 模块](./resend-notification.md) — `src/modules/resend-notification`

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -20,6 +20,14 @@
 | M08  | Subscriber 事件处理      | `src/subscribers/`                 | 活跃 | 监听订单、支付、库存、售后、登录等事件并执行异步处理。                 |
 | M09  | Module Links（模块关联） | `src/links/`                       | 活跃 | 维护跨模块实体关联（如品牌-销售渠道、补货订阅-商品变体）。             |
 
+## 详细模块文档
+
+- [模块文档注册表（MODULE-REGISTRY.md）](./MODULE-REGISTRY.md)
+- [Brand 模块](./brand.md)
+- [Restock 模块](./restock.md)
+- [Ticket 模块](./ticket.md)
+- [Resend Notification 模块](./resend-notification.md)
+
 ## 模块间关系
 
 主要调用/协作关系如下：

--- a/docs/modules/brand.md
+++ b/docs/modules/brand.md
@@ -1,0 +1,57 @@
+# Brand 模块
+
+## 概述
+
+Brand 模块负责 NordHjem 的品牌领域数据管理，维护品牌基础信息并作为品牌与销售渠道等域对象关联的锚点。
+
+## 职责范围
+
+- 定义品牌实体（名称、slug、品牌视觉信息、站点域名等）
+- 提供基于 MedusaService 的品牌数据 CRUD 能力
+- 作为 `src/links/brand-sales-channel.ts` 的 linkable 端，支持品牌与销售渠道关联
+- 通过模块入口向依赖方暴露统一 DI token（`brandModuleService`）
+
+## 对外接口
+
+- 暴露 Service / API
+  - DI Token：`BRAND_MODULE = "brandModuleService"`
+  - Service：`BrandModuleService`（继承 `MedusaService`，针对 `Brand` 模型自动生成标准数据访问方法）
+- 导出的类型
+  - 无显式导出自定义 TypeScript 类型（主要依赖 Medusa 自动推导实体与服务方法类型）
+
+## 依赖关系
+
+- 依赖的其他模块
+  - 通过 links 与 Medusa Sales Channel 模块建立关联（`Brand ↔ SalesChannel`）
+- 外部依赖
+  - `@medusajs/framework/utils`（`Module`、`MedusaService`、`model`）
+
+## 配置项
+
+- 环境变量
+  - 无模块专属环境变量
+- 配置参数
+  - 在 `medusa-config.ts` 中通过 `modules` 注册：`resolve: "./src/modules/brand"`
+
+## 数据模型
+
+- 核心实体/表
+  - `brand`
+    - 主键：`id`
+    - 关键字段：`name`、`slug`、`logo_url`、`primary_color`、`domain`、`metadata`
+
+## 使用示例
+
+```ts
+import { BRAND_MODULE } from "../../modules/brand";
+
+const brandService = container.resolve(BRAND_MODULE);
+
+const brand = await brandService.createBrands({
+  name: "NordHjem",
+  slug: "nordhjem",
+  primary_color: "#2C3E2D",
+});
+
+const brands = await brandService.listBrands({});
+```

--- a/docs/modules/resend-notification.md
+++ b/docs/modules/resend-notification.md
@@ -1,0 +1,66 @@
+# Resend Notification 模块
+
+## 概述
+
+Resend Notification 模块是 NordHjem 的邮件通知提供器实现，基于 Resend API 对接 Medusa Notification 模块，负责模板分发、邮件发送与日志记录。
+
+## 职责范围
+
+- 实现 `AbstractNotificationProviderService`，注册 provider 标识 `resend-notification`
+- 处理 email 渠道发送逻辑（不支持非 email channel）
+- 根据模板名渲染 HTML 内容并发送通知
+- 在发送失败时记录错误日志并抛出异常
+
+## 对外接口
+
+- 暴露 Service / API
+  - Provider Identifier：`resend-notification`
+  - Service：`ResendNotificationProviderService`
+    - `send(notification)`：发送通知，返回 `{ id }`
+- 导出的类型
+  - `ResendNotificationConfig`：`apiKey`、`fromEmail`、`replyToEmail?`
+  - `SendNotificationInput`：`to`、`channel`、`template`、`data`
+  - `SendNotificationResult`：`id`
+
+## 依赖关系
+
+- 依赖的其他模块
+  - 挂载在 Medusa 官方通知模块 `@medusajs/medusa/notification` 的 providers 配置中
+  - 被工作流与事件处理流程用于发送业务通知
+- 外部依赖
+  - `@medusajs/framework/utils`（`AbstractNotificationProviderService`）
+  - `@medusajs/framework/types`（`Logger`）
+  - `resend` SDK（邮件发送）
+
+## 配置项
+
+- 环境变量
+  - `RESEND_API_KEY`
+  - `RESEND_FROM_EMAIL`（缺省：`NordHjem <noreply@nordhjem.store>`）
+  - `RESEND_REPLY_TO`（缺省：`support@nordhjem.store`）
+- 配置参数
+  - 在 `medusa-config.ts` 的 notification provider 中配置：
+    - `channels: ["email"]`
+    - `resolve: "./src/modules/resend-notification"`
+    - `id: "resend-notification"`
+
+## 数据模型
+
+- 核心实体/表
+  - 无（该模块不定义数据库模型，仅作为通知 provider）
+
+## 使用示例
+
+```ts
+const notificationProvider = container.resolve("resend-notification");
+
+await notificationProvider.send({
+  to: "customer@example.com",
+  channel: "email",
+  template: "order-confirmation",
+  data: {
+    subject: "Your order is confirmed",
+    order: { display_id: "1001", items: [] },
+  },
+});
+```

--- a/docs/modules/restock.md
+++ b/docs/modules/restock.md
@@ -1,0 +1,64 @@
+# Restock 模块
+
+## 概述
+
+Restock 模块负责“到货通知/补货订阅”领域能力，管理用户对商品变体的补货订阅记录，并提供去重后的订阅聚合查询用于通知任务。
+
+## 职责范围
+
+- 定义补货订阅实体 `restock_subscription`
+- 提供订阅记录的创建、查询、删除等标准服务能力
+- 提供 `getUniqueSubscriptions`，用于按 `variant_id + sales_channel_id` 聚合唯一订阅集合
+- 作为补货工作流与定时任务的数据基础模块
+
+## 对外接口
+
+- 暴露 Service / API
+  - DI Token：`RESTOCK_MODULE = "restock"`
+  - Service：`RestockModuleService`
+    - 标准方法：由 `MedusaService({ RestockSubscription })` 自动生成
+    - 自定义方法：`getUniqueSubscriptions(context?)`
+- 导出的类型
+  - `UniqueSubscription`
+    - `variant_id: string`
+    - `sales_channel_id: string | null`
+
+## 依赖关系
+
+- 依赖的其他模块
+  - 通过 `src/links/restock-variant.ts` 与 Product Variant 建立只读关联
+  - 被工作流（如 `create-restock-subscription`、`send-restock-notifications`）调用
+- 外部依赖
+  - `@medusajs/framework/utils`（`Module`、`MedusaService`、`InjectManager`、`MedusaContext`、`model`）
+  - `@mikro-orm/postgresql`（`EntityManager` 查询构建）
+
+## 配置项
+
+- 环境变量
+  - 无模块专属环境变量
+- 配置参数
+  - 在 `medusa-config.ts` 中通过 `modules` 注册：`resolve: "./src/modules/restock"`
+
+## 数据模型
+
+- 核心实体/表
+  - `restock_subscription`
+    - 主键：`id`
+    - 字段：`variant_id`、`sales_channel_id`、`email`、`customer_id`
+    - 唯一索引：`IDX_RESTOCK_SUBSCRIPTION_UNIQUE`（`variant_id`, `sales_channel_id`, `email`）
+
+## 使用示例
+
+```ts
+import { RESTOCK_MODULE } from "../../modules/restock";
+
+const restockService = container.resolve(RESTOCK_MODULE);
+
+await restockService.createRestockSubscriptions({
+  variant_id: "variant_123",
+  sales_channel_id: "sc_123",
+  email: "customer@example.com",
+});
+
+const targets = await restockService.getUniqueSubscriptions();
+```

--- a/docs/modules/ticket.md
+++ b/docs/modules/ticket.md
@@ -1,0 +1,67 @@
+# Ticket 模块
+
+## 概述
+
+Ticket 模块负责售后工单域能力，支持工单主记录与消息记录的统一管理，为管理端售后流程、状态流转与 SLA 相关处理提供数据基础。
+
+## 职责范围
+
+- 定义工单实体 `ticket` 与工单消息实体 `ticket_message`
+- 提供工单与消息的标准 CRUD 服务能力
+- 支持工单状态、优先级、处理时效等字段管理
+- 为管理端 Ticket API 与事件订阅逻辑提供统一模块服务
+
+## 对外接口
+
+- 暴露 Service / API
+  - DI Token：`TICKET_MODULE = "ticketModuleService"`
+  - Service：`TicketModuleService`（基于 `Ticket` 与 `TicketMessage`）
+    - 自动方法示例：`createTickets`、`updateTickets`、`retrieveTicket`、`listTickets`、`createTicketMessages`
+- 导出的类型
+  - 无显式导出自定义类型（依赖 MedusaService 自动生成方法签名）
+
+## 依赖关系
+
+- 依赖的其他模块
+  - 被 `src/api/admin/tickets/**` 等管理端接口调用
+  - 与事件总线联动（例如 ticket 创建、状态变更、消息发送等事件）
+- 外部依赖
+  - `@medusajs/framework/utils`（`Module`、`MedusaService`、`model`）
+
+## 配置项
+
+- 环境变量
+  - 无模块专属环境变量
+- 配置参数
+  - 在 `medusa-config.ts` 中通过 `modules` 注册：`resolve: "./src/modules/ticket"`
+
+## 数据模型
+
+- 核心实体/表
+  - `ticket`
+    - 主键：`id`
+    - 关键字段：`order_id`、`customer_id`、`type`、`status`、`priority`、`subject`、`description`
+    - 时效字段：`resolved_at`、`resolution_time_hours`、`sla_deadline`、`closed_at`
+  - `ticket_message`
+    - 主键：`id`
+    - 关键字段：`ticket_id`、`sender_type`、`sender_id`、`body`、`metadata`
+
+## 使用示例
+
+```ts
+import { TICKET_MODULE } from "../../modules/ticket";
+
+const ticketService = container.resolve(TICKET_MODULE);
+
+const ticket = await ticketService.createTickets({
+  order_id: "order_123",
+  type: "return",
+  subject: "Need return support",
+});
+
+await ticketService.createTicketMessages({
+  ticket_id: ticket.id,
+  sender_type: "admin",
+  body: "We have received your request.",
+});
+```


### PR DESCRIPTION
Closes #167

### Motivation

- Provide per-module documentation for the active modules under `src/modules/` to improve discoverability and onboarding. 
- Centralize links to module docs so engineers and reviewers can quickly find module responsibilities, interfaces and data models.

### Description

- Add `docs/modules/<module>.md` for the active modules: `brand`, `restock`, `ticket`, and `resend-notification` with sections for overview, responsibilities, public interfaces, dependencies, configuration, data model and examples. 
- Add `docs/modules/MODULE-REGISTRY.md` that lists the new module docs and their `src/modules/` locations. 
- Update `docs/modules/README.md` to include a "详细模块文档" section linking the registry and the new module pages. 
- Ensure all new Markdown files are formatted with Prettier for consistent style.

### Testing

- Ran Prettier style checks and applied `--write` to fix initial formatting warnings, and a final Prettier check passed. 
- Executed a small Python validation that compares `src/modules/` directories to `docs/modules/*.md` and confirmed there are no missing per-module docs. 
- All automated checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b641df69a4833386adcb22f4c038ad)

ROADMAP Ref: INFRA