### PR TITLE
fix(ci): check-egp 增加 ROADMAP Ref 豁免逻辑

### DIFF
--- a/.github/workflows/check-execution-protocol.yml
+++ b/.github/workflows/check-execution-protocol.yml
@@ -83,6 +83,41 @@ jobs:
               return;
             }
 
+            // -- 2.5. Check ROADMAP Ref exemption --
+            // If the linked Issue's ROADMAP Ref is an exempt value, EGP Action is not required.
+            // This aligns with check-roadmap-ref which already exempts these values.
+            const exemptRoadmapRefs = ['HOTFIX', 'INFRA', 'DOCS', 'RESEARCH'];
+
+            // Extract linked issue number from PR body
+            const issuePattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const issueMatches = [...prBody.matchAll(issuePattern)];
+
+            if (issueMatches.length > 0) {
+              const issueNumber = parseInt(issueMatches[0][1], 10);
+
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber
+                });
+
+                const issueBody = issue.body || '';
+                const refPattern = /###\s*ROADMAP Ref\s*\n+\s*(.+)/i;
+                const refMatch = issueBody.match(refPattern);
+
+                if (refMatch) {
+                  const ref = refMatch[1].trim().toUpperCase();
+                  if (exemptRoadmapRefs.includes(ref)) {
+                    console.log(`✅ Skipping EGP Action check: Issue #${issueNumber} ROADMAP Ref is "${ref}" (exempt category)`);
+                    return;
+                  }
+                }
+              } catch (e) {
+                console.log(`⚠️ Could not fetch Issue #${issueNumber}: ${e.message}. Proceeding with EGP check.`);
+              }
+            }
+
             // -- 3. Extract EGP Action reference from PR body --
             // Format: "EGP Action: R-Px-xx-Ay" (one or more)
             const actionPattern = /EGP Action:\s*(R-P\d+-\d+-A\d+)/gi;


### PR DESCRIPTION
Closes #544

### Motivation
- The `check-execution-protocol` workflow required an `EGP Action` in every PR body which incorrectly blocked PRs whose linked Issue has an exempt `ROADMAP Ref` such as `INFRA`/`HOTFIX`/`DOCS`/`RESEARCH`.
- Make the `check-egp` behavior consistent with `check-roadmap-ref` by allowing these exempt roadmap categories to skip the EGP Action requirement.

### Description
- Inserted a ROADMAP Ref exemption step in `.github/workflows/check-execution-protocol.yml` that parses the linked issue number from the PR body, fetches the Issue via `github.rest.issues.get`, extracts the `### ROADMAP Ref` line, and returns early when the ref is one of `['HOTFIX','INFRA','DOCS','RESEARCH']`.
- Kept existing label-based skips (`egp-bootstrap`, `no-issue`, `hotfix`) and preserved the fallback to normal EGP validation when the Issue cannot be fetched.

### Testing
- Verified the diff for ` .github/workflows/check-execution-protocol.yml` to confirm the exemption block was added and reviewed the inserted lines.
- Ran a Node snippet that simulates a PR body `Closes #508` and an Issue body containing `### ROADMAP Ref\nINFRA`, which produced the expected skip log `Skipping EGP Action check: Issue #508 ROADMAP Ref is "INFRA" (exempt category)` and succeeded.
- Committed the change to branch `codex/544-check-egp-roadmap-exempt` and created the PR metadata with title `fix(ci): check-egp 增加 ROADMAP Ref 豁免逻辑`, with automated checks to be run by CI.

### ROADMAP Ref

INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b9f3e086848322a0a1dd1e8419cfcc)