### PR TITLE
fix(ci): handle duplicate sub-issue error in sync-registry-to-issues

### DIFF
--- a/scripts/sync-registry.js
+++ b/scripts/sync-registry.js
@@ -170,8 +170,13 @@ const ensureSubIssueLink = async (parentNodeId, subIssueNodeId, actionId) => {
     console.log(`  [link] Linked ${actionId} as sub-issue`)
   } catch (error) {
     const message = String(error?.message || error)
-    if (message.includes("already exists") || message.includes("already a sub-issue")) {
-      console.log(`  [link] ${actionId} already linked`)
+    if (
+      message.includes("already exists") ||
+      message.includes("already a sub-issue") ||
+      message.includes("duplicate sub-issues") ||
+      message.includes("only have one parent")
+    ) {
+      console.log(`  [link] ${actionId} already linked (skipped duplicate)`)
       return
     }
 


### PR DESCRIPTION
Closes #555

ROADMAP Ref: INFRA
EGP Action: INFRA

## Summary

- GitHub's `addSubIssue` mutation returns `"duplicate sub-issues"` / `"only have one parent"` when a sub-issue is already linked
- `ensureSubIssueLink` only caught `"already exists"` / `"already a sub-issue"` — mismatch caused fatal crash
- Also switches `sync-registry-to-issues.yml` to use `CTO_PAT` (has `project` scope) instead of `BOT_PAT`

## Changes

- `scripts/sync-registry.js`: add missing error patterns to catch block
- `.github/workflows/sync-registry-to-issues.yml`: use `CTO_PAT` instead of `BOT_PAT`