### PR TITLE
feat(governance): expand CODEOWNERS to lock core docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,16 @@
 
 # Issue template protection
 /.github/ISSUE_TEMPLATE/ @Nickwenniyxiao-art
+
+# PR template protection
+/.github/PULL_REQUEST_TEMPLATE.md @Nickwenniyxiao-art
+
+# Standards and governance documents - Owner approval required
+/docs/standards/ @Nickwenniyxiao-art
+
+# AI collaboration spec
+/AGENTS.md @Nickwenniyxiao-art
+
+# Core governance documents
+/docs/ROADMAP.md @Nickwenniyxiao-art
+/docs/PROJECT.md @Nickwenniyxiao-art


### PR DESCRIPTION
Closes #153

EGP Action: R-P0-01-A1

### Motivation
- Lock down core governance and standards documents so Owner approval is required for changes.
- Preserve existing workflow and issue-template protections while extending coverage to PR template, standards, AI collaboration spec, and core docs.

### Description
- Updated `.github/CODEOWNERS` to add `/.github/PULL_REQUEST_TEMPLATE.md`, `/docs/standards/`, `/AGENTS.md`, `/docs/ROADMAP.md`, and `/docs/PROJECT.md` all assigned to `@Nickwenniyxiao-art`.
- Kept the original three rules for workflows, CODEOWNERS, and issue templates unchanged.
- Change committed on branch `feat/153-codeowners-expand` with commit message `feat(governance): expand CODEOWNERS to lock core docs` and no other files modified.

### Testing
- Verified the patch with `git diff -- .github/CODEOWNERS` which shows only the intended additions and succeeded.
- Confirmed branch and workspace state with `git status --short --branch` which reported the new branch and clean changes.
- Inspected the final file contents with `nl -ba .github/CODEOWNERS` to validate the added lines, which matched the expected entries and succeeded.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b789316aa88333ab5a16755f639cf9)