### PR TITLE
fix(ci): use /admin route in smoke-test and accept 401

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -91,7 +91,7 @@ jobs:
 
           overall=0
           check_endpoint "Health" "/health" "200" || overall=1
-          check_endpoint "Admin Panel" "/app" "200 301 302" || overall=1
+          check_endpoint "Admin Panel" "/admin" "200 301 302 401" || overall=1
           check_endpoint "Store API Auth" "/store/products" "200 400" || overall=1
 
           {


### PR DESCRIPTION
修复 smoke-test Admin Panel 检查：
- /app → /admin（Medusa 实际的 admin 路由）
- 接受 HTTP 401（需要认证的正常响应，说明服务在线）