### PR TITLE
fix(cd): fix Log deployment event branch target and add continue-on-error #549

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -141,6 +141,7 @@ jobs:
 
       - name: Log deployment event
         if: success()
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.BOT_PAT }}
@@ -167,7 +168,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 path: 'docs/DEPLOY-LOG.md',
-                ref: 'develop'
+                ref: 'main'
               });
               content = Buffer.from(file.data.content, 'base64').toString('utf8');
               fileSha = file.data.sha;
@@ -191,7 +192,7 @@ jobs:
               path: 'docs/DEPLOY-LOG.md',
               message: 'docs: log production deployment [skip ci]',
               content: Buffer.from(content).toString('base64'),
-              branch: 'develop',
+              branch: 'main',
               ...(fileSha ? { sha: fileSha } : {})
             });
 

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -163,6 +163,7 @@ jobs:
 
       - name: Log deployment event
         if: success()
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.BOT_PAT }}
@@ -189,7 +190,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 path: 'docs/DEPLOY-LOG.md',
-                ref: 'develop'
+                ref: 'staging'
               });
               content = Buffer.from(file.data.content, 'base64').toString('utf8');
               fileSha = file.data.sha;
@@ -213,7 +214,7 @@ jobs:
               path: 'docs/DEPLOY-LOG.md',
               message: 'docs: log staging deployment [skip ci]',
               content: Buffer.from(content).toString('base64'),
-              branch: 'develop',
+              branch: 'staging',
               ...(fileSha ? { sha: fileSha } : {})
             });
 

--- a/DOC-REGISTRY.json
+++ b/DOC-REGISTRY.json
@@ -1183,6 +1183,122 @@
       "description": "自动化创建和配置 Upptime 监控仓库"
     },
     {
+      "id": "DB-SYNC-SANITIZE",
+      "title": "数据库同步脱敏",
+      "status": "active",
+      "path": "docs/operations/db-sync-sanitize.md",
+      "type": "runbook",
+      "category": "07-operations"
+    },
+    {
+      "id": "DEPENDABOT-CI-EXEMPT",
+      "title": "Dependabot CI 豁免配置",
+      "path": ".github/workflows/pr-compliance.yml",
+      "type": "config",
+      "module": "INFRA",
+      "status": "active",
+      "description": "Dependabot PR 自动跳过 branch-naming/commitlint/roadmap-ref/ai-review 检查"
+    },
+    {
+      "id": "AUTO-BOARD-DONE-FIX",
+      "title": "Project Board 自动更新修复",
+      "path": ".github/workflows/auto-board-done.yml",
+      "type": "workflow",
+      "module": "INFRA",
+      "status": "active",
+      "description": "修复 Issue 关闭时自动更新 Board 状态的权限问题"
+    },
+    {
+      "id": "NIGHTLY-BUILD-FIX",
+      "title": "Nightly Build ESLint 修复",
+      "path": ".github/workflows/nightly.yml",
+      "type": "workflow",
+      "module": "INFRA",
+      "status": "active",
+      "description": "修复 Nightly ESLint 命令与 CI 对齐"
+    },
+    {
+      "id": "UNIT-TEST-COVERAGE-GATE",
+      "title": "后端单元测试覆盖率门禁",
+      "path": "jest.config.ts",
+      "type": "config",
+      "module": "INFRA",
+      "status": "active",
+      "description": "Jest 单元测试覆盖率门禁配置（阈值 30%）"
+    },
+    {
+      "id": "INCIDENT-RESPONSE-PROCESS",
+      "title": "事件响应流程",
+      "path": "docs/ops/INCIDENT-RESPONSE.md",
+      "type": "document",
+      "module": "INFRA",
+      "status": "active",
+      "description": "生产事件响应流程、严重等级定义和角色分工"
+    },
+    {
+      "id": "DORA-REPORT-TEMPLATE",
+      "title": "DORA 度量周报模板",
+      "path": ".github/ISSUE_TEMPLATE/dora-report.yml",
+      "type": "template",
+      "module": "INFRA",
+      "status": "active",
+      "description": "DORA 度量周报 Issue 模板和自动创建工作流"
+    },
+    {
+      "id": "DEVEX-SURVEY-TEMPLATE",
+      "title": "开发者体验调查模板",
+      "path": ".github/ISSUE_TEMPLATE/devex-survey.yml",
+      "type": "template",
+      "module": "INFRA",
+      "status": "active",
+      "description": "月度开发者体验调查模板和自动创建工作流"
+    },
+    {
+      "id": "OPS-ALIGNMENT",
+      "title": "Ops 工作流对齐矩阵",
+      "path": "docs/ops/OPS-ALIGNMENT.md",
+      "type": "document",
+      "module": "INFRA",
+      "status": "active",
+      "description": "Ops 工作流与 Runbook 的对齐关系和改进计划"
+    },
+    {
+      "id": "DEPLOYMENT-EVENT-LOG",
+      "title": "部署事件日志",
+      "path": "docs/ops/DEPLOYMENT-LOG.md",
+      "type": "document",
+      "module": "INFRA",
+      "status": "active",
+      "description": "自动记录每次部署的时间、版本、状态和触发者"
+    },
+    {
+      "id": "ACTIONLINT-COMPLETE",
+      "title": "Actionlint 工作流检查完成",
+      "path": ".github/workflows/actionlint.yml",
+      "type": "workflow",
+      "module": "INFRA",
+      "status": "active",
+      "description": "GitHub Actions 工作流语法检查"
+    },
+    {
+      "id": "LOG-CENTRALIZATION",
+      "title": "日志集中化部署模板",
+      "path": "docs/ops/LOG-CENTRALIZATION.md",
+      "type": "document",
+      "module": "INFRA",
+      "status": "active",
+      "description": "Loki + Grafana 日志集中化方案和 Docker Compose 模板"
+    },
+    {
+      "id": "ROADMAP-REGISTRY-SYNC",
+      "title": "ROADMAP 与 TASK-REGISTRY 状态同步",
+      "path": "docs/ROADMAP.md",
+      "type": "document",
+      "module": "INFRA",
+      "status": "active",
+      "description": "批量更新 Phase 1/2 已完成任务的状态标记"
+    },
+    {
       "id": "CD-STAGING-WORKFLOW",
       "file": ".github/workflows/cd-staging.yml",
       "required": true,

--- a/DOC-REGISTRY.json
+++ b/DOC-REGISTRY.json
@@ -1181,6 +1181,20 @@
       "module": "INFRA",
       "status": "active",
       "description": "自动化创建和配置 Upptime 监控仓库"
+    },
+    {
+      "id": "CD-STAGING-WORKFLOW",
+      "file": ".github/workflows/cd-staging.yml",
+      "required": true,
+      "gate": 1,
+      "status": "exists"
+    },
+    {
+      "id": "CD-PRODUCTION-WORKFLOW",
+      "file": ".github/workflows/cd-production.yml",
+      "required": true,
+      "gate": 1,
+      "status": "exists"
     }
   ]
 }

