### PR TITLE
fix(config): respect COOKIE_SECURE env var override

### DIFF
--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -15,7 +15,9 @@ module.exports = defineConfig({
     databaseDriverOptions: { ssl: false },
     redisUrl: process.env.REDIS_URL,
     cookieOptions: {
-      secure: process.env.NODE_ENV === "production",
+      secure: process.env.COOKIE_SECURE !== undefined
+        ? process.env.COOKIE_SECURE !== "false"
+        : process.env.NODE_ENV === "production",
       sameSite: "lax" as const,
     },
     http: {


### PR DESCRIPTION
Closes #725

ROADMAP Ref: INFRA

EGP Action: INFRA

## Summary

- Cookie `secure` flag in `medusa-config.ts` was hardcoded to `NODE_ENV === "production"`, ignoring the `COOKIE_SECURE` env var
- Test container with `NODE_ENV=production` over HTTP silently dropped session cookies (marked `Secure`)
- This caused admin login to appear to succeed (API returns 200) but browser received no `Set-Cookie` header
- Fix: `COOKIE_SECURE` env var now overrides the default when explicitly set; prod behavior unchanged

## Test Plan

- [x] Verified on test container: `NODE_ENV=development` workaround → `Set-Cookie` header present → login works
- [ ] CI lint + typecheck pass
- [ ] After merge + CD-Test deploy with `COOKIE_SECURE=false`, verify login at http://66.94.127.117:9001/app/login