### PR TITLE
fix(ci): expand Doc Gate Check trigger paths [V3-6]

### DIFF
--- a/.github/workflows/doc-gate-check.yml
+++ b/.github/workflows/doc-gate-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - 'src/**'
+      - 'docs/**'
+      - 'DOC-REGISTRY.json'
+      - 'docs/standards/DOC-LIBRARY.json'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/DOC-REGISTRY.json
+++ b/DOC-REGISTRY.json
@@ -1019,12 +1019,13 @@
       "required": false,
       "gate": 2,
       "status": "exists"
-
+    },
+    {
       "id": "DORA-METRICS-DASHBOARD",
-      "path": "docs/DORA-METRICS-DASHBOARD.md",
-      "type": "DORA-METRICS",
-      "status": "active",
-      "version": "1.0.0"
+      "file": "docs/DORA-METRICS-DASHBOARD.md",
+      "required": false,
+      "gate": 3,
+      "status": "exists"
     }
   ]
 }

--- a/docs/CI-HEALTH.md
+++ b/docs/CI-HEALTH.md
@@ -44,7 +44,7 @@
 | semgrep.yml | Semgrep | push/PR | ✅ 应该绿 | 🟢 |
 | doc-format-check.yml | Doc Format Check | PR docs/** | ✅ 应该绿 | 🔴 调查中(S3-1a) |
 | doc-registry-check.yml | Doc Registry Check | PR docs/** | ✅ 应该绿 | 🔴 调查中(S3-1a) |
-| doc-gate-check.yml | Doc Gate Check | PR src/** | ✅ 应该绿 | 🟡 0次触发(正常) |
+| doc-gate-check.yml | Doc Gate Check | PR src/** + docs/** + DOC-REGISTRY.json | ✅ 应该绿 | 🟡 待触发验证(V3-6) |
 | doc-completeness-audit.yml | Doc Completeness | cron weekly | ✅ 应该绿 | 🟢 |
 | dora-metrics.yml | DORA Metrics | cron weekly Mon | ✅ 应该绿 | 🟢 |
 | dependency-audit.yml | Dependency Audit | PR/schedule | ✅ 应该绿 | 🟡 待验证 |


### PR DESCRIPTION
Closes #229

### Motivation
- The Doc Gate Check workflow never ran because it only listened for changes under `src/**` while recent governance work edits `docs/**` and registry files.
- The registry file contained a small JSON formatting issue that prevented the gate script from parsing `DOC-REGISTRY.json` reliably.

### Description
- Expanded `.github/workflows/doc-gate-check.yml` PR triggers to include `docs/**`, `DOC-REGISTRY.json`, and `docs/standards/DOC-LIBRARY.json`, and added `workflow_dispatch` for manual runs.
- Fixed malformed trailing entries in `DOC-REGISTRY.json` (corrected object delimiter and normalized the DORA entry fields) so the workflow can parse the registry.
- Updated `docs/CI-HEALTH.md` to reflect the new trigger scope/status for the Doc Gate Check.
- Left gate logic unchanged; the workflow still collects required docs for `current_gate` and reports warnings in `DOC_GATE_MODE: warning` or fails when set to `blocking`.

### Testing
- Verified `DOC-REGISTRY.json` can be parsed and evaluated with Node showing `current_gate: 2`, `required: 35`, `missing: 0` (pass).
- Ran `npm run lint` and observed only pre-existing warnings and no errors (pass with warnings).
- Ran `npx tsc --noEmit` with no type errors (pass).
- Checked `npm test` is not configured in this repo so automated test script is not available (not applicable).

EGP Action: R-P1-24-A2
ROADMAP Ref: DOCS

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b88ae2e5048333984253f46497fab3)