### PR TITLE
fix(ci): add Dependabot CI exemption and fix log deployment branch

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -168,7 +168,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 path: 'docs/DEPLOY-LOG.md',
-                ref: 'main'
+                ref: 'staging'
               });
               content = Buffer.from(file.data.content, 'base64').toString('utf8');
               fileSha = file.data.sha;
@@ -192,7 +192,7 @@ jobs:
               path: 'docs/DEPLOY-LOG.md',
               message: 'docs: log production deployment [skip ci]',
               content: Buffer.from(content).toString('base64'),
-              branch: 'main',
+              branch: 'staging',
               ...(fileSha ? { sha: fileSha } : {})
             });
 

--- a/.github/workflows/check-execution-protocol.yml
+++ b/.github/workflows/check-execution-protocol.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   check-egp:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/check-issue-approved.yml
+++ b/.github/workflows/check-issue-approved.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   check-issue-approved:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/check-issue-labels.yml
+++ b/.github/workflows/check-issue-labels.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   check-issue-labels:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   check-linked-issue:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/check-module-docs.yml
+++ b/.github/workflows/check-module-docs.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   check-module-docs:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/check-project-board.yml
+++ b/.github/workflows/check-project-board.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   check-project-board:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check project board membership and fields


### PR DESCRIPTION
Closes #540

ROADMAP Ref: INFRA
EGP Action: INFRA

## Summary

- Add `if: github.actor != 'dependabot[bot]'` to all governance check jobs (check-egp, check-linked-issue, check-project-board, check-issue-approved, check-module-docs, check-issue-labels) so Dependabot dependency-upgrade PRs skip governance checks
- Fix `cd-production.yml` Log deployment event to write to `staging` branch instead of `main` (main requires PRs; staging is writable)

Also closes #544 (check-egp ROADMAP Ref exemption already implemented in code).