### PR TITLE
fix(ci): exempt type:infra and type:docs from approved label check

### DIFF
--- a/.github/workflows/check-issue-approved.yml
+++ b/.github/workflows/check-issue-approved.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Check linked issue has 'approved' label
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const prBody = context.payload.pull_request.body || '';
@@ -41,6 +41,12 @@ jobs:
                 issue_number: issueNumber
               });
               const issueLabels = issue.data.labels.map(l => l.name);
+              const exemptLabels = ['type: infra', 'type: docs'];
+              const hasExemption = exemptLabels.some(l => issueLabels.includes(l));
+              if (hasExemption) {
+                console.log(`Issue #${issueNumber} has exempt label (${exemptLabels.filter(l => issueLabels.includes(l)).join(', ')}), skipping approved check`);
+                continue;
+              }
               if (!issueLabels.includes('approved')) {
                 core.setFailed(`Issue #${issueNumber} does not have approved label. Ask Owner to add it first.`);
                 return;


### PR DESCRIPTION
## Summary

- Add exemption for `type: infra` and `type: docs` labeled Issues in `check-issue-approved` workflow
- Issues with these labels skip the `approved` label requirement
- Downgrade `actions/github-script` from v8 to v7 for project-wide consistency

## Changes

**`.github/workflows/check-issue-approved.yml`:**
- After fetching issue labels, check if issue has `type: infra` or `type: docs` — if so, `continue` (skip approved check for that issue)
- Change `actions/github-script@v8` to `@v7`

## Impact

- infra/docs PRs no longer need `--admin` bypass for the approved label gate
- Feature/bug PRs still require `approved` label on linked Issues

## Test plan

- [ ] CI passes on this PR
- [ ] Cross-review by backend-lead

Closes #684

ROADMAP Ref: INFRA