### PR TITLE
fix(ci): 修复后端 staging promote 合并策略

### DIFF
--- a/.github/workflows/cd-test.yml
+++ b/.github/workflows/cd-test.yml
@@ -177,9 +177,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin staging
           git checkout staging
-          git merge origin/develop --no-edit --ff-only
+          git merge origin/develop --no-edit
           if [ $? -ne 0 ]; then
-            echo "❌ Fast-forward merge failed — staging has diverged from develop."
+            echo "❌ Merge failed — manual conflict resolution needed."
             echo "Please manually resolve the conflict or reset staging."
             exit 1
           fi


### PR DESCRIPTION
## 概要
修复后端 staging promote 合并策略，移除 --ff-only 限制。

### ROADMAP Ref
INFRA

## EGP Action
EGP Action: R-P1-01-A1

## 变更内容
- 移除 cd-staging promote 步骤的 --ff-only 参数
- 允许 merge commit 方式合并到 staging

Closes #489

<!-- compliance-check-trigger: 1773743232 -->