### PR TITLE
fix(cd): move secrets.DEPLOY_HOST out of workflow_call with: block

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -178,5 +178,5 @@ jobs:
     uses: ./.github/workflows/smoke-test.yml
     with:
       environment: production
-      base_url: "http://${{ secrets.DEPLOY_HOST }}:9000"
+      port: "9000"
     secrets: inherit

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -170,7 +170,7 @@ jobs:
     uses: ./.github/workflows/smoke-test.yml
     with:
       environment: staging
-      base_url: "http://${{ secrets.DEPLOY_HOST }}:9002"
+      port: "9002"
     secrets: inherit
 
   promote-to-production:

--- a/.github/workflows/cd-test.yml
+++ b/.github/workflows/cd-test.yml
@@ -157,7 +157,7 @@ jobs:
     uses: ./.github/workflows/smoke-test.yml
     with:
       environment: test
-      base_url: "http://${{ secrets.DEPLOY_HOST }}:9001"
+      port: "9001"
     secrets: inherit
 
   promote-to-staging:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,8 +11,8 @@ on:
           - test
           - staging
           - production
-      base_url:
-        description: "Base URL for smoke test target (e.g. https://api.example.com)"
+      port:
+        description: "Port number for the target environment (e.g. 9001)"
         type: string
         required: true
   workflow_call:
@@ -21,9 +21,12 @@ on:
         description: "Target environment"
         type: string
         required: true
-      base_url:
-        description: "Base URL for smoke test target (e.g. https://api.example.com)"
+      port:
+        description: "Port number for the target environment (e.g. 9001)"
         type: string
+        required: true
+    secrets:
+      DEPLOY_HOST:
         required: true
 
 jobs:
@@ -39,7 +42,7 @@ jobs:
         shell: bash
         env:
           ENVIRONMENT: ${{ inputs.environment }}
-          BASE_URL: ${{ inputs.base_url }}
+          BASE_URL: "http://${{ secrets.DEPLOY_HOST }}:${{ inputs.port }}"
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Closes #413

EGP Action: R-P2-05-A1

### Motivation
- Fix GitHub Actions parse-time failures caused by referencing `secrets.DEPLOY_HOST` inside the `with:` block when calling a reusable workflow, which resulted in 0 jobs being scheduled for CD workflows.

### Description
- Changed `.github/workflows/smoke-test.yml` to accept a `port` input for both `workflow_dispatch` and `workflow_call`, declared `DEPLOY_HOST` as a required secret for `workflow_call`, and construct `BASE_URL` internally as `http://${{ secrets.DEPLOY_HOST }}:${{ inputs.port }}`.
- Updated callers in `.github/workflows/cd-test.yml`, `.github/workflows/cd-staging.yml`, and `.github/workflows/cd-production.yml` to pass fixed `port` values (`9001`, `9002`, `9000`) and removed `base_url` uses from their `with:` blocks.
- Committed the changes on branch `fix/cd-smoke-test-secrets` with an appropriate conventional commit message.

### Testing
- Verified no remaining `base_url` references and that `port:` inputs exist in the four modified workflow files using `rg`.
- Successfully parsed all four modified workflow YAML files using Ruby's `YAML.load_file` to validate syntax.
- Attempted to run `actionlint` via `npx`, but the environment blocked package fetch with an npm 403 so `actionlint` could not be executed here.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7d30816c0833390909da594479c68)