### PR TITLE
feat(governance): expand CODEOWNERS to lock core docs (#198)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,27 @@
 
 # Issue template protection
 /.github/ISSUE_TEMPLATE/ @Nickwenniyxiao-art
+
+# PR template protection
+/.github/PULL_REQUEST_TEMPLATE.md @Nickwenniyxiao-art
+
+# Standards and governance documents - Owner approval required
+/docs/standards/ @Nickwenniyxiao-art
+
+# AI collaboration spec
+/AGENTS.md @Nickwenniyxiao-art
+
+# Core governance documents
+/docs/ROADMAP.md @Nickwenniyxiao-art
+/docs/ENGINEERING-PLAYBOOK.md @Nickwenniyxiao-art
+/docs/SECURITY-POLICY.md @Nickwenniyxiao-art
+/docs/PROJECT.md @Nickwenniyxiao-art
+/docs/PRD.md @Nickwenniyxiao-art
+/docs/BUSINESS-RULES.md @Nickwenniyxiao-art
+
+# Document registry and library
+/DOC-REGISTRY.json @Nickwenniyxiao-art
+/docs/standards/DOC-LIBRARY.json @Nickwenniyxiao-art
+
+# Release configuration
+/.releaserc.json @Nickwenniyxiao-art


### PR DESCRIPTION
Closes #198

### Motivation
- Require Owner approval for core governance and standards documents by expanding `.github/CODEOWNERS` so sensitive docs are locked to `@Nickwenniyxiao-art`.

### Description
- Updated `.github/CODEOWNERS` to keep existing workflow/CODEOWNERS/ISSUE_TEMPLATE rules and add entries for `/.github/PULL_REQUEST_TEMPLATE.md`, `/docs/standards/`, `/AGENTS.md`, core `/docs/*.md` governance files, `/DOC-REGISTRY.json`, `/docs/standards/DOC-LIBRARY.json`, and `/.releaserc.json` all assigned to `@Nickwenniyxiao-art`.

### Testing
- Verified changes with `git diff -- .github/CODEOWNERS`, `git diff --check`, `git status --short`, and committed the update with `git commit` which all completed successfully.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7892af3a48333910b4839beff8e5e)