### PR TITLE
feat(ci): add doc-registry-check workflow (#205)

### DIFF
--- a/.github/workflows/doc-registry-check.yml
+++ b/.github/workflows/doc-registry-check.yml
@@ -1,0 +1,120 @@
+name: Doc Registry Check
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'DOC-REGISTRY.json'
+
+permissions:
+  contents: read
+
+jobs:
+  registry-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check Registry Consistency
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const errors = [];
+            const warnings = [];
+
+            // --- Load JSON files ---
+            let library, registry;
+            try {
+              library = JSON.parse(fs.readFileSync('docs/standards/DOC-LIBRARY.json', 'utf8'));
+            } catch (e) {
+              core.setFailed('Cannot read docs/standards/DOC-LIBRARY.json: ' + e.message);
+              return;
+            }
+            try {
+              registry = JSON.parse(fs.readFileSync('DOC-REGISTRY.json', 'utf8'));
+            } catch (e) {
+              core.setFailed('Cannot read DOC-REGISTRY.json: ' + e.message);
+              return;
+            }
+
+            // --- Build lookup sets ---
+            const libraryIds = new Set(library.documents.map(d => d.id));
+            const registeredFiles = new Set(registry.documents.map(d => d.file));
+            const registeredIds = new Set(registry.documents.map(d => d.id));
+
+            // --- Whitelist directories (not subject to registry check) ---
+            const whitelist = ['docs/standards/'];
+
+            // --- 1. Scan docs/ for unregistered files (野文档) ---
+            function walkDir(dir) {
+              const entries = fs.readdirSync(dir, { withFileTypes: true });
+              const files = [];
+              for (const entry of entries) {
+                const fullPath = path.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                  files.push(...walkDir(fullPath));
+                } else if (entry.name.endsWith('.md')) {
+                  files.push(fullPath);
+                }
+              }
+              return files;
+            }
+
+            const docsFiles = walkDir('docs');
+
+            for (const file of docsFiles) {
+              // Skip whitelisted directories
+              if (whitelist.some(w => file.startsWith(w))) continue;
+
+              if (!registeredFiles.has(file)) {
+                errors.push(`Unregistered doc (野文档): ${file} — not found in DOC-REGISTRY.json`);
+              }
+            }
+
+            // --- 2. Check all registry IDs exist in library ---
+            for (const doc of registry.documents) {
+              if (!libraryIds.has(doc.id)) {
+                errors.push(`Unknown type: "${doc.id}" in DOC-REGISTRY.json is not defined in DOC-LIBRARY.json`);
+              }
+            }
+
+            // --- 3. Check registered files actually exist ---
+            for (const doc of registry.documents) {
+              if (!fs.existsSync(doc.file) && doc.status === 'exists') {
+                warnings.push(`Phantom doc: ${doc.file} (id: ${doc.id}) registered as "exists" but file not found`);
+              }
+            }
+
+            // --- Output Report ---
+            let report = '# Doc Registry Check Report\n\n';
+            report += `**Docs scanned**: ${docsFiles.length}\n`;
+            report += `**Registry entries**: ${registry.documents.length}\n`;
+            report += `**Library types**: ${library.documents.length}\n\n`;
+
+            if (errors.length === 0 && warnings.length === 0) {
+              report += '✅ All documents are properly registered and all types are valid.\n';
+              core.info('Registry check passed.');
+            } else {
+              if (errors.length > 0) {
+                report += `### ❌ Errors (${errors.length})\n\n`;
+                for (const err of errors) {
+                  report += `- ${err}\n`;
+                }
+                report += '\n';
+              }
+              if (warnings.length > 0) {
+                report += `### ⚠️ Warnings (${warnings.length})\n\n`;
+                for (const w of warnings) {
+                  report += `- ${w}\n`;
+                }
+              }
+            }
+
+            core.summary.addRaw(report);
+            await core.summary.write();
+
+            if (errors.length > 0) {
+              core.setFailed(`${errors.length} registry consistency errors found.`);
+            }


### PR DESCRIPTION
### Motivation
- Add a CI workflow to validate documentation registry consistency for PRs that touch docs or the registry file, ensuring all `docs/` Markdown files are registered and all registry type IDs exist in the library (Issue #205).

### Description
- Add `./github/workflows/doc-registry-check.yml` which triggers on `pull_request` for changes to `docs/**` or `DOC-REGISTRY.json` and uses `actions/github-script@v7` with `contents: read` permission.
- Implement a Node script that loads `docs/standards/DOC-LIBRARY.json` and `DOC-REGISTRY.json`, recursively scans `docs/` for `.md` files, and excludes the whitelist `docs/standards/` from the unregistered-doc check.
- The script collects `errors` for unregistered docs and for registry `id`s not found in the library, collects `warnings` for entries marked `status: 'exists'` whose files are missing, writes a report to `GITHUB_STEP_SUMMARY` via `core.summary.addRaw(report)`, and fails the step with `core.setFailed` when errors exist.

### Testing
- Ran `git diff --check` to validate there were no diff-check issues (passed).
- Inspected the added workflow file contents with `nl -ba .github/workflows/doc-registry-check.yml` to verify the scripted logic and trigger paths (file content validated).
- No GitHub Actions run was executed locally; the workflow is ready and will run on PRs that match the configured paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7a88879348333b2ebac9be2e22750)