### PR TITLE
feat(ci): add doc-completeness-audit workflow (#207)

### DIFF
--- a/.github/workflows/doc-completeness-audit.yml
+++ b/.github/workflows/doc-completeness-audit.yml
@@ -1,0 +1,222 @@
+name: Doc Completeness Audit
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # 每周一 UTC 9:00
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_PAT }}
+
+      - name: Run Completeness Audit
+        id: audit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { execSync } = require('child_process');
+
+            // --- Load files ---
+            let library, registry;
+            try {
+              library = JSON.parse(fs.readFileSync('docs/standards/DOC-LIBRARY.json', 'utf8'));
+              registry = JSON.parse(fs.readFileSync('DOC-REGISTRY.json', 'utf8'));
+            } catch (e) {
+              core.setFailed('Cannot load DOC-LIBRARY or DOC-REGISTRY: ' + e.message);
+              return;
+            }
+
+            const currentGate = registry.current_gate || 1;
+            const results = {
+              requiredMissing: [],
+              formatIssues: [],
+              unregisteredFiles: [],
+              staleFiles: [],
+              statusUpdates: [],
+              gateCompletion: { total: 0, present: 0 }
+            };
+
+            // --- 1. Check required docs exist ---
+            const requiredDocs = registry.documents.filter(d => d.required && d.gate <= currentGate);
+            results.gateCompletion.total = requiredDocs.length;
+
+            for (const doc of requiredDocs) {
+              if (fs.existsSync(doc.file)) {
+                results.gateCompletion.present++;
+              } else {
+                results.requiredMissing.push(doc);
+              }
+            }
+
+            // --- 2. Check format of existing docs ---
+            for (const doc of registry.documents) {
+              if (!fs.existsSync(doc.file)) continue;
+              const content = fs.readFileSync(doc.file, 'utf8');
+
+              // Check YAML frontmatter
+              if (!content.match(/^---\n[\s\S]*?\n---/)) {
+                results.formatIssues.push(`${doc.file}: missing YAML frontmatter`);
+              }
+
+              // Check required sections from library
+              const libEntry = library.documents.find(l => l.id === doc.id);
+              if (libEntry && libEntry.required_sections) {
+                for (const section of libEntry.required_sections) {
+                  if (!content.includes(section)) {
+                    results.formatIssues.push(`${doc.file}: missing section "${section}"`);
+                  }
+                }
+              }
+            }
+
+            // --- 3. Detect unregistered files (野文档) ---
+            const whitelist = ['docs/standards/'];
+            const registeredFiles = new Set(registry.documents.map(d => d.file));
+
+            function walkDir(dir) {
+              if (!fs.existsSync(dir)) return [];
+              const entries = fs.readdirSync(dir, { withFileTypes: true });
+              const files = [];
+              for (const entry of entries) {
+                const fullPath = path.join(dir, entry.name);
+                if (entry.isDirectory()) files.push(...walkDir(fullPath));
+                else if (entry.name.endsWith('.md')) files.push(fullPath);
+              }
+              return files;
+            }
+
+            for (const file of walkDir('docs')) {
+              if (whitelist.some(w => file.startsWith(w))) continue;
+              if (!registeredFiles.has(file)) {
+                results.unregisteredFiles.push(file);
+              }
+            }
+
+            // --- 4. Detect stale docs (>90 days since last modified) ---
+            const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+            for (const doc of registry.documents) {
+              if (!fs.existsSync(doc.file)) continue;
+              try {
+                const lastModified = execSync(`git log -1 --format=%aI -- "${doc.file}"`, { encoding: 'utf8' }).trim();
+                if (lastModified && new Date(lastModified) < ninetyDaysAgo) {
+                  results.staleFiles.push({ file: doc.file, lastModified });
+                }
+              } catch (e) {
+                // git log might fail for new files
+              }
+            }
+
+            // --- 5. Auto-sync status field ---
+            let registryModified = false;
+            for (const doc of registry.documents) {
+              const fileExists = fs.existsSync(doc.file);
+              const expectedStatus = fileExists ? 'exists' : 'missing';
+              if (doc.status !== expectedStatus) {
+                results.statusUpdates.push({
+                  id: doc.id,
+                  file: doc.file,
+                  oldStatus: doc.status,
+                  newStatus: expectedStatus
+                });
+                doc.status = expectedStatus;
+                registryModified = true;
+              }
+            }
+
+            // Write updated registry if changed
+            if (registryModified) {
+              fs.writeFileSync('DOC-REGISTRY.json', JSON.stringify(registry, null, 2) + '\n');
+              core.setOutput('registry_modified', 'true');
+            } else {
+              core.setOutput('registry_modified', 'false');
+            }
+
+            // --- Build Report ---
+            const gatePct = results.gateCompletion.total > 0
+              ? ((results.gateCompletion.present / results.gateCompletion.total) * 100).toFixed(0)
+              : '100';
+
+            let report = '# 📋 Doc Completeness Audit Report\n\n';
+            report += `**审计时间**: ${new Date().toISOString().split('T')[0]}\n`;
+            report += `**当前 Gate**: ${currentGate}\n`;
+            report += `**Gate 文档完成率**: ${gatePct}% (${results.gateCompletion.present}/${results.gateCompletion.total})\n\n`;
+
+            if (results.requiredMissing.length > 0) {
+              report += `### ❌ 缺失必需文档 (${results.requiredMissing.length})\n\n`;
+              for (const d of results.requiredMissing) {
+                report += `- \`${d.file}\` (${d.id}, Gate ${d.gate})\n`;
+              }
+              report += '\n';
+            }
+
+            if (results.unregisteredFiles.length > 0) {
+              report += `### ⚠️ 野文档 — 未注册 (${results.unregisteredFiles.length})\n\n`;
+              for (const f of results.unregisteredFiles) {
+                report += `- \`${f}\`\n`;
+              }
+              report += '\n';
+            }
+
+            if (results.staleFiles.length > 0) {
+              report += `### 🕐 过期文档 — 超过90天未更新 (${results.staleFiles.length})\n\n`;
+              for (const f of results.staleFiles) {
+                report += `- \`${f.file}\` (最后更新: ${f.lastModified.split('T')[0]})\n`;
+              }
+              report += '\n';
+            }
+
+            if (results.formatIssues.length > 0) {
+              report += `### 📝 格式问题 (${results.formatIssues.length})\n\n`;
+              for (const issue of results.formatIssues) {
+                report += `- ${issue}\n`;
+              }
+              report += '\n';
+            }
+
+            if (results.statusUpdates.length > 0) {
+              report += `### 🔄 Status 自动同步 (${results.statusUpdates.length})\n\n`;
+              for (const u of results.statusUpdates) {
+                report += `- \`${u.id}\`: ${u.oldStatus} → ${u.newStatus}\n`;
+              }
+              report += '\n';
+            }
+
+            if (results.requiredMissing.length === 0 && results.unregisteredFiles.length === 0 && results.formatIssues.length === 0) {
+              report += '### ✅ 所有检查通过\n\n文档体系健康。\n';
+            }
+
+            if (gatePct === '100') {
+              report += '\n💡 当前 Gate 文档已 100% 完成，建议考虑升级 `current_gate`。\n';
+            }
+
+            core.summary.addRaw(report);
+            await core.summary.write();
+
+      - name: Create sync PR
+        if: steps.audit.outputs.registry_modified == 'true'
+        run: |
+          git config user.name "nickwenniyxiao-bot"
+          git config user.email "bot@nordhjem.com"
+          BRANCH="auto/doc-registry-sync-$(date +%Y%m%d)"
+          git checkout -b "$BRANCH"
+          git add DOC-REGISTRY.json
+          git commit -m "fix(docs): auto-sync DOC-REGISTRY.json status fields"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "fix(docs): auto-sync DOC-REGISTRY.json status fields" \
+            --body "Automated: DOC-REGISTRY.json status fields synced by doc-completeness-audit workflow." \
+            --base develop \
+            --head "$BRANCH" \
+            --label "type: docs"
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}


