### PR TITLE
feat(ci): add DORA metrics workflow and docs (#193)

### DIFF
--- a/.github/workflows/dora-metrics.yml
+++ b/.github/workflows/dora-metrics.yml
@@ -1,0 +1,132 @@
+name: DORA Metrics
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # 每周一 UTC 9:00
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  collect-metrics:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Collect DORA Metrics
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const now = new Date();
+            const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
+            const thirtyDaysAgo = new Date(now - 30 * 24 * 60 * 60 * 1000);
+
+            // --- 1. Deployment Frequency ---
+            // Count pushes to main in last 7 and 30 days
+            const commits7d = await github.rest.repos.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: 'main',
+              since: sevenDaysAgo.toISOString(),
+              per_page: 100
+            });
+
+            const commits30d = await github.rest.repos.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: 'main',
+              since: thirtyDaysAgo.toISOString(),
+              per_page: 100
+            });
+
+            const deployFreq7d = commits7d.data.length;
+            const deployFreq30d = commits30d.data.length;
+            const deployFreqDaily = (deployFreq30d / 30).toFixed(1);
+
+            // --- 2. Lead Time for Changes ---
+            // Calculate average PR merge time (created → merged) for last 30 days
+            const mergedPRs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 50
+            });
+
+            const recentMerged = mergedPRs.data.filter(pr =>
+              pr.merged_at && new Date(pr.merged_at) > thirtyDaysAgo
+            );
+
+            let totalLeadTime = 0;
+            let leadTimeCount = 0;
+            for (const pr of recentMerged) {
+              const created = new Date(pr.created_at);
+              const merged = new Date(pr.merged_at);
+              const hours = (merged - created) / (1000 * 60 * 60);
+              totalLeadTime += hours;
+              leadTimeCount++;
+            }
+            const avgLeadTimeHours = leadTimeCount > 0 ? (totalLeadTime / leadTimeCount).toFixed(1) : 'N/A';
+
+            // --- 3. Change Failure Rate ---
+            // Count issues/PRs with hotfix label vs total merged PRs
+            const hotfixIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'type: hotfix',
+              state: 'all',
+              since: thirtyDaysAgo.toISOString(),
+              per_page: 100
+            });
+            const cfr = leadTimeCount > 0
+              ? ((hotfixIssues.data.length / leadTimeCount) * 100).toFixed(1)
+              : '0';
+
+            // --- 4. Time to Restore Service ---
+            // Average time from incident issue creation to close
+            const incidents = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'type: incident',
+              state: 'closed',
+              since: thirtyDaysAgo.toISOString(),
+              per_page: 100
+            });
+
+            let totalRestoreTime = 0;
+            let restoreCount = 0;
+            for (const issue of incidents.data) {
+              if (issue.closed_at) {
+                const created = new Date(issue.created_at);
+                const closed = new Date(issue.closed_at);
+                const hours = (closed - created) / (1000 * 60 * 60);
+                totalRestoreTime += hours;
+                restoreCount++;
+              }
+            }
+            const avgRestoreHours = restoreCount > 0 ? (totalRestoreTime / restoreCount).toFixed(1) : 'N/A';
+
+            // --- Output as Summary ---
+            const summary = `# DORA Metrics Report
+
+            | Metric | Value | Period | DORA Level |
+            |--------|-------|--------|------------|
+            | **部署频率 (Deployment Frequency)** | ${deployFreq7d} deploys/week, ${deployFreqDaily}/day | 7d / 30d | ${deployFreqDaily >= 1 ? '🟢 Elite' : deployFreqDaily >= 0.14 ? '🟡 High' : '🔴 Low'} |
+            | **变更前置时间 (Lead Time)** | ${avgLeadTimeHours} hours avg | 30d | ${avgLeadTimeHours !== 'N/A' && avgLeadTimeHours < 24 ? '🟢 Elite' : avgLeadTimeHours < 168 ? '🟡 High' : '🔴 Low'} |
+            | **变更失败率 (Change Failure Rate)** | ${cfr}% | 30d | ${cfr < 5 ? '🟢 Elite' : cfr < 15 ? '🟡 High' : '🔴 Low'} |
+            | **服务恢复时间 (MTTR)** | ${avgRestoreHours !== 'N/A' ? avgRestoreHours + ' hours' : 'No incidents'} | 30d | ${avgRestoreHours === 'N/A' ? '⚪ N/A' : avgRestoreHours < 1 ? '🟢 Elite' : avgRestoreHours < 24 ? '🟡 High' : '🔴 Low'} |
+
+            > DORA Level 参考: Elite (top tier) / High / Medium / Low
+            > 数据来源: GitHub API (commits, PRs, issues)
+            > 统计时间: ${now.toISOString().split('T')[0]}
+            `;
+
+            core.summary.addRaw(summary.split('\n').map(l => l.trim()).join('\n'));
+            await core.summary.write();
+
+            console.log('DORA metrics collected successfully.');

--- a/DOC-REGISTRY.json
+++ b/DOC-REGISTRY.json
@@ -151,6 +151,13 @@
       "required": true,
       "gate": 4,
       "status": "exists"
+    },
+    {
+      "id": "DORA-METRICS",
+      "file": "docs/DORA-METRICS.md",
+      "required": false,
+      "gate": 3,
+      "status": "exists"
     }
   ]
 }

