### PR TITLE
feat(ci): enhance pr-compliance-fix with auto-repair capability

### DIFF
--- a/.github/workflows/pr-compliance-fix.yml
+++ b/.github/workflows/pr-compliance-fix.yml
@@ -6,7 +6,8 @@ on:
     branches: [develop]
 
 permissions:
-  pull-requests: read
+  pull-requests: write
+  issues: write
 
 jobs:
   pr-compliance-fix:
@@ -15,6 +16,8 @@ jobs:
     steps:
       - name: Validate PR compliance requirements
         uses: actions/github-script@v7
+        env:
+          BOT_PAT: ${{ secrets.BOT_PAT }}
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({
@@ -28,6 +31,8 @@ jobs:
             const assignees = pr.assignees || [];
 
             const failures = [];
+            const autoFixNotes = [];
+            let fixedBody = body;
 
             // 1) PR title must follow Conventional Commits format
             const titlePattern = /^(feat|fix|hotfix|docs|chore|refactor|test|ci)(\(.+\))?\!?:\s.+$/;
@@ -41,23 +46,64 @@ jobs:
             const lines = body.split(/\r?\n/);
             const firstNonEmpty = (lines.find((line) => line.trim().length > 0) || '').trim();
             const closesFirstLinePattern = /^Closes\s+#\d+$/i;
-            if (!closesFirstLinePattern.test(firstNonEmpty)) {
-              failures.push(
-                `PR body first non-empty line must be \`Closes #<issue_number>\`. Got: "${firstNonEmpty || '(empty)'}"`
-              );
+            const closesAnywherePattern = /Closes\s+#\d+/i;
+            const closesMatch = body.match(closesAnywherePattern);
+            const hasClosesFirstLine = closesFirstLinePattern.test(firstNonEmpty);
+            if (!hasClosesFirstLine) {
+              if (!closesMatch) {
+                failures.push(
+                  `PR body first non-empty line must be \`Closes #<issue_number>\`. Got: "${firstNonEmpty || '(empty)'}"`
+                );
+              } else {
+                const closesLine = closesMatch[0].replace(/\s+/g, ' ').trim();
+                const bodyWithoutCloses = body
+                  .split(/\r?\n/)
+                  .filter((line) => !/^\s*Closes\s+#\d+\s*$/i.test(line))
+                  .join('\n')
+                  .trim();
+
+                fixedBody = [closesLine, bodyWithoutCloses].filter(Boolean).join('\n\n');
+                autoFixNotes.push(`Moved \`${closesLine}\` to the first non-empty line of PR body`);
+              }
             }
 
             // 3) PR body must contain ROADMAP Ref
             const roadmapPattern = /^ROADMAP Ref:\s*(R-P\d+-\d+|HOTFIX|INFRA)\s*$/im;
-            if (!roadmapPattern.test(body)) {
-              failures.push(
-                'PR body must include a line like `ROADMAP Ref: R-Px-xx` (or HOTFIX / INFRA).'
-              );
+            const roadmapExtractPattern = /ROADMAP\s+Ref:\s*(R-P\d+-\d+|HOTFIX|INFRA)/i;
+            const roadmapMatch = body.match(roadmapExtractPattern) || fixedBody.match(roadmapExtractPattern);
+            if (!roadmapPattern.test(fixedBody)) {
+              if (!roadmapMatch) {
+                failures.push(
+                  'PR body must include a line like `ROADMAP Ref: R-Px-xx` (or HOTFIX / INFRA).'
+                );
+              } else {
+                const roadmapValue = roadmapMatch[1].toUpperCase();
+                fixedBody = `${fixedBody.trim()}\n\nROADMAP Ref: ${roadmapValue}`.trim();
+                autoFixNotes.push(`Added standalone \`ROADMAP Ref: ${roadmapValue}\` line to PR body`);
+              }
             }
 
             // 4) PR must have at least one assignee
-            if (assignees.length === 0) {
-              failures.push('PR must have at least one assignee.');
+            const missingAssignee = assignees.length === 0;
+            if (missingAssignee) {
+              autoFixNotes.push('Added assignee: nickwenniyxiao-bot');
+            }
+
+            const compliantNow = failures.length === 0 && autoFixNotes.length === 0;
+            if (compliantNow) {
+              core.info('✅ PR compliance requirements passed');
+              return;
+            }
+
+            const canAutoFix = failures.length === 0 && autoFixNotes.length > 0;
+            const lastEditorLogin = (context.payload.sender?.login || '').toLowerCase();
+            const editedByBot = lastEditorLogin === 'nickwenniyxiao-bot';
+
+            if (canAutoFix && editedByBot) {
+              core.info(
+                `Skipping auto-fix to avoid loops because last editor is ${context.payload.sender?.login}.`
+              );
+              return;
             }
 
             if (failures.length > 0) {
@@ -65,4 +111,38 @@ jobs:
               return;
             }
 
-            core.info('✅ PR compliance requirements passed');
+            const { getOctokit } = require('@actions/github');
+            const botPat = process.env.BOT_PAT;
+            if (!botPat) {
+              core.setFailed('BOT_PAT is required for auto-fix operations but is not configured.');
+              return;
+            }
+
+            const botGithub = getOctokit(botPat);
+
+            if (fixedBody !== body) {
+              await botGithub.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                body: fixedBody,
+              });
+            }
+
+            if (missingAssignee) {
+              await botGithub.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                assignees: ['nickwenniyxiao-bot'],
+              });
+            }
+
+            await botGithub.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: `🔧 Auto-fix applied:\n${autoFixNotes.map((note) => `- ${note}`).join('\n')}`,
+            });
+
+            core.info('✅ PR compliance auto-fix applied successfully');


### PR DESCRIPTION
Closes #188

### Motivation
- Upgrade the PR compliance workflow from check-only to check-plus-auto-repair to reduce manual fixes for common PR metadata issues.
- Automatically repair misformatted `Closes #...` placement, non-standalone `ROADMAP Ref` lines, and missing assignees to streamline CI gates.
- Use a bot PAT for write operations and add loop protection to avoid repeated bot-triggered edits.

### Description
- Change workflow permissions to allow write operations by adding `pull-requests: write` and `issues: write` to the workflow permissions.
- Wire `secrets.BOT_PAT` into the `actions/github-script` step and use `getOctokit(botPat)` for programmatic PR updates and assignee changes.
- Detect `Closes #<n>` anywhere in the body and move it to the first non-empty line when present, and extract `ROADMAP Ref` values embedded in text and append a standalone `ROADMAP Ref: <VALUE>` line when applicable.
- Add assignee auto-repair to assign `nickwenniyxiao-bot` when missing and post a comment summarizing applied auto-fixes, with logic to skip auto-fix when the last editor is the bot to prevent loops.

### Testing
- Verified the working file diff with `git diff -- .github/workflows/pr-compliance-fix.yml` to confirm the intended changes were applied (succeeded).
- Inspected the updated workflow file with `nl -ba .github/workflows/pr-compliance-fix.yml` to validate the new logic is present (succeeded).
- Attempted YAML validation using a Python `PyYAML` safe load but it failed due to `PyYAML` not being installed in this environment (validation not executed).
- Attempted to run a Node-based YAML lint (`npx --yes yaml@2.8.1`) but the registry request returned HTTP 403 in this environment, so automated linter could not run (validation not executed).

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b64a4f8f348333b85569f7729b7e0f)