### PR TITLE
fix(security): use raw body buffer for Stripe webhook signature

### DIFF
--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -37,6 +37,11 @@ export default defineMiddlewares({
       middlewares: [stripeWebhookAuditMiddleware],
     },
     {
+      matcher: "/store/stripe-events",
+      method: "POST",
+      bodyParser: false,
+    },
+    {
       matcher: "/store/restock-subscriptions",
       method: "POST",
       middlewares: [

--- a/src/api/store/stripe-events/route.ts
+++ b/src/api/store/stripe-events/route.ts
@@ -20,7 +20,11 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
   }
 
   try {
-    const rawBody = typeof req.body === "string" ? req.body : JSON.stringify(req.body);
+    const rawBody = Buffer.isBuffer(req.body)
+      ? req.body.toString("utf-8")
+      : typeof req.body === "string"
+        ? req.body
+        : JSON.stringify(req.body);
 
     const stripe = new Stripe(process.env.STRIPE_API_KEY || "", {
       apiVersion: "2026-02-25.clover",


### PR DESCRIPTION
## Summary
- Disable body parsing for `/store/stripe-events` route via `bodyParser: false` in middlewares.ts
- Use `Buffer.isBuffer()` check to preserve original raw bytes for Stripe signature verification
- Previous `JSON.stringify(req.body)` fallback produced different bytes than original request, breaking or bypassing signature verification

## Changes
- `src/api/middlewares.ts`: Add `bodyParser: false` for `/store/stripe-events` POST route
- `src/api/store/stripe-events/route.ts`: Replace `JSON.stringify` fallback with Buffer-aware raw body extraction

## Test plan
- [ ] Deploy to staging and send test Stripe webhook event
- [ ] Verify signature verification passes with valid webhook
- [ ] Verify invalid signatures are correctly rejected
- [ ] `npx tsc --noEmit` passes (no new errors)

Closes #698
ROADMAP Ref: INFRA

Generated with [Claude Code](https://claude.com/claude-code)