### PR TITLE
feat(ci): add actionlint workflow for YAML syntax validation

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,24 @@
+name: Actionlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [develop, main]
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          reporter: github-pr-review
+          fail_on_error: true

--- a/docs/CURRENT-STATUS.md
+++ b/docs/CURRENT-STATUS.md
@@ -149,3 +149,9 @@
 - **问题**: semantic-release 尝试创建已存在的 v1.0.0 tag，导致 exit code 128
 - **修复**: 在 release.yml 中添加 `git fetch --tags --force` 确保 semantic-release 能识别所有已有 tag 并自动递增版本号
 - **原则**: 不删除已有 tag（保护 release 记录），让 semantic-release 自动判断下一版本
+
+## S1-5: actionlint 工作流检查已添加 (2026-03-16)
+
+- **新增**: `.github/workflows/actionlint.yml`
+- **触发条件**: 当 PR 或 push 修改了 `.github/workflows/` 目录下的文件时自动运行
+- **作用**: 检查所有 GitHub Actions 工作流文件的语法正确性，防止 YAML 语法错误导致 CI 失败


### PR DESCRIPTION
Closes #5

### Motivation
- Prevent CI breakage from invalid GitHub Actions YAML by adding an automated linter that runs whenever workflow files change.

### Description
- Added `./github/workflows/actionlint.yml` which runs `reviewdog/action-actionlint@v1` with `fail_on_error: true` and `contents: read` permission.
- Configured triggers to run on `pull_request` for changes under `.github/workflows/**` and on `push` to `develop` and `main` when `.github/workflows/**` is modified.
- Appended an S1-5 status entry to `docs/CURRENT-STATUS.md` documenting the new check and its trigger conditions.
- Committed with message `feat(ci): add actionlint workflow for YAML syntax validation [S1-5]`.

### Testing
- Parsed the new workflow locally with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/actionlint.yml')"` which returned `YAML parse OK`.
- Verified trigger blocks and path filters in ` .github/workflows/actionlint.yml` via `rg` which found the expected `pull_request`, `push`, `branches`, and `paths` entries.
- Attempted `npx -y yaml@2.8.1 .github/workflows/actionlint.yml` which failed due to registry access (`403 Forbidden`), so that specific npm-based validation could not run.

ROADMAP Ref: INFRA
EGP Action: R-P1-05-A1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b873377cdc833381303b781a94493a)