### PR TITLE
ci(cd): remove DISABLE_MEDUSA_ADMIN from prod deploy env

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -95,6 +95,9 @@ jobs:
             ENV_FILE="/tmp/${CONTAINER}_env.txt"
             docker inspect $CONTAINER --format '{{range .Config.Env}}{{println .}}{{end}}' > $ENV_FILE 2>/dev/null || true
 
+            # Remove legacy env vars that should no longer be set
+            sed -i '/^DISABLE_MEDUSA_ADMIN=/d' $ENV_FILE
+
             echo "=== Running DB migration ==="
             if [ -f "$ENV_FILE" ] && [ -s "$ENV_FILE" ]; then
               docker run --rm --network nordhjem_backend --env-file $ENV_FILE $IMAGE npx medusa db:migrate || echo "Migration warning"


### PR DESCRIPTION
Closes #733

ROADMAP Ref: INFRA

EGP Action: INFRA

## Summary

- Prod container has legacy `DISABLE_MEDUSA_ADMIN=true` env var, manually set at container creation
- `cd-production.yml` inherits all env vars from existing container via `docker inspect`, perpetuating this flag across deploys
- Added `sed -i '/^DISABLE_MEDUSA_ADMIN=/d' $ENV_FILE` after env extraction to strip the variable
- Next prod deploy will enable the admin panel

## Change

```diff
+ # Remove legacy env vars that should no longer be set
+ sed -i '/^DISABLE_MEDUSA_ADMIN=/d' $ENV_FILE
```

## Test Plan

- [ ] CI passes
- [ ] After merge to main + prod deploy, verify `DISABLE_MEDUSA_ADMIN` is no longer in container env
- [ ] Verify admin panel accessible at prod /app