### PR TITLE
chore(docs): update TASK-REGISTRY with completed task statuses [S2-4-registry]

### DIFF
--- a/docs/governance/TASK-REGISTRY.json
+++ b/docs/governance/TASK-REGISTRY.json
@@ -7,7 +7,7 @@
     {
       "id": "S1-0",
       "title": "禁用 Codex Auto-Fix on Failure",
-      "status": "in-progress",
+      "status": "done",
       "priority": "P0",
       "phase": "Phase 2",
       "module": "INFRA",
@@ -15,12 +15,13 @@
       "issue": null,
       "pr": null,
       "created": "2026-03-16",
-      "completed": null
+      "completed": null,
+      "completedAt": "2026-03-16"
     },
     {
       "id": "S1-1",
       "title": "修复 Release 工作流（tag冲突）",
-      "status": "in-progress",
+      "status": "done",
       "priority": "P0",
       "phase": "Phase 2",
       "module": "INFRA",
@@ -28,12 +29,13 @@
       "issue": null,
       "pr": null,
       "created": "2026-03-16",
-      "completed": null
+      "completed": null,
+      "completedAt": "2026-03-16"
     },
     {
       "id": "S1-2",
       "title": "修复 Database Backup 工作流",
-      "status": "in-progress",
+      "status": "done",
       "priority": "P0",
       "phase": "Phase 2",
       "module": "INFRA",
@@ -41,12 +43,13 @@
       "issue": null,
       "pr": null,
       "created": "2026-03-16",
-      "completed": null
+      "completed": null,
+      "completedAt": "2026-03-16"
     },
     {
       "id": "S1-3",
       "title": "修复 CD-Staging + 排查 CD-Production",
-      "status": "in-progress",
+      "status": "done",
       "priority": "P0",
       "phase": "Phase 2",
       "module": "INFRA",
@@ -54,12 +57,13 @@
       "issue": null,
       "pr": null,
       "created": "2026-03-16",
-      "completed": null
+      "completed": null,
+      "completedAt": "2026-03-16"
     },
     {
       "id": "S1-4",
       "title": "修复前端 Playwright 测试",
-      "status": "in-progress",
+      "status": "done",
       "priority": "P0",
       "phase": "Phase 2",
       "module": "INFRA",
@@ -67,12 +71,13 @@
       "issue": null,
       "pr": null,
       "created": "2026-03-16",
-      "completed": null
+      "completed": null,
+      "completedAt": "2026-03-16"
     },
     {
       "id": "S1-5",
       "title": "添加 actionlint 工作流检查",
-      "status": "planned",
+      "status": "in-progress",
       "priority": "P1",
       "phase": "Phase 2",
       "module": "INFRA",
@@ -85,7 +90,7 @@
     {
       "id": "S2-1",
       "title": "创建 TASK-REGISTRY.json",
-      "status": "in-progress",
+      "status": "done",
       "priority": "P1",
       "phase": "Phase 2",
       "module": "DOCS",
@@ -93,12 +98,13 @@
       "issue": null,
       "pr": null,
       "created": "2026-03-16",
-      "completed": null
+      "completed": null,
+      "completedAt": "2026-03-16"
     },
     {
       "id": "S2-2",
       "title": "制定红叉 SLA 制度",
-      "status": "planned",
+      "status": "done",
       "priority": "P1",
       "phase": "Phase 2",
       "module": "DOCS",
@@ -106,12 +112,13 @@
       "issue": null,
       "pr": null,
       "created": "2026-03-16",
-      "completed": null
+      "completed": null,
+      "completedAt": "2026-03-16"
     },
     {
       "id": "S2-3",
       "title": "README 添加 workflow status badges",
-      "status": "planned",
+      "status": "done",
       "priority": "P1",
       "phase": "Phase 2",
       "module": "DOCS",
@@ -119,12 +126,13 @@
       "issue": null,
       "pr": null,
       "created": "2026-03-16",
-      "completed": null
+      "completed": null,
+      "completedAt": "2026-03-16"
     },
     {
       "id": "S2-4",
       "title": "清理 112 个 Open Issues 并分层",
-      "status": "planned",
+      "status": "done",
       "priority": "P2",
       "phase": "Phase 2",
       "module": "INFRA",
@@ -132,12 +140,13 @@
       "issue": null,
       "pr": null,
       "created": "2026-03-16",
-      "completed": null
+      "completed": null,
+      "completedAt": "2026-03-16"
     },
     {
       "id": "S2-5",
       "title": "写 Sprint #2 日志",
-      "status": "planned",
+      "status": "done",
       "priority": "P2",
       "phase": "Phase 2",
       "module": "DOCS",
@@ -145,7 +154,8 @@
       "issue": null,
       "pr": null,
       "created": "2026-03-16",
-      "completed": null
+      "completed": null,
+      "completedAt": "2026-03-16"
     }
   ]
 }


### PR DESCRIPTION
Closes #0

### Motivation
- Keep `docs/governance/TASK-REGISTRY.json` in sync with completed Sprint work and ensure execution-tracking remains accurate.
- Record completion timestamps for traceability and to satisfy the repository's execution protocol requirements.

### Description
- Updated task entries in `docs/governance/TASK-REGISTRY.json` to set `status` → `done` and added `completedAt: "2026-03-16"` for the tasks present in the file: `S1-0` through `S1-4`, and `S2-1` through `S2-5`.
- Changed `S1-5` status to `in-progress` as requested and left other task entries unchanged.
- Noted that `S3-1a` and `S3-2` were not present in the current registry file so they were not modified.

### Testing
- Validated the resulting JSON by parsing `docs/governance/TASK-REGISTRY.json` with `python` and confirmed it is valid JSON.
- Ran a verification script to confirm the listed tasks present in the file have `status: "done"` and `completedAt: "2026-03-16"` and that `S1-5` is `in-progress`.
- Reviewed changes with `git diff -- docs/governance/TASK-REGISTRY.json` and committed the update with the message `chore(docs): update TASK-REGISTRY with completed task statuses [S2-4-registry]`, which succeeded.

EGP Action: R-P2-04-A1

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b87354e4e4833399f754e2a719df77)