### PR TITLE
fix(docker): enable admin panel build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,10 @@ RUN npm ci --legacy-peer-deps --maxsockets=2 --network-timeout=120000
 # Layer 2: source code
 COPY . .
 
-# Layer 3: build backend only (skip Admin Vite compilation ~3-5 min)
-# medusa-config.ts reads DISABLE_MEDUSA_ADMIN to set admin.disable
-ENV DISABLE_MEDUSA_ADMIN=true
+# Layer 3: build backend + admin frontend
 RUN npx medusa build
 
-# Reset so admin is enabled at runtime
-ENV DISABLE_MEDUSA_ADMIN=false
-
-# Admin static files link (no-op if admin wasn't built, harmless)
+# Admin static files link
 RUN mkdir -p /app/public && \
     ln -sfn /app/.medusa/server/public/admin /app/public/admin 2>/dev/null || true
 


### PR DESCRIPTION
Closes #711

## Summary

- Remove `DISABLE_MEDUSA_ADMIN=true` from Docker build stage
- `npx medusa build` now compiles both backend AND admin frontend
- Fixes "Cannot GET /app" — admin static files will exist in the image
- Adds ~3-5 min to Docker build time (admin Vite compilation)

## Root Cause

The Dockerfile set `DISABLE_MEDUSA_ADMIN=true` during build to speed up compilation, then reset it to `false` at runtime. This meant:
1. Admin frontend was never compiled → no static files
2. Runtime re-enabled the admin route → served a 404

## Test Plan

- [ ] Docker build completes successfully with admin compilation
- [ ] `/app` serves the admin login page (not "Cannot GET /app")
- [ ] `/app/login` redirects to admin authentication
- [ ] API endpoints still function normally on `:9000`

ROADMAP Ref: R-P1-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)