### PR TITLE
fix(docker): conditional Sentry preload to prevent crash loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,11 @@ RUN mkdir -p /app/public && \
 
 EXPOSE 9000
 
-# Preload Sentry instrumentation before Medusa starts (RFC-001 — Incident Management)
-# Gracefully no-ops if SENTRY_DSN is not set at runtime
-ENV NODE_OPTIONS="--require /app/.medusa/server/src/instrument.js"
+# Sentry instrumentation: only preload if build emitted the file (RFC-001)
+# If medusa build skips instrument.js, the server starts without Sentry
+# rather than crash-looping with MODULE_NOT_FOUND.
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["npx", "medusa", "start"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Conditionally preload Sentry instrumentation (RFC-001)
+INSTRUMENT_PATH="/app/.medusa/server/src/instrument.js"
+if [ -f "$INSTRUMENT_PATH" ]; then
+  export NODE_OPTIONS="--require $INSTRUMENT_PATH ${NODE_OPTIONS:-}"
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- Replace unconditional `ENV NODE_OPTIONS="--require instrument.js"` with a `docker-entrypoint.sh` that checks file existence first
- If `medusa build` fails to emit `instrument.js`, the container starts without Sentry instead of crash-looping

## Root Cause
CI logs show: `Error: Cannot find module '/app/.medusa/server/src/instrument.js'` with `code: 'MODULE_NOT_FOUND'`. The file is not emitted when `medusa build` encounters TS errors resolving `@sentry/node`.

## Changes
- `Dockerfile`: Remove `ENV NODE_OPTIONS`, add `ENTRYPOINT` using `docker-entrypoint.sh`
- `docker-entrypoint.sh` (new): Checks if `instrument.js` exists, sets `NODE_OPTIONS` only if present, then `exec "$@"`

## Test plan
- [ ] Docker build succeeds
- [ ] Container starts with `instrument.js` present → Sentry loaded (check logs for `[Sentry] Initialized`)
- [ ] Container starts without `instrument.js` → Sentry skipped, server runs normally
- [ ] Health check passes on test environment

Closes #704
ROADMAP Ref: INFRA

Generated with [Claude Code](https://claude.com/claude-code)