### PR TITLE
fix(deps): add @medusajs/draft-order to fix medusa build [P0]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@medusajs/admin-sdk": "2.13.1",
         "@medusajs/cli": "2.13.1",
+        "@medusajs/draft-order": "2.13.1",
         "@medusajs/framework": "2.13.1",
         "@medusajs/medusa": "2.13.1",
         "@mikro-orm/postgresql": "6.4.16",
@@ -4914,6 +4915,66 @@
         "node": ">=20"
       }
     },
+    "node_modules/@medusajs/draft-order": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@medusajs/draft-order/-/draft-order-2.13.1.tgz",
+      "integrity": "sha512-obmnyjfWUERLZ7MrWVeJC7Mem2tZccVyqlY4J/RTMnEMoY3koknX5FGTamJN83ib+KtBhJm6diXYYNjBBzpePQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react": "^0.4.15",
+        "@babel/runtime": "^7.26.10",
+        "@hookform/resolvers": "3.4.2",
+        "@medusajs/js-sdk": "2.13.1",
+        "@tanstack/react-query": "5.64.2",
+        "@uiw/react-json-view": "^2.0.0-alpha.17",
+        "date-fns": "^3.6.0",
+        "lodash.debounce": "^4.0.8",
+        "lodash.isequal": "^4.5.0",
+        "match-sorter": "^6.3.4",
+        "radix-ui": "1.1.2",
+        "react-hook-form": "7.49.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@medusajs/admin-sdk": "2.13.1",
+        "@medusajs/cli": "2.13.1",
+        "@medusajs/framework": "2.13.1",
+        "@medusajs/icons": "2.13.1",
+        "@medusajs/test-utils": "2.13.1",
+        "@medusajs/ui": "4.1.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "6.30.3"
+      },
+      "peerDependenciesMeta": {
+        "@medusajs/admin-sdk": {
+          "optional": true
+        },
+        "@medusajs/cli": {
+          "optional": true
+        },
+        "@medusajs/icons": {
+          "optional": true
+        },
+        "@medusajs/test-utils": {
+          "optional": true
+        },
+        "@medusajs/ui": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-router-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@medusajs/event-bus-local": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@medusajs/event-bus-local/-/event-bus-local-2.13.1.tgz",
@@ -5253,66 +5314,6 @@
           "optional": true
         },
         "yalc": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@medusajs/medusa/node_modules/@medusajs/draft-order": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@medusajs/draft-order/-/draft-order-2.13.1.tgz",
-      "integrity": "sha512-obmnyjfWUERLZ7MrWVeJC7Mem2tZccVyqlY4J/RTMnEMoY3koknX5FGTamJN83ib+KtBhJm6diXYYNjBBzpePQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/react": "^0.4.15",
-        "@babel/runtime": "^7.26.10",
-        "@hookform/resolvers": "3.4.2",
-        "@medusajs/js-sdk": "2.13.1",
-        "@tanstack/react-query": "5.64.2",
-        "@uiw/react-json-view": "^2.0.0-alpha.17",
-        "date-fns": "^3.6.0",
-        "lodash.debounce": "^4.0.8",
-        "lodash.isequal": "^4.5.0",
-        "match-sorter": "^6.3.4",
-        "radix-ui": "1.1.2",
-        "react-hook-form": "7.49.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@medusajs/admin-sdk": "2.13.1",
-        "@medusajs/cli": "2.13.1",
-        "@medusajs/framework": "2.13.1",
-        "@medusajs/icons": "2.13.1",
-        "@medusajs/test-utils": "2.13.1",
-        "@medusajs/ui": "4.1.1",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-router-dom": "6.30.3"
-      },
-      "peerDependenciesMeta": {
-        "@medusajs/admin-sdk": {
-          "optional": true
-        },
-        "@medusajs/cli": {
-          "optional": true
-        },
-        "@medusajs/icons": {
-          "optional": true
-        },
-        "@medusajs/test-utils": {
-          "optional": true
-        },
-        "@medusajs/ui": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-router-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@medusajs/admin-sdk": "2.13.1",
     "@medusajs/cli": "2.13.1",
+    "@medusajs/draft-order": "2.13.1",
     "@medusajs/framework": "2.13.1",
     "@medusajs/medusa": "2.13.1",
     "@mikro-orm/postgresql": "6.4.16",


### PR DESCRIPTION
Closes #711

## Summary

- Add `@medusajs/draft-order@2.13.1` as explicit dependency in package.json
- Regenerate package-lock.json to fix npm hoisting

## Root Cause

`@medusajs/draft-order` is a dependency of `@medusajs/medusa@2.13.1`, but npm installs it nested instead of top-level. Medusa's plugin resolver only checks top-level, causing `npx medusa build` to fail:

```
Error: Unable to resolve plugin "@medusajs/draft-order"
```

## Fix

Adding as explicit dependency forces npm to hoist it. Verified: `medusa build` completes in 2.66s.

## Test Plan

- [x] `npx medusa build` completes locally
- [x] `@medusajs/draft-order` at top-level `node_modules/`
- [ ] CI build passes
- [ ] CD-Test deploys successfully

ROADMAP Ref: INFRA
EGP Action: INFRA