### PR TITLE
chore(ops): add Redis diagnostic and fix workflow (closes #212)

### DIFF
--- a/.github/workflows/ops-redis-fix.yml
+++ b/.github/workflows/ops-redis-fix.yml
@@ -1,0 +1,175 @@
+name: "🔧 Ops — Redis 诊断与修复"
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "执行动作"
+        required: true
+        type: choice
+        options:
+          - diagnose-only
+          - diagnose-and-fix
+        default: diagnose-and-fix
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    name: Diagnose Redis and service health
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH diagnose on VPS
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 5m
+          script: |
+            echo "=== 1. Redis 进程状态 ==="
+            docker ps -a --filter "name=redis" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+
+            echo "=== 2. Redis 容器日志（最近50行）==="
+            REDIS_CONTAINER=$(docker ps -a --filter "name=redis" --format "{{.Names}}" | head -1)
+            if [ -n "$REDIS_CONTAINER" ]; then
+              docker logs "$REDIS_CONTAINER" --tail 50 2>&1
+            else
+              echo "未找到 Redis 容器，检查 systemd..."
+              systemctl status redis 2>&1 || echo "systemd 中也没有 redis 服务"
+            fi
+
+            echo "=== 3. 磁盘空间 ==="
+            df -h /
+
+            echo "=== 4. 内存使用 ==="
+            free -h
+
+            echo "=== 5. Docker 网络状态 ==="
+            docker network inspect nordhjem_backend --format '{{range .Containers}}{{.Name}} {{end}}' 2>&1
+
+            echo "=== 6. 当前健康检查 ==="
+            for PORT in 9000 9001 9002; do
+              STATUS=$(curl -sf -o /dev/null -w "%{http_code}" http://localhost:$PORT/health 2>/dev/null || echo "000")
+              BODY=$(curl -sf http://localhost:$PORT/health 2>/dev/null || echo "unreachable")
+              echo "Port $PORT: HTTP $STATUS — $BODY"
+            done
+
+  fix:
+    name: Fix Redis and restart backend services
+    runs-on: ubuntu-latest
+    needs: diagnose
+    if: github.event.inputs.action == 'diagnose-and-fix'
+    steps:
+      - name: SSH fix on VPS
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 10m
+          script: |
+            set -e
+
+            echo "=== Step 1: 定位 Redis ==="
+            REDIS_CONTAINER=$(docker ps -a --filter "name=redis" --format "{{.Names}}" | head -1)
+
+            if [ -n "$REDIS_CONTAINER" ]; then
+              echo "找到 Redis 容器: $REDIS_CONTAINER"
+
+              echo "=== Step 2: 重启 Redis ==="
+              docker restart "$REDIS_CONTAINER"
+              sleep 10
+
+              echo "=== Step 3: 验证 Redis ==="
+              docker exec "$REDIS_CONTAINER" redis-cli ping || { echo "❌ Redis ping 失败"; exit 1; }
+              echo "✅ Redis PONG"
+            else
+              echo "尝试 systemd restart..."
+              sudo systemctl restart redis || sudo systemctl restart redis-server
+              sleep 5
+              redis-cli ping || { echo "❌ Redis ping 失败"; exit 1; }
+              echo "✅ Redis PONG"
+            fi
+
+            echo "=== Step 4: 重启后端容器 ==="
+            for CONTAINER in nordhjem_medusa_production nordhjem_medusa_test nordhjem_medusa_staging; do
+              if docker ps -a --format "{{.Names}}" | grep -q "$CONTAINER"; then
+                echo "重启 $CONTAINER..."
+                docker restart "$CONTAINER"
+                sleep 15
+              else
+                echo "⚠️ 容器 $CONTAINER 不存在，跳过"
+              fi
+            done
+
+            echo "=== Step 5: 等待服务就绪 ==="
+            sleep 30
+
+            echo "=== Step 6: 验证所有健康检查 ==="
+            ALL_OK=true
+            for PORT in 9000 9001 9002; do
+              for ATTEMPT in 1 2 3 4 5 6; do
+                STATUS=$(curl -sf -o /dev/null -w "%{http_code}" http://localhost:$PORT/health 2>/dev/null || echo "000")
+                if [ "$STATUS" = "200" ]; then
+                  BODY=$(curl -sf http://localhost:$PORT/health)
+                  echo "✅ Port $PORT: HTTP 200 — $BODY"
+                  break
+                fi
+                echo "Port $PORT attempt $ATTEMPT: HTTP $STATUS, waiting 15s..."
+                sleep 15
+                if [ "$ATTEMPT" = "6" ]; then
+                  echo "❌ Port $PORT: 健康检查仍然失败"
+                  ALL_OK=false
+                fi
+              done
+            done
+
+            if [ "$ALL_OK" = "true" ]; then
+              echo ""
+              echo "🎉 所有环境健康检查通过！Redis 故障已修复。"
+            else
+              echo ""
+              echo "⚠️ 部分环境仍有问题，请检查日志。"
+              exit 1
+            fi
+
+  report:
+    name: Report summary
+    runs-on: ubuntu-latest
+    needs:
+      - diagnose
+      - fix
+    if: always()
+    steps:
+      - name: Output workflow summary
+        run: |
+          echo "## Redis 诊断与修复摘要" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Action: \\`${{ github.event.inputs.action }}\\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Diagnose job: **${{ needs.diagnose.result }}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Fix job: **${{ needs.fix.result || 'skipped' }}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### 健康检查（实时）" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: SSH final health snapshot
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 5m
+          script: |
+            echo "=== Final Redis Status ==="
+            docker ps -a --filter "name=redis" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+
+            echo "=== Final Docker Network Containers ==="
+            docker network inspect nordhjem_backend --format '{{range .Containers}}{{.Name}} {{end}}' 2>&1
+
+            echo "=== Final Health Checks ==="
+            for PORT in 9000 9001 9002; do
+              STATUS=$(curl -sf -o /dev/null -w "%{http_code}" http://localhost:$PORT/health 2>/dev/null || echo "000")
+              BODY=$(curl -sf http://localhost:$PORT/health 2>/dev/null || echo "unreachable")
+              echo "Port $PORT: HTTP $STATUS — $BODY"
+            done


### PR DESCRIPTION
Closes #212

### Motivation
- Provide a manual, auditable ops workflow to diagnose and repair Redis on the VPS via SSH and restore health checks for production/test/staging.
- Reuse existing deployment secrets and the same SSH action pattern used by other CD workflows to keep operations consistent.

### Description
- Added `.github/workflows/ops-redis-fix.yml` with a `workflow_dispatch` input `action` offering `diagnose-only` and `diagnose-and-fix` choices and top-level `permissions: contents: read`.
- Implemented a `diagnose` job that uses `appleboy/ssh-action@v1` with `command_timeout: 5m` to collect Redis/docker logs, disk/memory, docker network state, and run health checks on ports `9000`, `9001`, and `9002`.
- Implemented a conditional `fix` job (runs when `action == 'diagnose-and-fix'`) that uses `appleboy/ssh-action@v1` with `command_timeout: 10m` to restart Redis (container or systemd), validate with `redis-cli ping`, restart backend containers, and retry health checks with retries.
- Added a final `report` job that always runs to write a run summary to `$GITHUB_STEP_SUMMARY` and capture a final SSH health snapshot; all steps reuse `secrets.DEPLOY_HOST`, `secrets.DEPLOY_USER`, and `secrets.DEPLOY_SSH_KEY`.

### Testing
- Successfully validated YAML parsing using Ruby's `YAML.load_file` which reported `YAML OK` for `.github/workflows/ops-redis-fix.yml`.
- Attempted Python `PyYAML` validation which failed because `PyYAML` was not installed in the environment, so that check was skipped.
- Committed the workflow on branch `codex/212-redis-fix-workflow` with `chore(ops): add Redis diagnostic and fix workflow` and verified the file appears in `git status` as staged and committed.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b74de492ac833390df3873ce099e1b)

> CTO 已修复 CI 门禁所需的 Issue 标签、PR 元数据和 ROADMAP Ref（Issue body 格式已对齐 CI 正则，Project Board 已配置）。