### PR TITLE
feat(api): add health check endpoint

### DIFF
--- a/src/api/health/route.ts
+++ b/src/api/health/route.ts
@@ -1,0 +1,70 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+
+type HealthStatus = "ok" | "error";
+
+type RedisClient = {
+  ping: () => Promise<unknown>;
+};
+
+type PgConnection = {
+  raw: (query: string) => Promise<unknown>;
+};
+
+const API_VERSION = "1.0.0";
+
+const resolveRedisClient = (req: MedusaRequest): RedisClient | null => {
+  const candidateKeys = ["redis", "redisClient", "cache"];
+
+  for (const key of candidateKeys) {
+    try {
+      const candidate = req.scope.resolve(key) as Partial<RedisClient>;
+      if (candidate && typeof candidate.ping === "function") {
+        return candidate as RedisClient;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+};
+
+const checkDatabase = async (req: MedusaRequest): Promise<HealthStatus> => {
+  try {
+    const pgConnection = req.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION) as PgConnection;
+    await pgConnection.raw("SELECT 1");
+    return "ok";
+  } catch {
+    return "error";
+  }
+};
+
+const checkRedis = async (req: MedusaRequest): Promise<HealthStatus> => {
+  try {
+    const redisClient = resolveRedisClient(req);
+    if (!redisClient) {
+      return "error";
+    }
+
+    await redisClient.ping();
+    return "ok";
+  } catch {
+    return "error";
+  }
+};
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const [database, redis] = await Promise.all([checkDatabase(req), checkRedis(req)]);
+  const isHealthy = database === "ok" && redis === "ok";
+
+  return res.status(isHealthy ? 200 : 503).json({
+    status: isHealthy ? "ok" : "error",
+    timestamp: new Date().toISOString(),
+    version: API_VERSION,
+    checks: {
+      database,
+      redis,
+    },
+  });
+}


### PR DESCRIPTION
Closes #177

### Motivation
- Provide a lightweight, unauthenticated `/health` endpoint that reports overall service health and the status of critical dependencies (PostgreSQL and Redis) for monitoring and orchestration; ROADMAP Ref: INFRA.

### Description
- Add `src/api/health/route.ts` implementing `GET /health` which probes PostgreSQL via `PG_CONNECTION.raw("SELECT 1")` and resolves a Redis client from DI keys (`redis`, `redisClient`, `cache`) to `ping()`, returning HTTP `200` with `status: "ok"` when both checks pass or `503` with `status: "error"` otherwise, and including `timestamp`, `version` (`1.0.0`) and per-check results in the JSON payload.

### Testing
- Ran `npm run lint` (failed due to ESLint v9 expecting `eslint.config.*` in this environment), `npx tsc --noEmit` (failed due to missing project dependencies/type resolution), and `npm test` (failed because no `test` script is defined); these failures reflect environment/setup limitations and no unit tests were added for this trivial route.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b646335a2c8333910c4525f2bd16ff)

ROADMAP Ref: INFRA