--- a/docs/TASK-REGISTRY.json
+++ b/docs/TASK-REGISTRY.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schemas/task-registry.schema.json",
   "version": "1.1.0",
-  "last_updated": "2026-03-18",
+  "last_updated": "2026-03-17",
   "projects": [
     {
       "phase": "Phase 0",

--- a/docs/TASK-REGISTRY.json
+++ b/docs/TASK-REGISTRY.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schemas/task-registry.schema.json",
   "version": "1.1.0",
-  "last_updated": "2026-03-17",
+  "last_updated": "2026-03-18",
   "projects": [
     {
       "phase": "Phase 0",
@@ -229,6 +229,22 @@
               "issue": null,
               "completed_at": "2026-03-13T12:00:00Z",
               "notes": "延后，历史代码 any 类型太多（ADR-006）"
+            }
+          ]
+        },
+        {
+          "id": "R-P0-CD-LOG-FIX",
+          "name": "CD Pipeline deploy-log continue-on-error 修复",
+          "status": "done",
+          "actions": [
+            {
+              "id": "R-P0-CD-LOG-FIX-A1",
+              "name": "cd-staging.yml 和 cd-production.yml 添加 continue-on-error",
+              "status": "done",
+              "pr": null,
+              "issue": "#549",
+              "completed_at": null,
+              "notes": "Log deployment event 步骤添加 continue-on-error: true 避免阻塞部署流程"
             }
           ]
         }


### PR DESCRIPTION
Closes #549

### Motivation
- The CD "Log deployment event" step was writing to the protected `develop` branch and failing under branch protection, which caused the deploy job to fail and blocked downstream E2E / smoke / promote stages.

### Description
- Add `continue-on-error: true` to the `Log deployment event` step in both `.github/workflows/cd-staging.yml` and `.github/workflows/cd-production.yml` so the logging step cannot block the job.
- Update the GitHub Contents API targets so staging workflow reads/writes `docs/DEPLOY-LOG.md` on `staging` and production workflow reads/writes on `main` (replace `ref: 'develop'` / `branch: 'develop'`).
- Register both workflow files in `DOC-REGISTRY.json` and add the fix record to `docs/TASK-REGISTRY.json` (update `last_updated`).

### Testing
- Parsed `DOC-REGISTRY.json` and `docs/TASK-REGISTRY.json` with `python -m json.tool` to validate JSON (success).
- Searched workflows with `rg` to confirm `continue-on-error` and updated `ref`/`branch` entries are present (success).
- Ran `npm run lint`; lint completed with pre-existing warnings and no new errors (success).

ROADMAP Ref: INFRA
EGP Action: R-P0-CD-LOG-FIX-A1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ba20eb392c83229dbbf318a1567d0e)
<!-- CI trigger -->