### PR TITLE
fix(ci): skip auto-approve when PR author is bot [V3-2]

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -223,11 +223,33 @@ jobs:
         with:
           github-token: ${{ secrets.BOT_PAT }}
           script: |
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              event: 'APPROVE',
-              body: '✅ AI Code Review passed — all reviewers approved.\n\nAutomated approval by @nickwenniyxiao-bot'
-            });
-            console.log('✅ Bot approval submitted for PR #' + context.payload.pull_request.number);
+            const pr = context.payload.pull_request;
+            const prAuthor = pr.user.login;
+
+            // Skip auto-approval for bot-created PRs to avoid self-review errors.
+            const botUsers = ['nickwenniyxiao-bot', 'github-actions[bot]', 'dependabot[bot]'];
+            const isBot =
+              botUsers.some((bot) => prAuthor.toLowerCase() === bot.toLowerCase()) ||
+              pr.user.type === 'Bot';
+
+            if (isBot) {
+              console.log(
+                `⚠️ PR #${pr.number} was created by bot (${prAuthor}). Skipping auto-approve to avoid self-review error.`
+              );
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: '✅ AI Code Review passed — all reviewers approved.\n\n> Auto-approve skipped because PR was created by a bot account. Manual review still recommended.'
+              });
+            } else {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                event: 'APPROVE',
+                body: '✅ AI Code Review passed — all reviewers approved.\n\nAutomated approval by @nickwenniyxiao-bot'
+              });
+              console.log('✅ Bot approval submitted for PR #' + pr.number);
+            }


### PR DESCRIPTION
Closes #219

### Motivation
- Prevent GitHub self-approval errors by skipping automated `APPROVE` when the pull request author is a bot account or created by the same bot token.

### Description
- Updated `.github/workflows/ai-review.yml` in the `Auto-approve PR via bot` step to detect bot authors using known bot usernames and `pr.user.type === 'Bot'`.
- For bot-authored PRs the workflow now posts a success comment and skips creating an `APPROVE` review, while preserving the existing automated approval behavior for human-authored PRs.

### Testing
- `npx tsc --noEmit` ran and completed successfully.
- `npm run lint` failed due to ESLint configuration requiring `eslint.config.(js|mjs|cjs)` (repository lint config issue, unrelated to workflow change).
- `npm test` could not run because a `test` script is not defined in `package.json`.

EGP Action: R-P1-24-A2
ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b88a4378a88333bb0a5d85a33d8809)