### PR TITLE
chore(egp): backfill hotfix bypass record for PR #474

### DIFF
--- a/docs/TASK-REGISTRY.json
+++ b/docs/TASK-REGISTRY.json
@@ -233,12 +233,12 @@
           ]
         },
         {
-          "id": "HOTFIX-001",
+          "id": "R-P0-15",
           "name": "AI Review 自动批准恢复",
           "status": "done",
           "actions": [
             {
-              "id": "HOTFIX-001-A1",
+              "id": "R-P0-15-A1",
               "name": "恢复 ai-review.yml Auto-approve 步骤",
               "status": "done",
               "pr": "#474",

--- a/docs/TASK-REGISTRY.json
+++ b/docs/TASK-REGISTRY.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schemas/task-registry.schema.json",
   "version": "1.1.0",
-  "last_updated": "2026-03-17",
+  "last_updated": "2026-03-17T23:00:00Z",
   "projects": [
     {
       "phase": "Phase 0",
@@ -229,6 +229,22 @@
               "issue": null,
               "completed_at": "2026-03-13T12:00:00Z",
               "notes": "延后，历史代码 any 类型太多（ADR-006）"
+            }
+          ]
+        },
+        {
+          "id": "HOTFIX-001",
+          "name": "AI Review 自动批准恢复",
+          "status": "done",
+          "actions": [
+            {
+              "id": "HOTFIX-001-A1",
+              "name": "恢复 ai-review.yml Auto-approve 步骤",
+              "status": "done",
+              "pr": "#474",
+              "issue": "#475",
+              "completed_at": "2026-03-17T09:09:32Z",
+              "notes": "hotfix bypass — PR #442 误删 Auto-approve 导致所有 PR auto-merge 阻塞，紧急以 hotfix label bypass EGP 合并；EGP 补录见 Issue #476"
             }
           ]
         }


### PR DESCRIPTION
Closes #476

ROADMAP Ref: HOTFIX
EGP Action ID: R-P0-15-A1

## Summary

- PR #474 merged 2026-03-17T09:09:32Z via \`hotfix\` label bypass, skipping EGP execution protocol
- EGP spec requires backfill within 24h — deadline: 2026-03-18T09:09:32Z
- Adds \`R-P0-15\` / \`R-P0-15-A1\` to \`docs/TASK-REGISTRY.json\` with \`status: done\` and bypass notes

## Changes

- \`docs/TASK-REGISTRY.json\`: add R-P0-15 task entry under Phase 0; update \`last_updated\`; fix Action ID format to R-Px-xx-Ay

## Backfill Checklist

- [x] Action entry added (\`R-P0-15-A1\`) with \`status: done\`
- [x] \`notes\` field explains hotfix bypass reason
- [x] \`pr: "#474"\`, \`issue: "#475"\` referenced
- [x] \`completed_at\` matches merge time
- [x] ID format conforms to \`R-Px-xx-Ay\` spec