### PR TITLE
fix(ci): disable codex-autofix to stop runaway loop [S1-0]

### DIFF
--- a/.github/workflows/codex-autofix.yml
+++ b/.github/workflows/codex-autofix.yml
@@ -1,9 +1,16 @@
 name: Codex Auto-Fix on Failure
 
+# ⚠️ TEMPORARILY DISABLED — S1-0
+# 原因：22分钟内触发7次，累计525次运行，形成恶性循环
+# 恢复条件：阶段一所有工作流稳定变绿后重新启用
+# 禁用日期：2026-03-16
+# 禁用决策：Owner审批 + CTO执行
 on:
-  workflow_run:
-    workflows: ["CI", "AI Code Review"]
-    types: [completed]
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type ENABLE to re-enable auto-fix'
+        required: true
 
 permissions:
   contents: write
@@ -24,6 +31,15 @@ jobs:
       FAILED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
     steps:
+      - name: Confirm re-enable
+        run: |
+          if [ "${{ github.event.inputs.confirm }}" != "ENABLE" ]; then
+            echo "❌ Auto-fix is temporarily disabled (S1-0)."
+            echo "To re-enable, type ENABLE in the workflow_dispatch input."
+            exit 1
+          fi
+          echo "✅ Auto-fix manually enabled for this run."
+
       # ── 0. Guard: check retry counter ──────────────────────────
       - name: Check retry counter
         id: retry-check

--- a/docs/CURRENT-STATUS.md
+++ b/docs/CURRENT-STATUS.md
@@ -113,3 +113,13 @@
 | `BOT_PAT` | Bot 账号 Classic PAT，用于 PR auto-approve | 新增 |
 | `OPENAI_API_KEY` | AI Code Review (GPT-4o-mini) | 已有 |
 | `CD_PAT` | CD pipeline + Auto-merge | 已有 |
+
+## S1-0: Codex Auto-Fix 已禁用 (2026-03-16)
+
+- **状态**: 已禁用（改为 workflow_dispatch 手动触发）
+- **原因**: 累计运行525次，22分钟内触发7次，浪费Actions额度并阻塞其他工作流
+- **恢复条件**: 阶段一（S1-1 ~ S1-6）全部完成、所有核心工作流稳定变绿后重新启用
+- **恢复时需要做的修改**:
+  1. 将触发条件改回 `workflow_run`
+  2. 添加频率限制：24小时内同一分支最多触发1次
+  3. 添加触发范围限制：只监听 CI 工作流，不监听 AI Code Review


### PR DESCRIPTION
Closes #0

### Motivation
- Stop the runaway Codex Auto-Fix workflow which ran 525 times and triggered 7 times within 22 minutes, consuming Actions quota and creating cascading CI runs. 
- Temporarily halt automatic retries while Phase 1 workflows are stabilized to avoid further interference with CI and AI review pipelines.
- Preserve the workflow file and history while requiring an explicit manual re-enable to allow controlled testing and restoration.

### Description
- Replace the `workflow_run` trigger in `.github/workflows/codex-autofix.yml` with a `workflow_dispatch` trigger requiring a `confirm` input so the workflow no longer auto-starts on other workflow completions. 
- Insert a `Confirm re-enable` step at the top of `jobs.auto-fix` that exits unless the `confirm` input equals `ENABLE`, preventing accidental manual runs. 
- Append an `S1-0` entry to `docs/CURRENT-STATUS.md` documenting the disablement, reason, restoration conditions, and a short re-enable checklist.

### Testing
- Ran `git diff --check` to validate patch sanity and whitespace issues, which passed. 
- Verified the YAML changes via a file diff to confirm the trigger and guard step were inserted as specified. 
- Ensured `docs/CURRENT-STATUS.md` contains the new `S1-0` record and the added content matches the requested text.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b868f6efa0833393327189d7b29691)