### PR TITLE
fix(security): cookie secure flag + remove supersecret fallbacks

### DIFF
--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -1,20 +1,29 @@
 import { loadEnv, defineConfig } from "@medusajs/framework/utils"
 loadEnv(process.env.NODE_ENV || "production", process.cwd())
+
+if (process.env.NODE_ENV === "production") {
+  const required = ["JWT_SECRET", "COOKIE_SECRET", "DATABASE_URL"] as const
+  for (const key of required) {
+    if (!process.env[key]) {
+      throw new Error(`Missing required env var: ${key}`)
+    }
+  }
+}
 module.exports = defineConfig({
   projectConfig: {
     databaseUrl: process.env.DATABASE_URL,
     databaseDriverOptions: { ssl: false },
     redisUrl: process.env.REDIS_URL,
     cookieOptions: {
-      secure: false,
+      secure: process.env.NODE_ENV === "production",
       sameSite: "lax" as const,
     },
     http: {
       storeCors: process.env.STORE_CORS!,
       adminCors: process.env.ADMIN_CORS!,
       authCors: process.env.AUTH_CORS!,
-      jwtSecret: process.env.JWT_SECRET || "supersecret",
-      cookieSecret: process.env.COOKIE_SECRET || "supersecret",
+      jwtSecret: process.env.JWT_SECRET!,
+      cookieSecret: process.env.COOKIE_SECRET!,
     },
   },
   admin: {


### PR DESCRIPTION
## Summary
- Set `cookieOptions.secure` to `true` in production (was hardcoded `false`)
- Remove `"supersecret"` fallback from `jwtSecret` and `cookieSecret` in medusa-config.ts
- Add production startup guard: fail-fast if `JWT_SECRET`, `COOKIE_SECRET`, or `DATABASE_URL` are missing

## Changes
- `medusa-config.ts`: Environment-aware cookie secure flag, non-null assertion for secrets, startup validation

## Risk
- **Dev environments**: No impact — `NODE_ENV` defaults to non-production, secrets are optional in dev
- **Production**: Will fail to start if env vars are missing (this is the intended behavior — fail loud, not fail insecure)
- `docker-compose.yml` still has dev fallbacks (`${JWT_SECRET:-supersecret}`) which is appropriate for local dev

## Test plan
- [ ] `npx tsc --noEmit` passes (no new errors)
- [ ] Local dev server starts without JWT_SECRET set (NODE_ENV != production)
- [ ] Production build fails to start without required env vars

Closes #698
ROADMAP Ref: INFRA

Generated with [Claude Code](https://claude.com/claude-code)