### PR TITLE
docs: clarify ROADMAP Ref format requirement in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,18 @@ src/
 
 - PR 标题必须使用 Conventional Commits：`type(scope): description`。
 - PR 描述第一行必须是 Issue 关闭语句：`Closes #<issue_number>`。
-- PR 描述必须包含 `ROADMAP Ref`，并与 Issue 中的追溯信息保持一致。
+- PR 描述必须包含独立一行 `ROADMAP Ref: <ID>`（如 `ROADMAP Ref: INFRA` 或 `ROADMAP Ref: R-P2-01`）。
+  - **必须是独立一行**，不能嵌在其他文字中（如 ❌ `...for monitoring; ROADMAP Ref: INFRA.`）
+  - CI 正则：`/^ROADMAP Ref:\s*(R-P\d+-\d+|HOTFIX|INFRA)\s*$/im`，不匹配则 PR 被拒
+- PR body 标准格式：
+  ```
+  Closes #<issue_number>
+
+  ### Motivation
+  <变更摘要>
+
+  ROADMAP Ref: INFRA
+  ```
 - PR 必须指派至少 1 名 Assignee（Codex 任务默认指派发起任务的 CTO/Owner）。
 - PR 描述建议包含：变更摘要、影响范围、测试结果、风险与回滚方案、待办事项。
 - 提交前必须自检：分支命名合规、提交信息合规、CI 门禁要求齐全（Issue 标签/Project 字段/审批标签）。


### PR DESCRIPTION
Closes #187

### Motivation
- Ensure PRs provide the `ROADMAP Ref` in a deterministic, CI-validateable format by requiring it to be on its own line so gates like `check-roadmap-ref` can reliably parse and enforce policy.

### Description
- Updated `AGENTS.md` PR submission section to require an independent line `ROADMAP Ref: <ID>` and provided examples (`INFRA`, `R-P2-01`).
- Added an explicit prohibition against embedding the `ROADMAP Ref` in other text and documented the CI regex used for validation: `/^ROADMAP Ref:\s*(R-P\d+-\d+|HOTFIX|INFRA)\s*$/im`.
- Added a standard PR body template showing `Closes #<issue_number>`, a `### Motivation` block, and a final standalone `ROADMAP Ref: INFRA` line.

### Testing
- Verified the updated lines and template are present by searching for `ROADMAP Ref`, `PR body 标准格式`, and `Closes #<issue_number>` via `rg -n "ROADMAP Ref|PR body 标准格式|Closes #<issue_number>" AGENTS.md`, which succeeded.
- Inspected the updated portion of `AGENTS.md` with file viewers (`sed`/`nl`) to confirm the inserted template and regex are correct, which succeeded.
- Confirmed the repository contains the modified `AGENTS.md` file and the new content appears in the diff, which succeeded.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b64a3069ac8333a6eb076241734294)