### PR TITLE
feat(ci): add database backup workflow

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,42 @@
+name: Database Backup
+on:
+  schedule:
+    - cron: '0 2 * * *' # 每日 UTC 2:00
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Backup reason'
+        required: false
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PostgreSQL client
+        run: sudo apt-get install -y postgresql-client
+
+      - name: Create backup
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          TIMESTAMP=$(date +%Y-%m-%d-%H%M%S)
+          FILENAME="backup-${TIMESTAMP}.sql.gz"
+          pg_dump "$DATABASE_URL" | gzip > "$FILENAME"
+
+          # Verify backup is not empty
+          SIZE=$(stat -f%z "$FILENAME" 2>/dev/null || stat -c%s "$FILENAME")
+          if [ "$SIZE" -lt 100 ]; then
+            echo "::error::Backup file is too small (${SIZE} bytes)"
+            exit 1
+          fi
+          echo "Backup created: $FILENAME (${SIZE} bytes)"
+          echo "BACKUP_FILE=$FILENAME" >> $GITHUB_ENV
+
+      - name: Upload backup artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-backup-${{ github.run_id }}
+          path: ${{ env.BACKUP_FILE }}
+          retention-days: 30

--- a/docs/DB-BACKUP.md
+++ b/docs/DB-BACKUP.md
@@ -1,0 +1,96 @@
+# Database Backup Strategy
+
+## Overview
+
+This repository includes an automated GitHub Actions workflow for PostgreSQL backups.
+The workflow creates compressed SQL dump files daily and stores them as GitHub
+Actions artifacts for short-term retention.
+
+- Workflow file: `.github/workflows/db-backup.yml`
+- Schedule: Daily at **02:00 UTC**
+- Trigger: `schedule` + manual `workflow_dispatch`
+- Artifact retention: **30 days**
+
+## Backup Strategy
+
+### 1) Daily Automated Backups
+
+- Job runs once per day via cron: `0 2 * * *`
+- Uses `pg_dump` against `DATABASE_URL`
+- Compresses output as `backup-YYYY-MM-DD-HHMMSS.sql.gz`
+- Validates backup file size (must be >= 100 bytes)
+
+### 2) Offsite Storage Approach
+
+Current implementation stores backups in GitHub-hosted artifact storage (offsite
+relative to runtime infrastructure).
+
+Recommended long-term extension:
+
+- Add object storage replication (for example S3-compatible bucket)
+- Enable encryption at rest and lifecycle policies
+- Keep at least 30 days hot backups + monthly long-term snapshots
+
+### 3) Retention Policy
+
+- Current: GitHub artifact `retention-days: 30`
+- Suggested production policy:
+  - Daily backups: 30 days
+  - Weekly backups: 12 weeks
+  - Monthly backups: 12 months
+
+## Restore Procedure
+
+> Run restore in a controlled environment first, then execute in production.
+
+1. Download backup artifact from Actions run.
+2. Decompress backup:
+
+```bash
+gunzip backup-<timestamp>.sql.gz
+```
+
+3. Restore into target database:
+
+```bash
+psql "<TARGET_DATABASE_URL>" < backup-<timestamp>.sql
+```
+
+4. Validate restored data:
+   - Verify schema exists
+   - Verify critical tables row counts
+   - Run smoke queries / health checks
+
+## Manual Trigger
+
+You can trigger backup manually from GitHub Actions UI:
+
+1. Open **Actions** → **Database Backup** workflow.
+2. Click **Run workflow**.
+3. (Optional) Fill `reason` input for audit context.
+4. Run and download artifact after completion.
+
+## Secret Configuration Guide
+
+Configure repository secret:
+
+- Name: `DATABASE_URL`
+- Value format example:
+
+```text
+postgres://<user>:<password>@<host>:<port>/<database>
+```
+
+Recommendations:
+
+- Use least-privilege DB account with read permissions required by `pg_dump`
+- Rotate credentials periodically
+- Restrict repository admin access and secret visibility
+
+## Validation Checklist
+
+- [ ] Workflow exists at `.github/workflows/db-backup.yml`
+- [ ] `DATABASE_URL` secret is configured
+- [ ] Scheduled run succeeds
+- [ ] Artifact file can be downloaded and restored
+- [ ] Restore drill is tested regularly


### PR DESCRIPTION
Closes #178

ROADMAP Ref: INFRA

### Motivation
- Provide an automated daily PostgreSQL backup mechanism to reduce risk of data loss.
- Offer an immediate manual backup option for ad-hoc operations and audits.
- Document the backup and restore process and secret configuration for operators.

### Description
- Add workflow file ` .github/workflows/db-backup.yml` implementing a daily `pg_dump` at `02:00 UTC`, manual `workflow_dispatch` input `reason`, gzip compression, minimum-size verification, and upload to GitHub Actions artifacts with `retention-days: 30`.
- Add `docs/DB-BACKUP.md` containing backup strategy, offsite storage recommendations, retention policy suggestions, restore procedure, manual trigger instructions, and `DATABASE_URL` secret guidance.
- Branch created: `codex/add-database-backup-workflow`, and changes committed with Conventional Commit title `feat(ci): add database backup workflow`.

### Testing
- Ran `npm run lint`, which failed due to ESLint flat config not present in the current environment.
- Ran `npx tsc --noEmit`, which failed due to missing project dependencies/type declarations in the environment.
- Ran `npm test`, which failed because no `test` script is defined in `package.json` in this repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6463aa908833389493e44e1fb0306)