### PR TITLE
fix(ci): use native fetch in pr-compliance-fix auto-fix path

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -141,32 +141,34 @@ jobs:
               return;
             }
 
-            const { Octokit } = require('@octokit/rest');
-            const botGithub = new Octokit({ auth: botPat });
+            const headers = {
+              Authorization: `token ${botPat}`,
+              Accept: 'application/vnd.github.v3+json',
+              'Content-Type': 'application/json',
+            };
+            const apiBase = 'https://api.github.com';
+            const repo = `${context.repo.owner}/${context.repo.repo}`;
 
             if (fixedBody !== body) {
-              await botGithub.pulls.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pr.number,
-                body: fixedBody,
+              await fetch(`${apiBase}/repos/${repo}/pulls/${pr.number}`, {
+                method: 'PATCH',
+                headers,
+                body: JSON.stringify({ body: fixedBody }),
               });
             }
 
             if (missingAssignee) {
-              await botGithub.issues.addAssignees({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                assignees: ['nickwenniyxiao-bot'],
+              await fetch(`${apiBase}/repos/${repo}/issues/${pr.number}/assignees`, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({ assignees: ['nickwenniyxiao-bot'] }),
               });
             }
 
-            await botGithub.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              body: `🔧 Auto-fix applied:\n${autoFixNotes.map((note) => `- ${note}`).join('\n')}`,
+            await fetch(`${apiBase}/repos/${repo}/issues/${pr.number}/comments`, {
+              method: 'POST',
+              headers,
+              body: JSON.stringify({ body: `🔧 Auto-fix applied:\n${autoFixNotes.map((note) => `- ${note}`).join('\n')}` }),
             });
 
             core.info('✅ PR compliance auto-fix applied successfully');


### PR DESCRIPTION
Closes #740

ROADMAP Ref: INFRA

## Summary

- Replace `require('@octokit/rest')` with native `fetch()` in pr-compliance-fix auto-fix path
- Zero module dependencies — `fetch()` is built into Node.js 18+ (GitHub Actions runners)
- Previous fix (#741) used `@octokit/rest` which is also not available in `github-script@v7` inline script context

## Root Cause

`actions/github-script@v7` runs inline scripts in an isolated context where `require()` cannot resolve `@actions/github` or `@octokit/rest`. The `github` global object is injected but no npm modules are accessible via `require()`.

## Fix

Replace all Octokit SDK calls with direct GitHub REST API calls using native `fetch()`:
- `PATCH /repos/{owner}/{repo}/pulls/{number}` — update PR body
- `POST /repos/{owner}/{repo}/issues/{number}/assignees` — add assignee  
- `POST /repos/{owner}/{repo}/issues/{number}/comments` — post auto-fix comment

## Test plan

- [ ] This PR itself will trigger pr-compliance-fix — if auto-fix runs without crash, the fix works
- [ ] Verify assignee is auto-added and comment is posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)