### PR TITLE
docs(registry): add DOC-REGISTRY.json for project document tracking

### DIFF
--- a/DOC-REGISTRY.json
+++ b/DOC-REGISTRY.json
@@ -1,0 +1,128 @@
+{
+  "project": "nordhjem-medusa-backend",
+  "assessed_date": "2026-03-15",
+  "assessed_by": "Owner",
+  "project_type": [
+    "web",
+    "ecommerce"
+  ],
+  "features": {
+    "has_ui": true,
+    "is_microservice": false,
+    "has_ai_ml": false,
+    "has_iot": false,
+    "is_saas": false,
+    "regulated": [
+      "GDPR"
+    ],
+    "has_external_api": false
+  },
+  "current_gate": 2,
+  "documents": [
+    {
+      "id": "PROJECT-CHARTER",
+      "file": "docs/PROJECT.md",
+      "required": true,
+      "gate": 1,
+      "status": "exists"
+    },
+    {
+      "id": "PRD",
+      "file": "docs/PRD.md",
+      "required": true,
+      "gate": 1,
+      "status": "missing"
+    },
+    {
+      "id": "ARCHITECTURE",
+      "file": "docs/ARCHITECTURE.md",
+      "required": true,
+      "gate": 1,
+      "status": "exists"
+    },
+    {
+      "id": "AGENTS",
+      "file": "AGENTS.md",
+      "required": true,
+      "gate": 1,
+      "status": "exists"
+    },
+    {
+      "id": "ROADMAP",
+      "file": "docs/ROADMAP.md",
+      "required": true,
+      "gate": 1,
+      "status": "exists"
+    },
+    {
+      "id": "CHANGELOG",
+      "file": "docs/CHANGELOG.md",
+      "required": true,
+      "gate": 1,
+      "status": "exists"
+    },
+    {
+      "id": "SPRINT-LOG",
+      "file": "docs/SPRINT-LOG.md",
+      "required": true,
+      "gate": 2,
+      "status": "exists"
+    },
+    {
+      "id": "LOCAL-DEV-GUIDE",
+      "file": "docs/LOCAL-DEV-GUIDE.md",
+      "required": true,
+      "gate": 2,
+      "status": "exists"
+    },
+    {
+      "id": "TESTING-STRATEGY",
+      "file": "docs/TESTING-STRATEGY.md",
+      "required": true,
+      "gate": 2,
+      "status": "exists"
+    },
+    {
+      "id": "RELEASE-CHECKLIST",
+      "file": "docs/RELEASE-CHECKLIST.md",
+      "required": true,
+      "gate": 2,
+      "status": "exists"
+    },
+    {
+      "id": "RUNBOOK",
+      "file": "docs/RUNBOOK.md",
+      "required": true,
+      "gate": 2,
+      "status": "exists"
+    },
+    {
+      "id": "OPS-MONITORING",
+      "file": "docs/OPS-MONITORING.md",
+      "required": true,
+      "gate": 2,
+      "status": "exists"
+    },
+    {
+      "id": "SECURITY-POLICY",
+      "file": "docs/SECURITY-POLICY.md",
+      "required": true,
+      "gate": 2,
+      "status": "exists"
+    },
+    {
+      "id": "ONBOARDING",
+      "file": "docs/ONBOARDING.md",
+      "required": true,
+      "gate": 2,
+      "status": "exists"
+    },
+    {
+      "id": "POSTMORTEM",
+      "file": "docs/POSTMORTEM/000-template.md",
+      "required": false,
+      "gate": 3,
+      "status": "exists"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #201

### Motivation
- Add a root-level `DOC-REGISTRY.json` to record project documentation status, gate metadata and feature flags for the NordHjem backend to support doc completeness audits and CI visibility.

### Description
- Create `DOC-REGISTRY.json` at repository root containing `project`, `assessed_date`, `assessed_by`, `project_type`, `features`, and `current_gate` (set to `2`).
- Populate `documents` with document `id`, repo-relative `file` path, `required` flag, `gate` number and a filesystem-derived `status` of `exists` or `missing` (e.g. `PRD` is `missing`).
- Ensure the generated JSON is valid and parseable by Node.js.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('DOC-REGISTRY.json','utf8'))"` which succeeded.
- Verified repository files were scanned to compute `status` values and committed the file with `git`.
- Observed `docs/standards/DOC-LIBRARY.json` was not present in the checkout, so document entries were built from visible repo docs and the task-provided mapping.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6662645d48333ab6f1d3fc2f9335f)