### PR TITLE
ci: add --runInBand to jest and remove redundant coverage step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,7 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Run tests with coverage
-        run: npx jest --coverage --ci
-      - name: Check coverage threshold
-        run: npx jest --coverage --ci --coverageThreshold='{"global":{"branches":30,"functions":30,"lines":30,"statements":30}}'
+        run: npx jest --coverage --ci --runInBand
 
   build:
     needs: lint-and-typecheck


### PR DESCRIPTION
Closes #714

## Summary

- Add `--runInBand` flag to CI jest command to prevent memory issues with parallel workers
- Remove redundant second jest run that re-checked coverage threshold (already defined in `jest.config.ts`)

## Changes

`npx jest --coverage --ci` → `npx jest --coverage --ci --runInBand`

Removed duplicate step: `npx jest --coverage --ci --coverageThreshold='{"global":...}'` — the threshold in `jest.config.ts` (branches 45%, functions 45%, lines 58%, statements 55%) is authoritative.

## Test Plan

- [ ] CI unit-test job passes with --runInBand
- [ ] Coverage thresholds still enforced via jest.config.ts

ROADMAP Ref: R-P1-21