### PR TITLE
fix(feature-flags): address PR #621 review blockers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@medusajs/medusa": "2.13.1",
         "@mikro-orm/postgresql": "6.4.16",
         "@sentry/node": "^10.44.0",
-        "posthog-node": "^5.28.4",
         "resend": "^6.9.3",
         "stripe": "^20.4.1"
       },
@@ -9129,15 +9128,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
-      }
-    },
-    "node_modules/@posthog/core": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.24.0.tgz",
-      "integrity": "sha512-Wkp9mgNfgdf6+G4C1VMKakm2RXKQFf4bb5/CPQRAjpqv9l6BY36zZrD1+X5Y2XIAzZqbMKRxsDu3V1r6uKu7/A==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.6"
       }
     },
     "node_modules/@prisma/instrumentation": {
@@ -23179,26 +23169,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/posthog-node": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.28.4.tgz",
-      "integrity": "sha512-j8JBDNuSwUWR0TBZNuCwNRHQ+OReVz1UwDYMDol+iqFTbYrIKZnyC05oyGtSBRGntrYBiaIWFbH9N3kZuxfVdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@posthog/core": "1.24.0"
-      },
-      "engines": {
-        "node": "^20.20.0 || >=22.22.0"
-      },
-      "peerDependencies": {
-        "rxjs": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rxjs": {
-          "optional": true
-        }
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@medusajs/medusa": "2.13.1",
     "@mikro-orm/postgresql": "6.4.16",
     "@sentry/node": "^10.44.0",
-    "posthog-node": "^5.28.4",
     "resend": "^6.9.3",
     "stripe": "^20.4.1"
   },
@@ -63,8 +62,7 @@
     "@mikro-orm/knex": "6.4.16",
     "@mikro-orm/migrations": "6.4.16",
     "@mikro-orm/postgresql": "6.4.16",
-    "@mikro-orm/cli": "6.4.16",
-    "@posthog/core": "1.24.0"
+    "@mikro-orm/cli": "6.4.16"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -191,6 +191,11 @@ export default defineMiddlewares({
       middlewares: [authenticate("user", ["bearer", "session"])],
     },
     {
+      matcher: "/admin/feature-flags",
+      method: "GET",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+    {
       matcher: "/admin/finance/*",
       method: "GET",
       middlewares: [authenticate("user", ["bearer", "session"])],


### PR DESCRIPTION
Closes #621

### Motivation
- Apply the fixes from PR #667 onto the existing `feat/e2e-playwright-feature-flags` branch so PR #621 can be updated without opening a new PR and to resolve governance gate failures.

### Description
- Removed the runtime dependency `posthog-node` from `package.json` to eliminate the unwanted instrumentation package.
- Removed the `@posthog/core` override and purged the corresponding `posthog-node`/`@posthog/core` entries from `package-lock.json`.
- Added admin authentication middleware for `GET /admin/feature-flags` in `src/api/middlewares.ts` to protect the endpoint.
- Applied and committed these changes on the `feat/e2e-playwright-feature-flags` branch locally for PR #621; remote push and PR closure require repository remote/CLI access.

### Testing
- Ran `npx tsc --noEmit` which failed due to pre-existing TypeScript issues unrelated to this change (`src/api/store/stripe-events/route.ts` API version literal mismatch and missing `@sentry/node` types). 
- Ran `npm run lint` which completed successfully. 
- Ran `npm test` where all test suites passed (`9` suites, `18` tests total).

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc6dd0eebc8333b8a47c32a432f97e)