--- a/docs/DORA-METRICS.md
+++ b/docs/DORA-METRICS.md
@@ -1,0 +1,70 @@
+---
+项目名称: NordHjem Medusa Backend
+创建日期: 2026-03-16
+状态: 已发布
+负责人: CTO
+---
+
+## 概述
+
+DORA（DevOps Research and Assessment）工程效能度量由 Google Cloud 的 DevOps 研究团队提出，用于衡量软件交付流程的速度与稳定性。
+
+通过持续追踪 DORA 四项核心指标，团队可以识别交付瓶颈、评估研发改进效果，并在“交付速度”与“系统可靠性”之间保持平衡。
+
+## 四个核心指标
+
+### 部署频率 (Deployment Frequency)
+
+- **含义**：单位时间内成功部署到生产（或主分支代表生产发布）的次数。
+- **计算方式**：统计最近 7 天和最近 30 天内 `main` 分支新增 commit 数，近似作为部署次数；并计算 30 天日均部署频率。
+- **数据来源**：GitHub API `repos.listCommits`（`sha: main`，按 `since` 过滤）。
+
+### 变更前置时间 (Lead Time for Changes)
+
+- **含义**：代码从创建变更（PR 创建）到可交付（PR 合并）的平均耗时。
+- **计算方式**：筛选最近 30 天内已合并 PR，按 `merged_at - created_at` 计算每个 PR 耗时（小时），再取平均值。
+- **数据来源**：GitHub API `pulls.list`（`state: closed`），再筛选 `merged_at` 在统计窗口内的数据。
+
+### 变更失败率 (Change Failure Rate)
+
+- **含义**：上线变更导致故障、回滚或热修复的比例。
+- **计算方式**：最近 30 天 `type: hotfix` 标签的 Issue/PR 数量 ÷ 最近 30 天合并 PR 数量 × 100%。
+- **数据来源**：GitHub API `issues.listForRepo`（`labels: type: hotfix`）+ `pulls.list` 合并结果。
+
+### 服务恢复时间 (Time to Restore Service / MTTR)
+
+- **含义**：服务出现故障后恢复到正常状态的平均时间。
+- **计算方式**：统计最近 30 天内已关闭且带 `type: incident` 标签的 Issue，按 `closed_at - created_at` 计算每个事件恢复时长（小时），再取平均值。
+- **数据来源**：GitHub API `issues.listForRepo`（`labels: type: incident`，`state: closed`）。
+
+## 行业基准
+
+以下为常见 DORA 分层参考（用于趋势对比，非绝对门槛）：
+
+| 指标 | Elite | High | Medium | Low |
+|---|---|---|---|---|
+| 部署频率 | 按需/每天多次 | 每天到每周 | 每周到每月 | 少于每月一次 |
+| 变更前置时间 | < 1 天 | 1 天到 1 周 | 1 周到 1 个月 | > 1 个月 |
+| 变更失败率 | 0% - 5% | 6% - 15% | 16% - 30% | > 30% |
+| 服务恢复时间（MTTR） | < 1 小时 | 1 小时到 1 天 | 1 天到 1 周 | > 1 周 |
+
+## 本项目数据来源
+
+`DORA Metrics` 工作流通过 `actions/github-script@v7` 调用 GitHub REST API，收集如下数据：
+
+- `repos.listCommits`：主分支近 7/30 天提交数量（部署频率）。
+- `pulls.list`：近 30 天合并 PR 的创建与合并时间（变更前置时间）。
+- `issues.listForRepo` + `labels: type: hotfix`：热修复数量（变更失败率）。
+- `issues.listForRepo` + `labels: type: incident`：故障恢复耗时（MTTR）。
+
+最终结果以 Markdown 表格写入 `GITHUB_STEP_SUMMARY`，便于在 Actions 运行页直接查看。
+
+## 使用方法
+
+1. 进入 GitHub 仓库的 **Actions** 页面。
+2. 选择 `DORA Metrics` 工作流。
+3. 可通过两种方式触发：
+   - 自动触发：每周一 UTC 09:00（cron `0 9 * * 1`）。
+   - 手动触发：点击 **Run workflow**（`workflow_dispatch`）。
+4. 打开任一运行记录，进入 `collect-metrics` job。
+5. 在页面底部 **Summary** 区域查看 DORA 四项指标与等级评估结果。


### PR DESCRIPTION
Closes #193

### Motivation
- Provide an automated, repeatable way to collect weekly DORA engineering metrics from GitHub so the team's delivery performance can be tracked and trended. 
- Add documentation that explains the four DORA metrics, data sources, and how to view/run the report to make the metrics discoverable for the team.

### Description
- Add `.github/workflows/dora-metrics.yml` which runs on a weekly cron (`0 9 * * 1`) and supports `workflow_dispatch`, and uses `actions/github-script@v7` to collect metrics. 
- Implement metric collection for the four DORA indicators: Deployment Frequency, Lead Time for Changes, Change Failure Rate, and Time to Restore Service (MTTR), and write the results as a Markdown table to `GITHUB_STEP_SUMMARY`. 
- Add `docs/DORA-METRICS.md` with metadata, an overview, detailed definitions and formulas for each metric, industry benchmark tiers, data sources, and usage instructions. 
- Register the document in `DOC-REGISTRY.json` by adding a `DORA-METRICS` entry (`required: false`, `gate: 3`, `status: exists`).

### Testing
- Parsed the workflow YAML with a Ruby YAML load (`ruby -e "require 'yaml'; YAML.load_file('.github/workflows/dora-metrics.yml')"`) and the command returned `ok`, indicating the workflow file is syntactically valid. 
- Validated `DOC-REGISTRY.json` as valid JSON using `jq empty DOC-REGISTRY.json`, which succeeded.

EGP Action: R-P2-24-A2

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7913722748333beff44a90c1f40e0)