### PR TITLE
fix(ci): reduce GraphQL pagination to API limit of 100 [V3-3]

### DIFF
--- a/.github/workflows/auto-board-done.yml
+++ b/.github/workflows/auto-board-done.yml
@@ -22,7 +22,7 @@ jobs:
             const query = `query($projectId: ID!) {
               node(id: $projectId) {
                 ... on ProjectV2 {
-                  items(first: 250) {
+                  items(first: 100) {
                     nodes {
                       id
                       content {


### PR DESCRIPTION
Closes #3

### Motivation
- Fix the GitHub Actions workflow failure caused by a GraphQL query using `items(first: 250)` which exceeds the GitHub API `first` limit of 100.

### Description
- Updated `.github/workflows/auto-board-done.yml` to use `items(first: 100)` instead of `items(first: 250)` and left the rest of the query and mutation logic unchanged.

### Testing
- Verified the change with `git diff` and `rg` to confirm `items(first: 100)` is present, created branch `fix/board-status-pagination`, and committed the change successfully.

EGP Action: R-P1-24-A2
ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b88adaa6988333a901fa8b0e3a2f53)