### PR DESCRIPTION
Closes #207

### Motivation
- Add an automated weekly/manual CI workflow to continuously audit documentation completeness and surface missing, malformed, stale, or unregistered docs so the docs registry stays accurate.
- Automatically sync `DOC-REGISTRY.json` `status` fields and open a bot PR when changes are required to keep the registry authoritative without manual work.

ROADMAP Ref: INFRA
EGP Action: R-P2-08-A1

### Description
- Added `.github/workflows/doc-completeness-audit.yml` that runs on schedule (`cron: '0 9 * * 1'`) and supports `workflow_dispatch` for manual runs and grants `contents: write` and `pull-requests: write` permissions.
- The workflow uses `actions/github-script` to load `docs/standards/DOC-LIBRARY.json` and `DOC-REGISTRY.json`, check required docs for the current gate, validate YAML frontmatter and required sections, detect unregistered markdown files under `docs/` (excluding `docs/standards/`), and flag stale docs (>90 days) using `git log`.
- When `status` mismatches are found the script updates `DOC-REGISTRY.json` and, if modified, the workflow creates an automated branch `auto/doc-registry-sync-YYYYMMDD`, commits the change, and opens a PR using the bot token (`BOT_PAT`).
- Report summary is published to the GitHub step summary including completion percentage, missing/unregistered/stale/format issues, and status synchronization details.

### Testing
- Validated the workflow YAML by parsing it with Ruby using `YAML.load_file('.github/workflows/doc-completeness-audit.yml')`, which succeeded.
- Performed a local git commit of the new workflow with `git commit` to ensure file was added and staged correctly, which succeeded.
- No runtime backend tests were modified or required for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7a899392083339daaee6995004bae)