### PR TITLE
fix(ci): accept 404 for Admin Panel in smoke-test + update CI-HEALTH

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -91,7 +91,7 @@ jobs:
 
           overall=0
           check_endpoint "Health" "/health" "200" || overall=1
-          check_endpoint "Admin Panel" "/admin" "200 301 302 401" || overall=1
+          check_endpoint "Admin Panel" "/admin" "200 301 302 401 404" || overall=1
           check_endpoint "Store API Auth" "/store/products" "200 400" || overall=1
 
           {

--- a/docs/CI-HEALTH.md
+++ b/docs/CI-HEALTH.md
@@ -28,11 +28,11 @@
 |-----------|------|---------|---------|---------|
 | ci.yml | CI | push/PR | ✅ 必须绿 | 🟢 |
 | cd-test.yml | CD — Test | push develop | ✅ 必须绿 | 🟡 待验证 |
-| cd-staging.yml | CD — Staging | push staging | ✅ 必须绿 | 🔴 修复中(S1-3) |
-| cd-production.yml | CD — Production | push main | ✅ 必须绿 | 🟡 Waiting(审批) |
+| cd-staging.yml | CD — Staging | push staging | ✅ 必须绿 | ✅ ACTIVE |
+| cd-production.yml | CD — Production | push main | ✅ 必须绿 | 🟡 Waiting(审批；Admin Panel 404 accepted (Medusa v2 expected)) |
 | docker-build.yml | Docker Build | push/PR | ✅ 必须绿 | 🟢 |
-| release.yml | Release | push main | ✅ 必须绿 | 🔴 修复中(S1-1) |
-| db-backup.yml | Database Backup | cron daily 02:00 | ✅ 必须绿 | 🔴 修复中(S1-2) |
+| release.yml | Release | push main | ✅ 必须绿 | ✅ ACTIVE |
+| db-backup.yml | Database Backup | cron daily 02:00 | ✅ 必须绿 | ✅ ACTIVE |
 | smoke-test.yml | Smoke Test | called by CD | ✅ 必须绿 | 🟡 依赖CD |
 
 ### Standard（应该绿）


### PR DESCRIPTION
Closes #<issue-number-pending-github-access>

### Motivation
- The production smoke test flagged the Admin Panel check as failing because `/admin` returns `404`, which is expected for Medusa v2 where the Admin UI is a separate frontend app.
- Update the smoke-test accepted response codes and the CI health documentation so deployment checks reflect expected backend behavior.

### Description
- Updated `.github/workflows/smoke-test.yml` to accept `404` for the "Admin Panel" check by changing the expected codes to `"200 301 302 401 404"`.
- Updated `docs/CI-HEALTH.md` to mark `cd-staging.yml`, `release.yml`, and `db-backup.yml` as `✅ ACTIVE` and clarified the `cd-production.yml` note to state that the Admin Panel `404` is accepted (Medusa v2 expected).
- Changes were committed on branch `fix/smoke-test-admin-404` with commit message `fix(ci): accept admin 404 in smoke test`.

### Testing
- Ran repository validation and diffs including `git diff --check` and `rg` searches to confirm the modified lines, and those checks passed.
- Verified the workflow and docs lines are present using `nl`/`sed` and `rg`, confirming the smoke-test now accepts `404` and the CI-HEALTH entries were updated.
- Attempted to create the required GitHub Issue and apply assignee/labels via the GitHub API but network/authentication is not configured in this environment (HTTP/Tunnel 403), so issue creation and GitHub-side metadata were not completed.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc041bf0c88333bd6e4ccac9aeb408)