### PR TITLE
fix(ci): resolve ESLint warnings to fix Nightly Build

### DIFF
--- a/src/api/admin/inventory/report/route.ts
+++ b/src/api/admin/inventory/report/route.ts
@@ -67,7 +67,7 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
         COALESCE(SUM(
           ibi.total_stock * COALESCE(
             CASE
-              WHEN (ii.metadata->>'unit_cost') ~ '^-?[0-9]+(\.[0-9]+)?$' THEN (ii.metadata->>'unit_cost')::numeric
+              WHEN (ii.metadata->>'unit_cost') ~ '^-?[0-9]+(\\.[0-9]+)?$' THEN (ii.metadata->>'unit_cost')::numeric
               ELSE NULL
             END,
             0

--- a/src/api/admin/products/batch/route.ts
+++ b/src/api/admin/products/batch/route.ts
@@ -14,10 +14,6 @@ type ProductBatchBody = {
   };
 };
 
-type ProductModuleServiceLike = {
-  updateProducts?: (payload: Array<Record<string, unknown>>) => Promise<unknown>;
-  retrieveProduct?: (id: string, config?: Record<string, unknown>) => Promise<unknown>;
-};
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {

--- a/src/api/admin/products/import/route.ts
+++ b/src/api/admin/products/import/route.ts
@@ -1,14 +1,6 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
 import { Modules } from "@medusajs/framework/utils";
 
-type ProductModuleServiceLike = {
-  createProducts?: (payload: Array<Record<string, unknown>>) => Promise<unknown>;
-  updateProducts?: (payload: Array<Record<string, unknown>>) => Promise<unknown>;
-  listProducts?: (
-    filters?: Record<string, unknown>,
-    config?: Record<string, unknown>,
-  ) => Promise<unknown[]>;
-};
 
 type CsvRow = {
   id?: string;

--- a/src/jobs/low-stock-alert.ts
+++ b/src/jobs/low-stock-alert.ts
@@ -53,6 +53,7 @@ export default async function lowStockAlertJob(container: MedusaContainer) {
     let offset = 0;
     const limit = 100;
 
+    // eslint-disable-next-line no-constant-condition
     while (true) {
       const [items] = await inventoryService.listAndCountInventoryItems(
         {},

--- a/src/modules/resend-notification/service.ts
+++ b/src/modules/resend-notification/service.ts
@@ -257,8 +257,6 @@ class ResendNotificationProviderService extends AbstractNotificationProviderServ
 
   private returnRequestedHtml(data: Record<string, any>): string {
     const order = data.order || {};
-    const returnId = data.returnId || "";
-
     return `<!DOCTYPE html>
 <html>
 <head><meta charset="utf-8"></head>
@@ -467,7 +465,6 @@ class ResendNotificationProviderService extends AbstractNotificationProviderServ
 
   private abandonedCartHtml(data: Record<string, any>): string {
     const items = (data.items || []) as any[];
-    const cartId = data.cartId || "";
     const itemList = items
       .map(
         (item: any) =>

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -1,6 +1,6 @@
 import { ExecArgs } from "@medusajs/framework/types";
 
-export default async function seed({ container }: ExecArgs) {
+export default async function seed(_args: ExecArgs) {
   console.log("🌱 NordHjem 种子数据开始导入...");
   // TODO: Week 2 — 从 products-data.js 导入 504 个商品
   console.log("✅ NordHjem 种子数据导入完成");

--- a/src/subscribers/order-shipment.ts
+++ b/src/subscribers/order-shipment.ts
@@ -72,7 +72,7 @@ export default async function orderShipmentHandler({
             text: `\ud83d\udce6 \u53d1\u8d27\u901a\u77e5\u5df2\u53d1\u9001\nOrder #${order.display_id}\nTracking: ${trackingNumber}\nEmail: ${order.email}`,
           }),
         });
-      } catch (e) {
+      } catch {
         // Non-critical
       }
     }

--- a/src/workflows/send-restock-notifications/steps/get-restocked.ts
+++ b/src/workflows/send-restock-notifications/steps/get-restocked.ts
@@ -1,5 +1,4 @@
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk";
-import { Modules } from "@medusajs/framework/utils";
 
 import { DistinctSubscription } from "./get-distinct-subscriptions";
 


### PR DESCRIPTION
Closes #456

ROADMAP Ref: INFRA
EGP Action: INFRA

## 背景

Nightly Build 因 ESLint `--max-warnings 0` 配置每日失败，共 9 个 warnings 分布在 8 个文件中。

## 修复内容

- `inventory/report/route.ts`: 修复 SQL 字符串中不必要的转义字符 `\.` → `\\.`
- `products/batch/route.ts`: 删除未使用的 `ProductModuleServiceLike` 类型定义
- `products/import/route.ts`: 删除未使用的 `ProductModuleServiceLike` 类型定义
- `low-stock-alert.ts`: 添加 `eslint-disable` 注释（`while(true)` 是有意为之的分页逻辑）
- `resend-notification/service.ts`: 删除未使用的 `returnId` 和 `cartId` 变量
- `seed.ts`: 将未使用的 `container` 参数改为 `_args`
- `order-shipment.ts`: 将 `catch (e)` 改为 `catch`（可选 catch binding）
- `get-restocked.ts`: 删除未使用的 `Modules` import

本地验证：`eslint 'src/**/*.ts' --max-warnings 0` 零 warnings，零 errors。