### PR TITLE
feat(ci): auto-update Board Status to Done on Issue close (#365)

### DIFF
--- a/.github/workflows/auto-board-done.yml
+++ b/.github/workflows/auto-board-done.yml
@@ -1,0 +1,98 @@
+name: Auto Update Board Status on Issue Close
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  update-board:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Project Board Status to Done
+        uses: actions/github-script@v7
+        env:
+          BOT_PAT: ${{ secrets.BOT_PAT }}
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const projectId = 'PVT_kwHODtocYs4BRtgN';
+            const issueNodeId = context.payload.issue.node_id;
+
+            // 1. Find the item in the project
+            const query = `query($projectId: ID!) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  items(first: 250) {
+                    nodes {
+                      id
+                      content {
+                        ... on Issue {
+                          id
+                        }
+                      }
+                    }
+                  }
+                  fields(first: 20) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }`;
+
+            const result = await github.graphql(query, { projectId });
+            const project = result.node;
+
+            // Find the item matching this issue
+            const item = project.items.nodes.find(
+              i => i.content && i.content.id === issueNodeId
+            );
+
+            if (!item) {
+              console.log('Issue not found in project board, skipping.');
+              return;
+            }
+
+            // Find the Status field and Done option
+            const statusField = project.fields.nodes.find(f => f.name === 'Status');
+            if (!statusField) {
+              console.log('Status field not found, skipping.');
+              return;
+            }
+
+            const doneOption = statusField.options.find(o => o.name === 'Done');
+            if (!doneOption) {
+              console.log('Done option not found in Status field, skipping.');
+              return;
+            }
+
+            // Update the status
+            const mutation = `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $optionId }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }`;
+
+            await github.graphql(mutation, {
+              projectId,
+              itemId: item.id,
+              fieldId: statusField.id,
+              optionId: doneOption.id
+            });
+
+            console.log(`Updated Issue #${context.payload.issue.number} status to Done on project board.`);


### PR DESCRIPTION
Closes #365

### Motivation
- Keep Projects v2 board in sync by automatically moving a project's Issue item to `Done` when the Issue is closed.

### Description
- Added `.github/workflows/auto-board-done.yml` which triggers on `issues: closed` and runs on `ubuntu-latest`.
- Uses `actions/github-script@v7` with `BOT_PAT` to call the GitHub GraphQL API against project `PVT_kwHODtocYs4BRtgN`.
- Fetches project `items(first: 250)` and `fields`, finds the Issue's project item, resolves the `Status` single-select field and its `Done` option, and calls `updateProjectV2ItemFieldValue` to set the status.
- Includes safe early exits when the project item, Status field, or Done option are not found, and does not modify other repository files.

### Testing
- Ran `npx prettier --check .github/workflows/auto-board-done.yml` and the workflow file passed formatting checks.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7893819ac83339c50d45e22a8ac2b)