### PR TITLE
fix(ci): pr-compliance-fix crash on require('@actions/github')

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -135,17 +135,17 @@ jobs:
               return;
             }
 
-            const { getOctokit } = require('@actions/github');
             const botPat = process.env.BOT_PAT;
             if (!botPat) {
               core.setFailed('BOT_PAT is required for auto-fix operations but is not configured.');
               return;
             }
 
-            const botGithub = getOctokit(botPat);
+            const { Octokit } = require('@octokit/rest');
+            const botGithub = new Octokit({ auth: botPat });
 
             if (fixedBody !== body) {
-              await botGithub.rest.pulls.update({
+              await botGithub.pulls.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pr.number,
@@ -154,7 +154,7 @@ jobs:
             }
 
             if (missingAssignee) {
-              await botGithub.rest.issues.addAssignees({
+              await botGithub.issues.addAssignees({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
@@ -162,7 +162,7 @@ jobs:
               });
             }
 
-            await botGithub.rest.issues.createComment({
+            await botGithub.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,


### PR DESCRIPTION
Closes #740

ROADMAP Ref: INFRA

## Summary

- Replace `require('@actions/github')` with `require('@octokit/rest')` in pr-compliance-fix auto-fix path
- Update API calls from `botGithub.rest.X` to `botGithub.X` to match `@octokit/rest` API surface
- `@octokit/rest` is bundled in `actions/github-script@v7` runtime, so no new dependencies needed

## Root Cause

`require('@actions/github')` fails with "Cannot find module" in the `actions/github-script@v7` runtime on newer GitHub Actions runners. This only triggers when a PR needs auto-fix (missing assignee or body format issues), which is why some PRs pass and others crash.

## Impact

Unblocks PR #737 and PR #739 which are currently stuck on `pr-compliance-fix` failure.

## Test plan

- [ ] PR #741 itself should trigger pr-compliance-fix — if auto-fix runs without crash, the fix works
- [ ] Verify existing compliant PRs still pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)