### PR TITLE
fix(api): resolve health check Redis detection failure

### DIFF
--- a/src/api/health/route.ts
+++ b/src/api/health/route.ts
@@ -11,6 +11,15 @@ type PgConnection = {
   raw: (query: string) => Promise<unknown>;
 };
 
+type RedisConstructor = new (
+  url: string,
+  opts: Record<string, unknown>
+) => {
+  connect: () => Promise<void>;
+  ping: () => Promise<string>;
+  disconnect: () => void;
+};
+
 const API_VERSION = "1.0.0";
 
 const resolveRedisClient = (req: MedusaRequest): RedisClient | null => {
@@ -55,7 +64,8 @@ const checkRedis = async (req: MedusaRequest): Promise<HealthStatus> => {
       return "ok"; // No Redis configured, not an error
     }
 
-    const { default: Redis } = await import("ioredis");
+    const ioredis = await import("ioredis");
+    const Redis = ioredis.default as unknown as RedisConstructor;
     const testClient = new Redis(redisUrl, {
       connectTimeout: 5000,
       maxRetriesPerRequest: 1,

--- a/src/api/health/route.ts
+++ b/src/api/health/route.ts
@@ -55,7 +55,7 @@ const checkRedis = async (req: MedusaRequest): Promise<HealthStatus> => {
       return "ok"; // No Redis configured, not an error
     }
 
-    const Redis = require("ioredis");
+    const { default: Redis } = await import("ioredis");
     const testClient = new Redis(redisUrl, {
       connectTimeout: 5000,
       maxRetriesPerRequest: 1,

--- a/src/api/health/route.ts
+++ b/src/api/health/route.ts
@@ -42,13 +42,33 @@ const checkDatabase = async (req: MedusaRequest): Promise<HealthStatus> => {
 
 const checkRedis = async (req: MedusaRequest): Promise<HealthStatus> => {
   try {
+    // First try DI container
     const redisClient = resolveRedisClient(req);
-    if (!redisClient) {
-      return "error";
+    if (redisClient) {
+      await redisClient.ping();
+      return "ok";
     }
 
-    await redisClient.ping();
-    return "ok";
+    // Fallback: direct connection test using REDIS_URL
+    const redisUrl = process.env.REDIS_URL;
+    if (!redisUrl) {
+      return "ok"; // No Redis configured, not an error
+    }
+
+    const Redis = require("ioredis");
+    const testClient = new Redis(redisUrl, {
+      connectTimeout: 5000,
+      maxRetriesPerRequest: 1,
+      lazyConnect: true,
+    });
+
+    try {
+      await testClient.connect();
+      await testClient.ping();
+      return "ok";
+    } finally {
+      testClient.disconnect();
+    }
   } catch {
     return "error";
   }

--- a/src/api/store/health/route.ts
+++ b/src/api/store/health/route.ts
@@ -55,7 +55,7 @@ const checkRedis = async (req: MedusaRequest): Promise<HealthStatus> => {
       return "ok"; // No Redis configured, not an error
     }
 
-    const Redis = require("ioredis");
+    const { default: Redis } = await import("ioredis");
     const testClient = new Redis(redisUrl, {
       connectTimeout: 5000,
       maxRetriesPerRequest: 1,

--- a/src/api/store/health/route.ts
+++ b/src/api/store/health/route.ts
@@ -11,6 +11,15 @@ type PgConnection = {
   raw: (query: string) => Promise<unknown>;
 };
 
+type RedisConstructor = new (
+  url: string,
+  opts: Record<string, unknown>
+) => {
+  connect: () => Promise<void>;
+  ping: () => Promise<string>;
+  disconnect: () => void;
+};
+
 const APP_VERSION = "0.0.1";
 
 const resolveRedisClient = (req: MedusaRequest): RedisClient | null => {
@@ -55,7 +64,8 @@ const checkRedis = async (req: MedusaRequest): Promise<HealthStatus> => {
       return "ok"; // No Redis configured, not an error
     }
 
-    const { default: Redis } = await import("ioredis");
+    const ioredis = await import("ioredis");
+    const Redis = ioredis.default as unknown as RedisConstructor;
     const testClient = new Redis(redisUrl, {
       connectTimeout: 5000,
       maxRetriesPerRequest: 1,

--- a/src/api/store/health/route.ts
+++ b/src/api/store/health/route.ts
@@ -2,7 +2,6 @@ import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 
 type HealthStatus = "ok" | "error";
-type RedisStatus = HealthStatus | "skipped";
 
 type RedisClient = {
   ping: () => Promise<unknown>;
@@ -41,19 +40,35 @@ const checkDatabase = async (req: MedusaRequest): Promise<HealthStatus> => {
   }
 };
 
-const checkRedis = async (req: MedusaRequest): Promise<RedisStatus> => {
-  if (!process.env.REDIS_URL) {
-    return "skipped";
-  }
-
+const checkRedis = async (req: MedusaRequest): Promise<HealthStatus> => {
   try {
+    // First try DI container
     const redisClient = resolveRedisClient(req);
-    if (!redisClient) {
-      return "error";
+    if (redisClient) {
+      await redisClient.ping();
+      return "ok";
     }
 
-    await redisClient.ping();
-    return "ok";
+    // Fallback: direct connection test using REDIS_URL
+    const redisUrl = process.env.REDIS_URL;
+    if (!redisUrl) {
+      return "ok"; // No Redis configured, not an error
+    }
+
+    const Redis = require("ioredis");
+    const testClient = new Redis(redisUrl, {
+      connectTimeout: 5000,
+      maxRetriesPerRequest: 1,
+      lazyConnect: true,
+    });
+
+    try {
+      await testClient.connect();
+      await testClient.ping();
+      return "ok";
+    } finally {
+      testClient.disconnect();
+    }
   } catch {
     return "error";
   }

--- a/src/api/store/health/route.ts
+++ b/src/api/store/health/route.ts
@@ -76,9 +76,10 @@ const checkRedis = async (req: MedusaRequest): Promise<HealthStatus> => {
 
 export async function GET(req: MedusaRequest, res: MedusaResponse) {
   const [database, redis] = await Promise.all([checkDatabase(req), checkRedis(req)]);
+  const isHealthy = database === "ok" && redis === "ok";
 
-  return res.status(200).json({
-    status: "ok",
+  return res.status(isHealthy ? 200 : 503).json({
+    status: isHealthy ? "ok" : "error",
     version: APP_VERSION,
     timestamp: new Date().toISOString(),
     checks: {


### PR DESCRIPTION
## Summary

- Fix `/health` endpoint returning `503` with `redis: "error"` due to DI container key mismatch in Medusa v2
- Add fallback direct `ioredis` connection test using `REDIS_URL` when DI resolution fails
- Return `"ok"` (not error) when no Redis is configured (`REDIS_URL` unset)

Closes #214
ROADMAP Ref: INFRA

## Test plan

- [ ] Deploy to staging and verify `/health` returns `{"status":"ok","checks":{"database":"ok","redis":"ok"}}`
- [ ] Verify with `REDIS_URL` set and Redis running → `redis: "ok"`
- [ ] Verify with `REDIS_URL` unset → `redis: "ok"` (not error)
- [ ] Verify with `REDIS_URL` set but Redis down → `redis: "error"`