### PR TITLE
fix(ci): use BOT_PAT for promote PR creation in cd-staging [S1-3b]

### DIFF
--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -206,11 +206,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.CD_PAT }}
+          token: ${{ secrets.BOT_PAT }}
 
       - name: Create promote PR staging to main
         env:
-          GH_TOKEN: ${{ secrets.CD_PAT }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
         run: |
           EXISTING_PR=$(gh pr list --repo ${{ github.repository }} --base main --head staging --json number --jq '.[0].number' 2>/dev/null || echo "")
           if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then


### PR DESCRIPTION
## Motivation
CD-Staging Promote步骤创建staging→main PR时失败:
```
Resource not accessible by personal access token (createPullRequest)
```

## Fix
将promote-to-production job中的 `CD_PAT` 替换为 `BOT_PAT`（已验证有repo权限）。

EGP Action: R-P1-24-A2
ROADMAP Ref: INFRA