### PR TITLE
fix(stripe): update apiVersion to match SDK v20.4.1

### DIFF
--- a/src/api/store/stripe-events/route.ts
+++ b/src/api/store/stripe-events/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     const rawBody = typeof req.body === "string" ? req.body : JSON.stringify(req.body);
 
     const stripe = new Stripe(process.env.STRIPE_API_KEY || "", {
-      apiVersion: "2025-02-24.acacia",
+      apiVersion: "2026-02-25.clover",
     });
 
     const event = stripe.webhooks.constructEvent(rawBody, signature, webhookSecret);


### PR DESCRIPTION
Closes #640

### Motivation
- Align the Stripe webhook client's `apiVersion` with the installed Stripe SDK v20.4.1 to resolve CI type mismatches that caused signature/type errors.

### Description
- Update `apiVersion` in `src/api/store/stripe-events/route.ts` from `"2025-02-24.acacia"` to `"2026-02-25.clover"` so the route matches Stripe SDK v20.4.1.

### Testing
- Ran `npx tsc --noEmit`, which could not complete in this environment because the local `node_modules` contained `stripe@17.7.0` (stale vs `package.json`) and `npm ci` failed with `403 Forbidden` before dependencies could be refreshed, so TypeScript checks are currently blocked; the file change itself was committed on branch `codex/640-fix-stripe-api-version`.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc3ae02e648333960a7b299023ce9a)