### PR TITLE
fix(ci): change Dependabot target branch to develop (#361)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -16,6 +17,7 @@ updates:
       - dependency-name: "@medusajs/*"
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
Closes #361

### Motivation
- Change Dependabot's target branch to `develop` so dependency upgrade PRs do not open directly against `main` and cause branch divergence.

### Description
- Added `target-branch: "develop"` to both the `npm` and `github-actions` entries in `.github/dependabot.yml` and did not modify other files.

### Testing
- Verified the file with `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'` which loaded successfully indicating valid YAML.

ROADMAP Ref: INFRA

EGP Action: R-P0-14-A1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b782ea81088333b723566571c21271)