### PR TITLE
fix(ci): expand Check Module Docs trigger paths [V3-7]

### DIFF
--- a/.github/workflows/check-module-docs.yml
+++ b/.github/workflows/check-module-docs.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     paths:
       - "src/modules/**"
+      - "src/api/**"
+      - "src/services/**"
+  workflow_dispatch:
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Closes #7

### Motivation
The Check Module Docs workflow was not running because its PR path filter only watched `src/modules/**`, which missed module changes in other backend locations.

### Description
Updated `.github/workflows/check-module-docs.yml` to expand `pull_request.paths` to include `src/api/**` and `src/services/**` and added `workflow_dispatch`, while leaving the existing module-doc verification logic intact.

### Testing
Verified the workflow file update with `nl -ba .github/workflows/check-module-docs.yml` and validated there are no diff/whitespace issues using `git diff --check HEAD~1 HEAD`, and confirmed repository module directories with `find src -maxdepth 2 -type d`; all checks passed.

EGP Action: R-P1-24-A2

ROADMAP Ref: DOCS

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b88a645c248333af0846a63c097dec)