### PR TITLE
feat(infra): register Redis modules for event-bus, workflow, cache, locking

### DIFF
--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -41,7 +41,7 @@ module.exports = defineConfig({
           {
             resolve: "@medusajs/medusa/workflow-engine-redis",
             options: {
-              redis: { url: process.env.REDIS_URL },
+              redis: { redisUrl: process.env.REDIS_URL },
             },
           },
           {

--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -30,6 +30,43 @@ module.exports = defineConfig({
     {
       resolve: "./src/modules/ticket",
     },
+    ...(process.env.REDIS_URL
+      ? [
+          {
+            resolve: "@medusajs/medusa/event-bus-redis",
+            options: {
+              redisUrl: process.env.REDIS_URL,
+            },
+          },
+          {
+            resolve: "@medusajs/medusa/workflow-engine-redis",
+            options: {
+              redis: { url: process.env.REDIS_URL },
+            },
+          },
+          {
+            resolve: "@medusajs/medusa/cache-redis",
+            options: {
+              redisUrl: process.env.REDIS_URL,
+            },
+          },
+          {
+            resolve: "@medusajs/medusa/locking",
+            options: {
+              providers: [
+                {
+                  id: "locking-redis",
+                  resolve: "@medusajs/medusa/locking-redis",
+                  is_default: true,
+                  options: {
+                    redisUrl: process.env.REDIS_URL,
+                  },
+                },
+              ],
+            },
+          },
+        ]
+      : []),
     {
       resolve: "@medusajs/medusa/notification",
       options: {


### PR DESCRIPTION
## Summary
- Explicitly register 4 Redis modules in medusa-config.ts when `REDIS_URL` is available
- Self-hosted Medusa v2 defaults to in-memory modules even with `redisUrl` set (Redis auto-registration only happens in Medusa Cloud)
- Modules: event-bus-redis, workflow-engine-redis, cache-redis, locking-redis

## Why This Matters
Without explicit Redis module registration:
- **Event bus**: Falls back to `event-bus-local` (in-memory) — events lost on restart
- **Workflow engine**: Falls back to `workflow-engine-inmemory` — workflow state lost on restart
- **Cache**: Falls back to `cache-inmemory` — no shared cache across instances
- **Locking**: Falls back to `locking` (Postgres-based) — no distributed locking for multi-instance

## Technical Details
- Verified by reading `@medusajs/utils/dist/common/define-config.js`: `defaultModules` (non-cloud) uses in-memory variants; only `cloudModules` auto-registers Redis
- `transformModules` uses `reduce` with `acc[serviceName]`, so user config modules override defaults
- Conditional spread (`...process.env.REDIS_URL ? [...] : []`) ensures backward compatibility when Redis is not configured
- Options format matches Medusa Cloud's auto-registration (verified from source)

## Test plan
- [ ] `npx tsc --noEmit` passes (no new errors)
- [ ] Start with `REDIS_URL` set — verify Redis modules load (check startup logs)
- [ ] Start without `REDIS_URL` — verify in-memory fallback still works
- [ ] Verify event-bus publishes to Redis (check `redis-cli MONITOR`)

Closes #698
ROADMAP Ref: INFRA

Generated with [Claude Code](https://claude.com/claude-code)