### PR TITLE
feat(docs): add workflow status badges to README [S2-3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # NordHjem Medusa Backend
 
+[![CI](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/ci.yml/badge.svg)](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/ci.yml)
+[![CD — Staging](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/cd-staging.yml/badge.svg)](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/cd-staging.yml)
+[![CD — Production](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/cd-production.yml/badge.svg)](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/cd-production.yml)
+[![Release](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/release.yml/badge.svg)](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/release.yml)
+[![Gitleaks](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/gitleaks.yml/badge.svg)](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/gitleaks.yml)
+[![DORA Metrics](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/dora-metrics.yml/badge.svg)](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/dora-metrics.yml)
+[![Database Backup](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/db-backup.yml/badge.svg)](https://github.com/Nickwenniyxiao-art/nordhjem-medusa-backend/actions/workflows/db-backup.yml)
+
 NordHjem 电商平台后端服务，基于 [Medusa.js v2](https://medusajs.com/) 构建。
 
 ## 技术栈


### PR DESCRIPTION
Closes #0

### Motivation
- Add GitHub Actions workflow status badges to the top of the backend `README.md` so CI/CD and operational workflow health are visible at a glance.

### Description
- Inserted 7 badge markdown lines directly under `# NordHjem Medusa Backend` and before `## 技术栈`, linking to the repository workflows: `ci.yml`, `cd-staging.yml`, `cd-production.yml`, `release.yml`, `gitleaks.yml`, `dora-metrics.yml`, and `db-backup.yml`.

### Testing
- Verified the change by inspecting the file with `rg`/`sed`/`nl` checks (e.g. `rg -n "^\[!\[" README.md`, `sed -n '1,25p' README.md`, `nl -ba README.md | sed -n '1,25p'`) and confirmed the 7 badge lines are present and the file was committed successfully.

ROADMAP Ref: INFRA

EGP Action: R-P2-01-A1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b86c5a607883338d54de82b4c65113)